### PR TITLE
LRCI-1771 Add 'databases.size' logic for SQL Server

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -5997,6 +5997,21 @@ alter database lportal set read_committed_snapshot on;
 go]]></replacevalue>
 								</replacefilter>
 							</replace>
+
+							<if>
+								<isset property="databases.size" />
+								<then>
+									<echo append="true" file="create.sql">
+create database lportal${databases.size};
+go
+
+alter database lportal${databases.size} set allow_snapshot_isolation on;
+go
+
+alter database lportal${databases.size} set read_committed_snapshot on;
+go</echo>
+								</then>
+							</if>
 						</then>
 					</elseif>
 					<elseif>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1771

Please backport to 7.3, 7.2, 7.1 and 7.0. It cherry picks cleanly. Not applicable to 6.2 and below. 