### PR TITLE
POSHI-110

### DIFF
--- a/modules/test/poshi/poshi-runner/build.gradle
+++ b/modules/test/poshi/poshi-runner/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 	compile group: "com.github.scribejava", name: "scribejava-core", version: "3.2.0"
 	compile group: "com.google.guava", name: "guava", version: "23.0"
 	compile group: "com.jayway.jsonpath", name: "json-path", version: "2.1.0"
-	compile group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.10"
+	compile group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.11"
 	compile group: "com.liferay", name: "net.jsourcerer.webdriver.JSErrorCollector", version: "0.6"
 	compile group: "com.sun.mail", name: "javax.mail", version: "1.6.2"
 	compile group: "commons-io", name: "commons-io", version: "2.6"

--- a/modules/test/poshi/poshi-runner/build.gradle
+++ b/modules/test/poshi/poshi-runner/build.gradle
@@ -1,4 +1,3 @@
-import com.liferay.gradle.util.GradleUtil
 import com.liferay.gradle.util.copy.RenameDependencyClosure
 
 buildCSS {
@@ -9,10 +8,11 @@ buildCSS {
 
 dependencies {
 	compile group: "com.deque", name: "axe-selenium", version: "1.1"
+	compile group: "com.github.lewka", name: "ocular", version: "1.0.5"
 	compile group: "com.github.scribejava", name: "scribejava-core", version: "3.2.0"
 	compile group: "com.google.guava", name: "guava", version: "23.0"
 	compile group: "com.jayway.jsonpath", name: "json-path", version: "2.1.0"
-	compile group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.9"
+	compile group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.10"
 	compile group: "com.liferay", name: "net.jsourcerer.webdriver.JSErrorCollector", version: "0.6"
 	compile group: "com.sun.mail", name: "javax.mail", version: "1.6.2"
 	compile group: "commons-io", name: "commons-io", version: "2.6"

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -139,8 +139,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	public BaseWebDriverImpl(String browserURL, WebDriver webDriver) {
 		_webDriver = webDriver;
 
-		initKeysSpecialChars();
-
 		setDefaultWindowHandle(webDriver.getWindowHandle());
 
 		System.setProperty("java.awt.headless", "false");
@@ -4467,18 +4465,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		return point.getY();
 	}
 
-	protected void initKeysSpecialChars() {
-		_keysSpecialChars.put("!", "1");
-		_keysSpecialChars.put("#", "3");
-		_keysSpecialChars.put("$", "4");
-		_keysSpecialChars.put("%", "5");
-		_keysSpecialChars.put("&", "7");
-		_keysSpecialChars.put("(", "9");
-		_keysSpecialChars.put(")", "0");
-		_keysSpecialChars.put("<", ",");
-		_keysSpecialChars.put(">", ".");
-	}
-
 	protected boolean isObscured(WebElement webElement) {
 		WrapsDriver wrapsDriver = (WrapsDriver)webElement;
 
@@ -4696,11 +4682,24 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 				put("SHIFT", Integer.valueOf(KeyEvent.VK_SHIFT));
 			}
 		};
+	private static final Map<String, String> _keysSpecialChars =
+		new HashMap<String, String>() {
+			{
+				put("!", "1");
+				put("#", "3");
+				put("$", "4");
+				put("%", "5");
+				put("&", "7");
+				put("(", "9");
+				put(")", "0");
+				put("<", ",");
+				put(">", ".");
+			}
+		};
 
 	private String _clipBoard = "";
 	private String _defaultWindowHandle;
 	private Stack<WebElement> _frameWebElements = new Stack<>();
-	private final Map<String, String> _keysSpecialChars = new HashMap<>();
 	private int _navigationBarHeight = 120;
 	private final String _ocularResultImageDirName;
 	private final String _ocularSnapImageDirName;

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -147,31 +147,23 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		System.setProperty("java.awt.headless", "false");
 
 		String ocularSnapImageDirName =
-			_TEST_DEPENDENCIES_DIR_NAME + "//ocular//linux//snap";
+			_TEST_DEPENDENCIES_DIR_NAME + "//ocular//snap";
 		String ocularResultImageDirName =
-			_TEST_DEPENDENCIES_DIR_NAME + "//ocular//linux//result";
+			_TEST_DEPENDENCIES_DIR_NAME + "//ocular//result";
 		String outputDirName = _OUTPUT_DIR_NAME;
 		String sikuliImagesDirName =
 			_TEST_DEPENDENCIES_DIR_NAME + "//sikuli//linux//";
 		String testDependenciesDirName = _TEST_DEPENDENCIES_DIR_NAME;
 
 		if (OSDetector.isApple()) {
-			ocularResultImageDirName = StringUtil.replace(
-				ocularResultImageDirName, "linux", "osx");
-			ocularSnapImageDirName = StringUtil.replace(
-				ocularSnapImageDirName, "linux", "osx");
 			sikuliImagesDirName = StringUtil.replace(
 				sikuliImagesDirName, "linux", "osx");
 		}
 		else if (OSDetector.isWindows()) {
 			ocularResultImageDirName = StringUtil.replace(
 				ocularResultImageDirName, "//", "\\");
-			ocularResultImageDirName = StringUtil.replace(
-				ocularResultImageDirName, "linux", "windows");
 			ocularSnapImageDirName = StringUtil.replace(
 				ocularSnapImageDirName, "//", "\\");
-			ocularSnapImageDirName = StringUtil.replace(
-				ocularSnapImageDirName, "linux", "windows");
 			outputDirName = StringUtil.replace(outputDirName, "//", "\\");
 			sikuliImagesDirName = StringUtil.replace(
 				sikuliImagesDirName, "//", "\\");

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -2919,8 +2919,13 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 		while (count > 0) {
 			actions.click();
+
 			count -= 1;
 		}
+
+		Action action = actions.build();
+
+		action.perform();
 	}
 
 	@Override

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -2225,6 +2225,7 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 	public boolean ocularImageValidation(String locator) {
 		ocularConfig();
+
 		WebElement webElement = getWebElement(locator);
 
 		SnapshotBuilder snapshotBuilder = Ocular.snapshot();

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -2906,6 +2906,24 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
+	public void tripleClick(String locator) {
+		WebElement webElement = getWebElement(locator);
+
+		WrapsDriver wrapsDriver = (WrapsDriver)webElement;
+
+		WebDriver webDriver = wrapsDriver.getWrappedDriver();
+
+		Actions actions = new Actions(webDriver);
+
+		int count = 3;
+
+		while (count > 0) {
+			actions.click();
+			count -= 1;
+		}
+	}
+
+	@Override
 	public void type(String locator, String value) {
 		WebElement webElement = getWebElement(locator);
 

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -142,7 +142,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		initKeysSpecialChars();
 
 		setDefaultWindowHandle(webDriver.getWindowHandle());
-		setNavigationBarHeight(120);
 
 		System.setProperty("java.awt.headless", "false");
 
@@ -4702,7 +4701,7 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	private String _defaultWindowHandle;
 	private Stack<WebElement> _frameWebElements = new Stack<>();
 	private final Map<String, String> _keysSpecialChars = new HashMap<>();
-	private int _navigationBarHeight;
+	private int _navigationBarHeight = 120;
 	private final String _ocularResultImageDirName;
 	private final String _ocularSnapImageDirName;
 	private final String _outputDirName;

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -146,42 +146,37 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 		System.setProperty("java.awt.headless", "false");
 
-		String outputDirName = _OUTPUT_DIR_NAME;
 		String ocularSnapImageDirName =
 			_TEST_DEPENDENCIES_DIR_NAME + "//ocular//linux//snap";
 		String ocularResultImageDirName =
 			_TEST_DEPENDENCIES_DIR_NAME + "//ocular//linux//result";
+		String outputDirName = _OUTPUT_DIR_NAME;
 		String sikuliImagesDirName =
 			_TEST_DEPENDENCIES_DIR_NAME + "//sikuli//linux//";
 		String testDependenciesDirName = _TEST_DEPENDENCIES_DIR_NAME;
 
 		if (OSDetector.isApple()) {
-			ocularSnapImageDirName = StringUtil.replace(
-				ocularSnapImageDirName, "linux", "osx");
 			ocularResultImageDirName = StringUtil.replace(
 				ocularResultImageDirName, "linux", "osx");
-
+			ocularSnapImageDirName = StringUtil.replace(
+				ocularSnapImageDirName, "linux", "osx");
 			sikuliImagesDirName = StringUtil.replace(
 				sikuliImagesDirName, "linux", "osx");
 		}
 		else if (OSDetector.isWindows()) {
-			outputDirName = StringUtil.replace(outputDirName, "//", "\\");
-
-			ocularSnapImageDirName = StringUtil.replace(
-				ocularSnapImageDirName, "//", "\\");
-			ocularSnapImageDirName = StringUtil.replace(
-				ocularSnapImageDirName, "linux", "windows");
-
 			ocularResultImageDirName = StringUtil.replace(
 				ocularResultImageDirName, "//", "\\");
 			ocularResultImageDirName = StringUtil.replace(
 				ocularResultImageDirName, "linux", "windows");
-
+			ocularSnapImageDirName = StringUtil.replace(
+				ocularSnapImageDirName, "//", "\\");
+			ocularSnapImageDirName = StringUtil.replace(
+				ocularSnapImageDirName, "linux", "windows");
+			outputDirName = StringUtil.replace(outputDirName, "//", "\\");
 			sikuliImagesDirName = StringUtil.replace(
 				sikuliImagesDirName, "//", "\\");
 			sikuliImagesDirName = StringUtil.replace(
 				sikuliImagesDirName, "linux", "windows");
-
 			testDependenciesDirName = StringUtil.replace(
 				testDependenciesDirName, "//", "\\");
 		}

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -166,6 +166,7 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 				sikuliImagesDirName, "//", "\\");
 			sikuliImagesDirName = StringUtil.replace(
 				sikuliImagesDirName, "linux", "windows");
+
 			testDependenciesDirName = StringUtil.replace(
 				testDependenciesDirName, "//", "\\");
 		}

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -2174,7 +2174,7 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		return _webDriver.navigate();
 	}
 
-	public boolean ocularImageValidation(String locator) {
+	public void ocularAssertElementImage(String locator) throws Exception {
 		ocularConfig();
 
 		WebElement webElement = getWebElement(locator);
@@ -2191,7 +2191,10 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 		OcularResult ocularResult = sampleBuilder.compare();
 
-		return ocularResult.isEqualsImages();
+		if (!ocularResult.isEqualsImages()) {
+			throw new Exception(
+				"Actual element image does not match expected element image");
+		}
 	}
 
 	@Override

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -137,45 +137,11 @@ import org.xml.sax.InputSource;
 public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 	public BaseWebDriverImpl(String browserURL, WebDriver webDriver) {
+		System.setProperty("java.awt.headless", "false");
+
 		_webDriver = webDriver;
 
 		setDefaultWindowHandle(webDriver.getWindowHandle());
-
-		System.setProperty("java.awt.headless", "false");
-
-		String ocularSnapImageDirName =
-			_TEST_DEPENDENCIES_DIR_NAME + "//ocular//snap";
-		String ocularResultImageDirName =
-			_TEST_DEPENDENCIES_DIR_NAME + "//ocular//result";
-		String outputDirName = _OUTPUT_DIR_NAME;
-		String sikuliImagesDirName =
-			_TEST_DEPENDENCIES_DIR_NAME + "//sikuli//linux//";
-		String testDependenciesDirName = _TEST_DEPENDENCIES_DIR_NAME;
-
-		if (OSDetector.isApple()) {
-			sikuliImagesDirName = StringUtil.replace(
-				sikuliImagesDirName, "linux", "osx");
-		}
-		else if (OSDetector.isWindows()) {
-			ocularResultImageDirName = StringUtil.replace(
-				ocularResultImageDirName, "//", "\\");
-			ocularSnapImageDirName = StringUtil.replace(
-				ocularSnapImageDirName, "//", "\\");
-			outputDirName = StringUtil.replace(outputDirName, "//", "\\");
-			sikuliImagesDirName = StringUtil.replace(
-				sikuliImagesDirName, "//", "\\");
-			sikuliImagesDirName = StringUtil.replace(
-				sikuliImagesDirName, "linux", "windows");
-
-			testDependenciesDirName = StringUtil.replace(
-				testDependenciesDirName, "//", "\\");
-		}
-
-		_outputDirName = outputDirName;
-		_ocularSnapImageDirName = ocularSnapImageDirName;
-		_ocularResultImageDirName = ocularResultImageDirName;
-		_sikuliImagesDirName = sikuliImagesDirName;
-		_testDependenciesDirName = testDependenciesDirName;
 
 		WebDriver.Options options = webDriver.manage();
 
@@ -1370,16 +1336,16 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	public String getOcularResultImageDirName() {
-		return _ocularResultImageDirName;
+		return _OCULAR_RESULT_IMAGE_DIR_NAME;
 	}
 
 	public String getOcularSnapImageDirName() {
-		return _ocularSnapImageDirName;
+		return _OCULAR_SNAP_IMAGE_DIR_NAME;
 	}
 
 	@Override
 	public String getOutputDirName() {
-		return _outputDirName;
+		return _OUTPUT_DIR_NAME;
 	}
 
 	@Override
@@ -1439,12 +1405,12 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 	@Override
 	public String getSikuliImagesDirName() {
-		return _sikuliImagesDirName;
+		return _SIKULI_IMAGES_DIR_NAME;
 	}
 
 	@Override
 	public String getTestDependenciesDirName() {
-		return _testDependenciesDirName;
+		return _TEST_DEPENDENCIES_DIR_NAME;
 	}
 
 	@Override
@@ -3206,7 +3172,7 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		throws Exception {
 
 		String filePath =
-			FileUtil.getSeparator() + _testDependenciesDirName +
+			FileUtil.getSeparator() + getTestDependenciesDirName() +
 				FileUtil.getSeparator() + value;
 
 		filePath = LiferaySeleniumUtil.getSourceDirFilePath(filePath);
@@ -3218,7 +3184,8 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 			if (file.isDirectory()) {
 				String archiveFilePath =
-					_outputDirName + FileUtil.getSeparator() + file.getName();
+					getOutputDirName() + FileUtil.getSeparator() +
+						file.getName();
 
 				archiveFilePath = FileUtil.getCanonicalPath(archiveFilePath);
 
@@ -3244,7 +3211,7 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 	@Override
 	public void uploadTempFile(String location, String value) {
-		String filePath = _outputDirName + FileUtil.getSeparator() + value;
+		String filePath = getOutputDirName() + FileUtil.getSeparator() + value;
 
 		filePath = FileUtil.fixFilePath(filePath);
 
@@ -4664,10 +4631,15 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	private static final String _CURRENT_DIR_NAME = FileUtil.getCanonicalPath(
 		".");
 
-	private static final String _OUTPUT_DIR_NAME = PropsValues.OUTPUT_DIR_NAME;
+	private static final String _OCULAR_RESULT_IMAGE_DIR_NAME;
 
-	private static final String _TEST_DEPENDENCIES_DIR_NAME =
-		PropsValues.TEST_DEPENDENCIES_DIR_NAME;
+	private static final String _OCULAR_SNAP_IMAGE_DIR_NAME;
+
+	private static final String _OUTPUT_DIR_NAME;
+
+	private static final String _SIKULI_IMAGES_DIR_NAME;
+
+	private static final String _TEST_DEPENDENCIES_DIR_NAME;
 
 	private static final Pattern _aceEditorPattern = Pattern.compile(
 		"\\(|\\$\\{line\\.separator\\}");
@@ -4698,18 +4670,51 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 			}
 		};
 
+	static {
+		String testDependenciesDirName = PropsValues.TEST_DEPENDENCIES_DIR_NAME;
+
+		String ocularSnapImageDirName =
+			testDependenciesDirName + "//ocular//snap";
+		String ocularResultImageDirName =
+			testDependenciesDirName + "//ocular//result";
+		String sikuliImagesDirName =
+			testDependenciesDirName + "//sikuli//linux//";
+
+		String outputDirName = PropsValues.OUTPUT_DIR_NAME;
+
+		if (OSDetector.isApple()) {
+			sikuliImagesDirName = StringUtil.replace(
+				sikuliImagesDirName, "linux", "osx");
+		}
+		else if (OSDetector.isWindows()) {
+			ocularResultImageDirName = StringUtil.replace(
+				ocularResultImageDirName, "//", "\\");
+			ocularSnapImageDirName = StringUtil.replace(
+				ocularSnapImageDirName, "//", "\\");
+			outputDirName = StringUtil.replace(outputDirName, "//", "\\");
+			sikuliImagesDirName = StringUtil.replace(
+				sikuliImagesDirName, "//", "\\");
+			sikuliImagesDirName = StringUtil.replace(
+				sikuliImagesDirName, "linux", "windows");
+
+			testDependenciesDirName = StringUtil.replace(
+				testDependenciesDirName, "//", "\\");
+		}
+
+		_OUTPUT_DIR_NAME = outputDirName;
+		_OCULAR_SNAP_IMAGE_DIR_NAME = ocularSnapImageDirName;
+		_OCULAR_RESULT_IMAGE_DIR_NAME = ocularResultImageDirName;
+		_SIKULI_IMAGES_DIR_NAME = sikuliImagesDirName;
+		_TEST_DEPENDENCIES_DIR_NAME = testDependenciesDirName;
+	}
+
 	private String _clipBoard = "";
 	private String _defaultWindowHandle;
 	private Stack<WebElement> _frameWebElements = new Stack<>();
 	private int _navigationBarHeight = 120;
-	private final String _ocularResultImageDirName;
-	private final String _ocularSnapImageDirName;
-	private final String _outputDirName;
 	private String _primaryTestSuiteName;
 	private int _screenshotCount;
 	private int _screenshotErrorCount;
-	private final String _sikuliImagesDirName;
-	private final String _testDependenciesDirName;
 	private final WebDriver _webDriver;
 
 	private class LocationCallable implements Callable<String> {

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -4673,10 +4673,10 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	static {
 		String testDependenciesDirName = PropsValues.TEST_DEPENDENCIES_DIR_NAME;
 
-		String ocularSnapImageDirName =
-			testDependenciesDirName + "//ocular//snap";
 		String ocularResultImageDirName =
 			testDependenciesDirName + "//ocular//result";
+		String ocularSnapImageDirName =
+			testDependenciesDirName + "//ocular//snap";
 		String sikuliImagesDirName =
 			testDependenciesDirName + "//sikuli//linux//";
 
@@ -4702,8 +4702,8 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		}
 
 		_OUTPUT_DIR_NAME = outputDirName;
-		_OCULAR_SNAP_IMAGE_DIR_NAME = ocularSnapImageDirName;
 		_OCULAR_RESULT_IMAGE_DIR_NAME = ocularResultImageDirName;
+		_OCULAR_SNAP_IMAGE_DIR_NAME = ocularSnapImageDirName;
 		_SIKULI_IMAGES_DIR_NAME = sikuliImagesDirName;
 		_TEST_DEPENDENCIES_DIR_NAME = testDependenciesDirName;
 	}

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -4534,10 +4534,10 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		OcularConfiguration ocularConfiguration = Ocular.config();
 
 		ocularConfiguration = ocularConfiguration.snapshotPath(
-			Paths.get(".", _ocularSnapImageDirName));
+			Paths.get(".", getOcularSnapImageDirName()));
 
 		ocularConfiguration.resultPath(
-			Paths.get(".", _ocularResultImageDirName));
+			Paths.get(".", getOcularResultImageDirName()));
 
 		ocularConfiguration.globalSimilarity(99);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/POSHI-110
https://issues.liferay.com/browse/POSHI-130
https://issues.liferay.com/browse/POSHI-133

Took a while to fix due to multiple resends. This is a follow up pull to https://github.com/brianchandotcom/liferay-portal/pull/96566 and will resync poshi-runner with the latest poshi-core. 

poshi-core and poshi-runner got out of sync due to initially adding a new method for ocular only in LiferaySelenium in poshi-core. The pull that implemented the new method were sent subsequently, but a name change was needed for that method (https://github.com/brianchandotcom/liferay-portal/pull/96023), which delayed syncing poshi-runner back to the latest poshi-core. 

I combined the ocular method implementation update with POSHI-133 as it's a minor change that touched the same files, and was being blocked due to poshi-core and poshi-runner not matching. 

Also, I created a separate ticket for POSHI-130 after I made changes based on https://github.com/kenjiheigel/liferay-portal/pull/724/commits/ca92edba53fd5bbba530d562a069ad071bc2c383 and found that additional refactors should be done. 

Additional pulls for poshi-core and poshi-runner will be sent together to prevent this from happening again.  

@pyoo47, combined resend of https://github.com/pyoo47/liferay-portal/pull/1579 and https://github.com/brianchandotcom/liferay-portal/pull/96023

fyi. @austinchiang, @lucasneves91