### PR TITLE
LRCI-4293 Update GitRepository.getJSONObject to pass in String instead of File (Fix Jenkins Report generation)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRepositoryJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRepositoryJob.java
@@ -59,7 +59,9 @@ public abstract class GitRepositoryJob extends BaseJob {
 		jsonObject = super.getJSONObject();
 
 		jsonObject.put("branch", _getBranchJSONObject());
-		jsonObject.put("git_repository_dir", gitRepositoryDir);
+		jsonObject.put(
+			"git_repository_dir",
+			JenkinsResultsParserUtil.getCanonicalPath(gitRepositoryDir));
 		jsonObject.put("upstream_branch_name", _upstreamBranchName);
 
 		return jsonObject;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-4293