### PR TITLE
LRCI-2157 Skip relevant testing for changes in modules/dxp/apps/commerce-salesforce-connector/commerce-salesforce-talend-connectors/*

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -116,6 +116,7 @@ ci.test.available.suites=\
     workflow
 
 ci.test.relevant.bypass.file.path.patterns=\
+    .*/modules/dxp/apps/commerce-salesforce-connector/commerce-salesforce-talend-connectors/.*,\
     .*/modules/etl/.*,\
     .*/modules/test/jenkins-results-parser/.*,\
     .*/packageinfo$,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2157

From the ticket: 

> Why: content of folder is Eclipse workspace infrastructure files and talend integration job design files (*.item)
>
> To make it short, content is produced by Talend Open Studio - Eclipse based tool for modeling integration processes.