### PR TITLE
LRCI-1429 Move non mysql modules-integration-* and functional-upgrade-* tests from acceptance upstream to upstream job

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -2092,12 +2092,7 @@
         functional-tomcat90-mysql57-jdk8,\
         functional-tomcat90-postgresql10-jdk8,\
         functional-tomcat90-postgresql121-jdk8,\
-        functional-upgrade-jboss72-mysql57-jdk8,\
-        functional-upgrade-tomcat90-mariadb102-jdk8,\
         functional-upgrade-tomcat90-mysql57-jdk8,\
-        functional-upgrade-tomcat90-postgresql10-jdk8,\
-        functional-upgrade-tomcat90-postgresql121-jdk8,\
-        functional-upgrade-wildfly160-mariadb102-jdk8,\
         gogo-shell-client-jdk8,\
         javadoc-jdk8,\
         js-unit-jdk8,\
@@ -2115,12 +2110,7 @@
         modules-compile-jdk8,\
         modules-functional-jdk8,\
         modules-functional-tomcat90-mysql57-jdk8,\
-        modules-integration-hypersonic20-jdk8,\
-        modules-integration-mariadb102-jdk8,\
         modules-integration-mysql57-jdk8,\
-        modules-integration-mysql57-jdk11_open,\
-        modules-integration-postgresql10-jdk8,\
-        modules-integration-postgresql121-jdk8,\
         modules-integration-project-templates-jdk8,\
         modules-semantic-versioning-jdk8,\
         modules-unit-jdk8,\
@@ -2160,19 +2150,7 @@
         functional-tomcat90-oracle122-jdk8,\
         functional-tomcat90-sqlserver2017-jdk8,\
         functional-tomcat90-sqlserver2019-jdk8,\
-        functional-tomcat90-sybase160-jdk8,\
-        functional-upgrade-tomcat90-db2111-jdk8,\
-        functional-upgrade-tomcat90-oracle122-jdk8,\
-        #functional-upgrade-tomcat90-sqlserver2017-jdk8,\
-        #functional-upgrade-tomcat90-sqlserver2019-jdk8,\
-        functional-upgrade-weblogic122-mysql57-jdk8,\
-        functional-upgrade-websphere90-mysql57-jdk8,\
-        #functional-upgrade-tomcat90-sybase160-jdk8,\
-        modules-integration-db2111-jdk8,\
-        modules-integration-oracle122-jdk8,\
-        modules-integration-sqlserver2017-jdk8,\
-        modules-integration-sqlserver2019-jdk8,\
-        #modules-integration-sybase160-jdk8
+        functional-tomcat90-sybase160-jdk8
 
     #
     # Accounts
@@ -3883,9 +3861,31 @@
         functional-tomcat90-oracle122-jdk8,\
         functional-tomcat90-postgresql10-jdk8,\
         functional-tomcat90-sybase160-jdk8,\
+        functional-upgrade-jboss72-mysql57-jdk8,\
+        functional-upgrade-tomcat90-db2111-jdk8,\
+        functional-upgrade-tomcat90-mariadb102-jdk8,\
+        functional-upgrade-tomcat90-oracle122-jdk8,\
+        functional-upgrade-tomcat90-postgresql10-jdk8,\
+        functional-upgrade-tomcat90-postgresql121-jdk8,\
+        #functional-upgrade-tomcat90-sqlserver2017-jdk8,\
+        #functional-upgrade-tomcat90-sqlserver2019-jdk8,\
+        #functional-upgrade-tomcat90-sybase160-jdk8,\
+        functional-upgrade-weblogic122-mysql57-jdk8,\
+        functional-upgrade-websphere90-mysql57-jdk8,\
+        functional-upgrade-wildfly160-mariadb102-jdk8,\
         functional-weblogic122-mysql57-jdk8,\
         functional-websphere90-mysql57-jdk8,\
-        functional-wildfly160-mysql57-jdk8
+        functional-wildfly160-mysql57-jdk8,\
+        modules-integration-db2111-jdk8,\
+        modules-integration-hypersonic20-jdk8,\
+        modules-integration-mariadb102-jdk8,\
+        modules-integration-mysql57-jdk11_open,\
+        modules-integration-oracle122-jdk8,\
+        modules-integration-postgresql10-jdk8,\
+        modules-integration-postgresql121-jdk8,\
+        modules-integration-sqlserver2017-jdk8,\
+        modules-integration-sqlserver2019-jdk8,\
+        #modules-integration-sybase160-jdk8
 
     test.batch.names.smoke[upstream-dxp]=\
         functional-smoke-tomcat90-mysql57-jdk8


### PR DESCRIPTION
This change will reduce load by an estimated 24 days (conservative estimate) of server resource time per day. For reference, 1 large PR takes 2 days of server time. 1 small PR takes 15 hours of server time. 7.2 hotfix test takes ~4 days of server time. 7.0 hotfix tests takes ~2.5 days of server time.

End result is that those batches will run once a day (in upstream tester) instead of 3-4 times a day (in upstream acceptance tester).

cc-ing: @vicnate5, @pyoo47, @jpince

https://issues.liferay.com/browse/LRCI-1429

Backports: 
https://github.com/brianchandotcom/liferay-portal-ee/pull/30755 (7.2.x)
https://github.com/brianchandotcom/liferay-portal-ee/pull/30756 (7.1.x)
https://github.com/brianchandotcom/liferay-portal-ee/pull/30757 (7.0.x)