### PR TITLE
LRCI-5683 Don't copy symbolic links when updating binaries cache

### DIFF
--- a/modules/util.gradle
+++ b/modules/util.gradle
@@ -4,6 +4,8 @@ import com.liferay.gradle.plugins.util.PortalTools
 import com.liferay.gradle.util.FileUtil
 import com.liferay.gradle.util.StringUtil
 
+import java.nio.file.Files
+
 import java.util.regex.Matcher
 
 import org.gradle.util.GUtil
@@ -377,6 +379,12 @@ private void _createYarnTasks() {
 
 			yarnTask = tasks.create(name: "updateYarnBinariesCache" + _camelCase(yarnLockFile.parentFile.name), type: Copy) {
 				from nodeModulesCacheDir
+
+				exclude {
+					FileTreeElement fileTreeElement ->
+					return Files.isSymbolicLink(fileTreeElement.file.toPath())
+				}
+
 				into offlineCacheDir
 
 				doFirst {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-5683

cc: @drewbrokke

This gradle task is used only in CI to daily update the binaries cache repo. With the changes I made last week https://github.com/liferay/liferay-portal/commit/842722805e87c06e183e37c4eff1445446e2453c, we started using symbolic links with the ant `sync-dir` task to improve performance in AWS CI, which inadvertently caused an issue with the binaries cache update job. 

There were several issues earlier this week, this being one of them, so on tuesday, we reverted the bad binaries cache commits, and disabled the job in CI. Since then there haven't been any current issues, but we haven't been updating binaries cache. This change will fix it. 

I've tested the changes and it worked correctly here: 
https://github.com/liferay/liferay-binaries-cache-2020/commit/d63c180352a70efa70a5f02ad586219558844029