### PR TITLE
LRCI-7215 Rely on local liferay-jenkins-ee repo instead of CI for properties; consolidate build properties to liferay-jenkins-ee only; clean up unnecessary things

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -2211,8 +2211,6 @@ public abstract class BaseBuild implements Build {
 			JenkinsResultsParserUtil.combine(
 				"(", Pattern.quote(Build.DEPENDENCIES_URL_TOKEN), "|",
 				Pattern.quote(JenkinsResultsParserUtil.urlDependenciesFile),
-				"|",
-				Pattern.quote(JenkinsResultsParserUtil.urlDependenciesHttp),
 				")/*(?<archiveName>.*)/(?<master>[^/]+)/+(?<jobName>[^/]+)",
 				".*/(?<buildNumber>\\d+)/?"));
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -6569,32 +6569,26 @@ public class JenkinsResultsParserUtil {
 	protected static String initCacheURL() {
 		String cacheDirPath = System.getenv("CACHE_DIR");
 
-		if ((cacheDirPath == null) &&
-			(System.getenv("JENKINS_GITHUB_URL") != null)) {
-
+		if (cacheDirPath == null) {
 			cacheDirPath = "/opt/dev/projects/github";
 		}
 
-		if (cacheDirPath != null) {
-			File cacheDir = new File(cacheDirPath);
+		File cacheDir = new File(cacheDirPath);
 
-			File cacheRepositoryDir = new File(
-				cacheDir, JENKINS_REPOSITORY_NAME);
+		File cacheRepositoryDir = new File(cacheDir, JENKINS_REPOSITORY_NAME);
 
-			if (cacheDir.exists() && cacheRepositoryDir.exists()) {
-				System.out.println(
-					"Using " + cacheDirPath + " for cached files");
+		if (cacheDir.exists() && cacheRepositoryDir.exists()) {
+			System.out.println("Using " + cacheDirPath + " for cached files");
 
-				return "file://" + cacheDirPath;
-			}
+			return "file://" + cacheDirPath;
 		}
 
 		throw new RuntimeException(
 			combine(
 				"Unable to locate local ", JENKINS_REPOSITORY_NAME,
-				" repository. Set CACHE_DIR or JENKINS_GITHUB_URL to a ",
-				"directory containing a ", JENKINS_REPOSITORY_NAME,
-				" checkout."));
+				" repository at ", cacheDirPath,
+				". Set CACHE_DIR to a directory containing a ",
+				JENKINS_REPOSITORY_NAME, " checkout."));
 	}
 
 	protected static String urlDependenciesFile;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -146,11 +146,6 @@ public class JenkinsResultsParserUtil {
 		URL_CACHE + "/liferay-jenkins-ee/git-working-directories.json"
 	};
 
-	public static final String[] URLS_JENKINS_BUILD_PROPERTIES_DEFAULT = {
-		URL_CACHE + "/liferay-jenkins-ee/build.properties",
-		URL_CACHE + "/liferay-jenkins-ee/commands/build.properties"
-	};
-
 	public static final String[] URLS_JENKINS_PROPERTIES_DEFAULT = {
 		URL_CACHE + "/liferay-jenkins-ee/jenkins.properties"
 	};
@@ -2384,41 +2379,12 @@ public class JenkinsResultsParserUtil {
 	}
 
 	public static Properties getJenkinsBuildProperties() {
-		Properties properties = new Properties();
-
-		synchronized (_jenkinsBuildProperties) {
-			if (!_jenkinsBuildProperties.isEmpty()) {
-				properties.putAll(_jenkinsBuildProperties);
-
-				return properties;
-			}
-
-			for (String url : URLS_JENKINS_BUILD_PROPERTIES_DEFAULT) {
-				if (url.startsWith("file://")) {
-					properties.putAll(
-						getProperties(new File(url.replace("file://", ""))));
-
-					continue;
-				}
-
-				try {
-					properties.load(
-						new StringReader(
-							toString(
-								getLocalURL(url), false, 0, null, null, 0,
-								_MILLIS_TIMEOUT_DEFAULT, null, true)));
-				}
-				catch (IOException ioException) {
-					throw new RuntimeException(ioException);
-				}
-			}
-
-			_jenkinsBuildProperties.clear();
-
-			_jenkinsBuildProperties.putAll(properties);
+		try {
+			return getBuildProperties();
 		}
-
-		return new SecureProperties(properties);
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
 	}
 
 	public static String getJenkinsBuildResult(String buildURL) {
@@ -7454,7 +7420,6 @@ public class JenkinsResultsParserUtil {
 	private static JSONArray _gitWorkingDirectoriesJSONArray;
 	private static final Pattern _javaVersionPattern = Pattern.compile(
 		"(\\d+\\.\\d+)");
-	private static final Properties _jenkinsBuildProperties = new Properties();
 	private static final Pattern _jenkinsBuildQueueURLPattern = Pattern.compile(
 		"https?://test-\\d+-\\d+(.liferay.com)?/queue/item/(?<queueId>\\d+)/?");
 	private static final Pattern _jenkinsMasterPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -125,10 +125,7 @@ import org.json.JSONObject;
  */
 public class JenkinsResultsParserUtil {
 
-	public static final String[] CACHED_REPOSITORIES = {
-		"liferay-jenkins-ee", "liferay-jenkins-results-parser-samples-ee",
-		"liferay-portal"
-	};
+	public static final String JENKINS_REPOSITORY_NAME = "liferay-jenkins-ee";
 
 	public static final int PAGES_GITHUB_API_PAGES_SIZE_MAX = 10;
 
@@ -138,10 +135,7 @@ public class JenkinsResultsParserUtil {
 
 	public static final String[] URLS_BUILD_PROPERTIES_DEFAULT = {
 		URL_CACHE + "/liferay-jenkins-ee/build.properties",
-		URL_CACHE + "/liferay-jenkins-ee/commands/build.properties",
-		URL_CACHE + "/liferay-portal/build.properties",
-		URL_CACHE + "/liferay-portal/ci.properties",
-		URL_CACHE + "/liferay-portal/test.properties"
+		URL_CACHE + "/liferay-jenkins-ee/commands/build.properties"
 	};
 
 	public static final String[] URLS_GIT_DIRECTORIES_JSON_DEFAULT = {
@@ -6638,19 +6632,15 @@ public class JenkinsResultsParserUtil {
 			File cacheDir = new File(cacheDirPath);
 
 			if (cacheDir.exists()) {
-				for (String cachedRepository : CACHED_REPOSITORIES) {
-					File cacheRepositoryDir = new File(
-						cacheDir, cachedRepository);
+				File cacheRepositoryDir = new File(
+					cacheDir, JENKINS_REPOSITORY_NAME);
 
-					if (!cacheRepositoryDir.exists()) {
-						break;
-					}
+				if (cacheRepositoryDir.exists()) {
+					System.out.println(
+						"Using " + cacheDirPath + " for cached files");
+
+					return "file://" + cacheDirPath;
 				}
-
-				System.out.println(
-					"Using " + cacheDirPath + " for cached files");
-
-				return "file://" + cacheDirPath;
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -6590,7 +6590,12 @@ public class JenkinsResultsParserUtil {
 			}
 		}
 
-		return "http://mirrors-no-cache.lax.liferay.com/github.com/liferay";
+		throw new RuntimeException(
+			combine(
+				"Unable to locate local ", JENKINS_REPOSITORY_NAME,
+				" repository. Set CACHE_DIR or JENKINS_GITHUB_URL to a ",
+				"directory containing a ", JENKINS_REPOSITORY_NAME,
+				" checkout."));
 	}
 
 	protected static String urlDependenciesFile;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2880,10 +2880,6 @@ public class JenkinsResultsParserUtil {
 			if (file.exists()) {
 				remoteURL = fileURL;
 			}
-			else {
-				remoteURL = remoteURL.replace(
-					Build.DEPENDENCIES_URL_TOKEN, urlDependenciesHttp);
-			}
 		}
 
 		if (remoteURL.startsWith("file")) {
@@ -5266,22 +5262,6 @@ public class JenkinsResultsParserUtil {
 			int retryPeriod, int timeout, HTTPAuthorization httpAuthorization)
 		throws IOException {
 
-		if (url.startsWith("file:") &&
-			url.contains("liferay-jenkins-results-parser-samples-ee")) {
-
-			File file = new File(url.replace("file:", ""));
-
-			if (!file.exists()) {
-				if (url.contains("json?")) {
-					url = url.substring(0, url.indexOf("json?") + 4);
-				}
-
-				if (url.contains("json[qt]")) {
-					url = url.substring(0, url.indexOf("json[qt]") + 4);
-				}
-			}
-		}
-
 		if (url.contains("/userContent/") && (timeout == 0)) {
 			timeout = 5000;
 		}
@@ -6648,8 +6628,6 @@ public class JenkinsResultsParserUtil {
 	}
 
 	protected static String urlDependenciesFile;
-	protected static String urlDependenciesHttp =
-		URL_CACHE + "/liferay-jenkins-results-parser-samples-ee/1/";
 
 	static {
 		File dependenciesDir = new File("src/test/resources/dependencies/");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2383,7 +2383,8 @@ public class JenkinsResultsParserUtil {
 			return getBuildProperties();
 		}
 		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
+			throw new RuntimeException(
+				"Unable to get build properties", ioException);
 		}
 	}
 
@@ -6577,16 +6578,14 @@ public class JenkinsResultsParserUtil {
 		if (cacheDirPath != null) {
 			File cacheDir = new File(cacheDirPath);
 
-			if (cacheDir.exists()) {
-				File cacheRepositoryDir = new File(
-					cacheDir, JENKINS_REPOSITORY_NAME);
+			File cacheRepositoryDir = new File(
+				cacheDir, JENKINS_REPOSITORY_NAME);
 
-				if (cacheRepositoryDir.exists()) {
-					System.out.println(
-						"Using " + cacheDirPath + " for cached files");
+			if (cacheDir.exists() && cacheRepositoryDir.exists()) {
+				System.out.println(
+					"Using " + cacheDirPath + " for cached files");
 
-					return "file://" + cacheDirPath;
-				}
+				return "file://" + cacheDirPath;
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -218,12 +218,6 @@ public class Test {
 				"${dependencies.url}");
 		}
 
-		if (message.contains(JenkinsResultsParserUtil.urlDependenciesHttp)) {
-			message = message.replace(
-				JenkinsResultsParserUtil.urlDependenciesHttp,
-				"${dependencies.url}");
-		}
-
 		return message.replaceAll("[^\\S\\r\\n]+\n", "\n");
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7215

**What is being fixed:** `JenkinsResultsParserUtil.getBuildProperties()`
falls back to `http://mirrors-no-cache.lax.liferay.com` when the local
cache dir isn't found, making mirrors a soft SPOF for property lookups.
The portal property files in the default URL list (`build.properties`,
`ci.properties`, `test.properties`) aren't actually read through
`getBuildProperty`/`getBuildProperties` anywhere — portal-only keys go
through `getCIProperty` or `getProperties(File)` instead.

**How it is being fixed:** Narrows `URLS_BUILD_PROPERTIES_DEFAULT` to the
two `liferay-jenkins-ee` files, removes the dead `urlDependenciesHttp`
samples-ee path, folds `getJenkinsBuildProperties` into
`getBuildProperties` behind a single loader and cache, and replaces the
mirrors fallback in `initCacheURL` with a `RuntimeException` so missing
local state fails loudly instead of silently routing through mirrors.