### PR TITLE
LRCI-1298 Don't run jacoco on functional test batches

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -669,6 +669,9 @@ mariadb.executable=${mariadb.executable}]]></echo>
 					<not>
 						<os family="windows" />
 					</not>
+					<not>
+						<contains string="${test.batch.name}" substring="functional" />
+					</not>
 				</and>
 				<then>
 					<var name="test.batch.app.server.start.executable.arg.line" value="jacoco ${test.batch.app.server.start.executable.arg.line}" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1298

The change can be cherry picked. Please cherry pick to 7.2.x, 7.1.x, and 7.0.x. Not necessary on ee-6.2.x and below. Thank you! 