### PR TITLE
LRCI-1633 Rename portal-web-jdk8 batch to poshi-validation-jdk8

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -6322,7 +6322,7 @@ ${output.content}</echo>
 		</sequential>
 	</target>
 
-	<target name="portal-web-jdk8">
+	<target name="poshi-validation-jdk8">
 		<run-batch-test>
 			<test-action>
 				<run-poshi-validation />

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -6325,13 +6325,7 @@ ${output.content}</echo>
 	<target name="portal-web-jdk8">
 		<run-batch-test>
 			<test-action>
-				<database-test-run-test database.type="mysql">
-					<test-action>
-						<ant dir="portal-web" target="compile-tomcat" />
-
-						<run-poshi-validation />
-					</test-action>
-				</database-test-run-test>
+				<run-poshi-validation />
 			</test-action>
 
 			<test-set-up>

--- a/test.properties
+++ b/test.properties
@@ -1952,7 +1952,7 @@
     test.batch.size[portal-license-jdk8]=1
     test.batch.size[portal-second-startup-space-in-path-jdk8]=1
     test.batch.size[portal-startup-space-in-path-jdk8]=1
-    test.batch.size[portal-web-jdk8]=1
+    test.batch.size[poshi-validation-jdk8]=1
     test.batch.size[release-osgi-state-exploded-test-jdk8]=1
     test.batch.size[release-osgi-state-lpkg-change-directory-test-jdk8]=1
     test.batch.size[release-osgi-state-lpkg-test-jdk8]=1
@@ -2310,7 +2310,7 @@
         portal-license-jdk8,\
         portal-second-startup-space-in-path-jdk8,\
         portal-startup-space-in-path-jdk8,\
-        portal-web-jdk8,\
+        poshi-validation-jdk8,\
         release-osgi-state-exploded-test-jdk8,\
         release-osgi-state-lpkg-change-directory-test-jdk8,\
         release-osgi-state-lpkg-test-jdk8,\

--- a/test.properties
+++ b/test.properties
@@ -4169,7 +4169,8 @@
     test.batch.dist.app.servers[poshi]=tomcat
 
     test.batch.names[poshi]=\
-        functional-tomcat90-mysql57-jdk8
+        functional-tomcat90-mysql57-jdk8,\
+        poshi-validation-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][poshi]=\
         (app.server.types == null OR app.server.types ~ tomcat) AND \
@@ -4185,7 +4186,8 @@
     test.batch.dist.app.servers[poshi-gauntlet]=tomcat
 
     test.batch.names[poshi-gauntlet]=\
-        functional-tomcat90-mysql57-jdk8
+        functional-tomcat90-mysql57-jdk8,\
+        poshi-validation-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][poshi-gauntlet]=\
         (app.server.types == null OR app.server.types ~ tomcat) AND \


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1633

This can be cherry picked to 7.3.x and 7.2.x. The other branches don't cherry pick cleanly, and I've sent the other pulls here: 

https://github.com/brianchandotcom/liferay-portal-ee/pull/31497 (7.1.x) 
https://github.com/brianchandotcom/liferay-portal-ee/pull/31498 (7.0.x)
https://github.com/brianchandotcom/liferay-portal-ee/pull/31499 (ee-6.2.x & ee-6.2.10)
https://github.com/brianchandotcom/liferay-portal-ee/pull/31500 (ee-6.1.x & ee-6.1.30)