### PR TITLE
LRCI-3336 Bypass CI for gradle changes

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -159,10 +159,13 @@ ci.test.relevant.bypass.file.path.patterns=\
     .*/(ci|test).properties$,\
     .*/liferay-portal[^/]*/.m2-tmp/.*,\
     .*/liferay-portal[^/]*/learn-resources/.*,\
+    .*/liferay-portal[^/]*/modules/build-buildscript.gradle,\
     .*/liferay-portal[^/]*/modules/dxp/apps/commerce-salesforce-connector/commerce-salesforce-talend-connectors/.*,\
     .*/liferay-portal[^/]*/modules/etl/.*,\
+    .*/liferay-portal[^/]*/modules/sdk/.*,\
     .*/liferay-portal[^/]*/modules/test/jenkins-results-parser/.*,\
     .*/liferay-portal[^/]*/modules/test/poshi/.*,\
+    .*/liferay-portal[^/]*/portal-web/build-test.gradle,\
     .*/liferay-portal[^/]*/readme/.*,\
     .*/packageinfo$,\
     .*\\.function$,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3336

For all gradle plugin changes, only SF will run. This is because currently, any gradle plugin PR will use 1000+ builds, but isn't providing any real value to any gradle related testing.