### PR TITLE
LRCI-1578 Fix SQL Server CI failures

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -197,22 +197,23 @@ lportal_BS
 
 			<property name="database.type" value="@{database.type}" />
 
-			<local name="database.service.executable" />
-
-			<get-database-property property.name="database.service.executable" />
-
 			<local name="database.service.cmd.start" />
-
-			<get-database-property property.name="database.service.cmd.start" />
-
 			<local name="database.service.cmd.stop" />
-
-			<get-database-property property.name="database.service.cmd.stop" />
-
+			<local name="database.service.executable" />
 			<local name="database.version.cmd" />
 
 			<get-database-property property.name="database.version.cmd" />
 
+			<if>
+				<not>
+					<equals arg1="${env.DOCKER_ENABLED}" arg2="true" />
+				</not>
+				<then>
+					<get-database-property property.name="database.service.executable" />
+					<get-database-property property.name="database.service.cmd.start" />
+					<get-database-property property.name="database.service.cmd.stop" />
+				</then>
+			</if>
 			<action />
 		</sequential>
 	</macrodef>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1578

This will need to be backported to 7.3.x, 7.2.x, 7.1.x, 7.0.x, ee-6.2.x, ee-6.2.10, ee-6.1.x, ee-6.1.30. To my surprise, it cherry picks cleanly all the way down. Thanks!