### PR TITLE
LRCI-3921 Fix poshi macro's curl syntax; add space before backslash

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
@@ -34,7 +34,7 @@ definition {
 			var command = StringUtil.add(${command}, " \ ${body}", "");
 		}
 
-		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}", "\ ${command}", "");
+		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}", " \ ${command}", "");
 
 		return ${curl};
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardMessageAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardMessageAPI.macro
@@ -29,7 +29,7 @@ definition {
 			var command = StringUtil.add(${command}, " \ ${body}", "");
 		}
 
-		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}", "\ ${command}", "");
+		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}", " \ ${command}", "");
 
 		return ${curl};
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardSectionAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardSectionAPI.macro
@@ -23,7 +23,7 @@ definition {
 			}
 		''';
 
-		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}/message-board-sections", "\ ${command}", "");
+		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}/message-board-sections", " \ ${command}", "");
 
 		return ${curl};
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardThreadAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardThreadAPI.macro
@@ -33,7 +33,7 @@ definition {
 			var command = StringUtil.add(${command}, " \ ${body}", "");
 		}
 
-		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}", "\ ${command}", "");
+		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}", " \ ${command}", "");
 
 		return ${curl};
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3921

Tested here on test-1 (old image) and test-5 (new image) to confirm the fix works in both cases. 
https://github.com/kenjiheigel/liferay-portal/pull/1537

cc: @pyoo47, @CalumR23