### PR TITLE
POSHI-158 Output total duration of 'LiferaySelenium.pause' after every test case

### DIFF
--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -2242,8 +2242,12 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void pause(String waitTime) throws Exception {
-		LiferaySeleniumUtil.pause(waitTime);
+	public void pause(String durationString) throws Exception {
+		int duration = GetterUtil.getInteger(durationString);
+
+		_totalPauseDuration = _totalPauseDuration + duration;
+
+		LiferaySeleniumUtil.pause(duration);
 	}
 
 	@Override
@@ -2252,6 +2256,10 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 	@Override
 	public void quit() {
+		System.out.println(
+			"Total duration of 'LiferaySelenium.pause' usages: " +
+				_totalPauseDuration + " ms");
+
 		_webDriver.quit();
 	}
 
@@ -4755,6 +4763,7 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	private String _primaryTestSuiteName;
 	private int _screenshotCount;
 	private int _screenshotErrorCount;
+	private int _totalPauseDuration;
 	private final WebDriver _webDriver;
 
 	private class LocationCallable implements Callable<String> {

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySeleniumUtil.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySeleniumUtil.java
@@ -678,8 +678,8 @@ public class LiferaySeleniumUtil {
 		return false;
 	}
 
-	public static void pause(String waitTime) throws Exception {
-		Thread.sleep(GetterUtil.getInteger(waitTime));
+	public static void pause(int duration) throws Exception {
+		Thread.sleep(duration);
 	}
 
 	public static void printJavaProcessStacktrace() throws Exception {


### PR DESCRIPTION
https://issues.liferay.com/browse/POSHI-158

Eventually, I want to make the time data portion and the logging portion of this more built out, but for now, just want to provide some quick information of total 'pause' usages at the end of each test. When I ran PortalSmoke#Smoke locally, the test took 8 minutes, and 4.4 minutes were attributed to pausing. 