### PR TITLE
LRCI-7362 Balance modules-compile axes by test class method count

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/CompileModulesTestClass.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/CompileModulesTestClass.java
@@ -26,6 +26,18 @@ import org.json.JSONObject;
  */
 public class CompileModulesTestClass extends ModulesTestClass {
 
+	@Override
+	public long getOverheadWeight() {
+		return 0;
+	}
+
+	@Override
+	public long getWeight() {
+		List<TestClassMethod> testClassMethods = getTestClassMethods();
+
+		return testClassMethods.size();
+	}
+
 	protected CompileModulesTestClass(
 		BatchTestClassGroup batchTestClassGroup, File moduleBaseDir) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/AxisTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/AxisTestClassGroup.java
@@ -13,7 +13,6 @@ import com.liferay.jenkins.results.parser.test.clazz.TestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClassFactory;
 
 import java.io.File;
-import java.io.IOException;
 
 import java.util.Collections;
 import java.util.List;
@@ -182,6 +181,7 @@ public class AxisTestClassGroup extends BaseTestClassGroup {
 		return jsonObject;
 	}
 
+	@Override
 	public Integer getMinimumSlaveRAM() {
 		if (_segmentTestClassGroup != null) {
 			return _segmentTestClassGroup.getMinimumSlaveRAM();
@@ -280,36 +280,17 @@ public class AxisTestClassGroup extends BaseTestClassGroup {
 		testClass.setAxisTestClassGroup(this);
 	}
 
-	@Override
-	protected String getBaseSlaveLabel() {
-		String baseSlaveLabel = _getBaseSlaveLabel();
-
-		if (!JenkinsResultsParserUtil.isCloudCINode() ||
-			!JenkinsResultsParserUtil.isNullOrEmpty(baseSlaveLabel)) {
-
-			return baseSlaveLabel;
-		}
-
-		String slaveLabel = null;
-
-		try {
-			slaveLabel = JenkinsResultsParserUtil.getBuildProperty(
-				"jenkins.osb.jenkins.web.slave.label.minimum.ram",
-				String.valueOf(getMinimumSlaveRAM()));
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		if (!JenkinsResultsParserUtil.isNullOrEmpty(slaveLabel)) {
-			return slaveLabel;
-		}
-
-		return baseSlaveLabel;
-	}
-
 	protected GroupingStrategy getGroupingStrategy() {
 		return _batchTestClassGroup.getGroupingStrategy();
+	}
+
+	@Override
+	protected String getParentBaseSlaveLabel() {
+		if (_segmentTestClassGroup != null) {
+			return _segmentTestClassGroup.getBaseSlaveLabel();
+		}
+
+		return _batchTestClassGroup.getBaseSlaveLabel();
 	}
 
 	protected void setBatchTestClassGroup(
@@ -322,14 +303,6 @@ public class AxisTestClassGroup extends BaseTestClassGroup {
 		SegmentTestClassGroup segmentTestClassGroup) {
 
 		_segmentTestClassGroup = segmentTestClassGroup;
-	}
-
-	private String _getBaseSlaveLabel() {
-		if (_segmentTestClassGroup != null) {
-			return _segmentTestClassGroup.getBaseSlaveLabel();
-		}
-
-		return _batchTestClassGroup.getBaseSlaveLabel();
 	}
 
 	private Long _averageDuration;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/AxisTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/AxisTestClassGroup.java
@@ -282,8 +282,12 @@ public class AxisTestClassGroup extends BaseTestClassGroup {
 
 	@Override
 	protected String getBaseSlaveLabel() {
-		if (!JenkinsResultsParserUtil.isCloudCINode()) {
-			return _getBaseSlaveLabel();
+		String baseSlaveLabel = _getBaseSlaveLabel();
+
+		if (!JenkinsResultsParserUtil.isCloudCINode() ||
+			!JenkinsResultsParserUtil.isNullOrEmpty(baseSlaveLabel)) {
+
+			return baseSlaveLabel;
 		}
 
 		String slaveLabel = null;
@@ -301,7 +305,7 @@ public class AxisTestClassGroup extends BaseTestClassGroup {
 			return slaveLabel;
 		}
 
-		return _getBaseSlaveLabel();
+		return baseSlaveLabel;
 	}
 
 	protected GroupingStrategy getGroupingStrategy() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BaseTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BaseTestClassGroup.java
@@ -25,6 +25,8 @@ import java.util.TreeSet;
  */
 public abstract class BaseTestClassGroup implements TestClassGroup {
 
+	public abstract Integer getMinimumSlaveRAM();
+
 	public abstract String getOSArchitecture();
 
 	public String getSlaveLabel() {
@@ -108,7 +110,32 @@ public abstract class BaseTestClassGroup implements TestClassGroup {
 		return !_testClasses.isEmpty();
 	}
 
-	protected abstract String getBaseSlaveLabel();
+	protected String getBaseSlaveLabel() {
+		String baseSlaveLabel = getParentBaseSlaveLabel();
+
+		if (!JenkinsResultsParserUtil.isCloudCINode() ||
+			!JenkinsResultsParserUtil.isNullOrEmpty(baseSlaveLabel)) {
+
+			return baseSlaveLabel;
+		}
+
+		String slaveLabel = null;
+
+		try {
+			slaveLabel = JenkinsResultsParserUtil.getBuildProperty(
+				"jenkins.osb.jenkins.web.slave.label.minimum.ram",
+				String.valueOf(getMinimumSlaveRAM()));
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(slaveLabel)) {
+			return slaveLabel;
+		}
+
+		return baseSlaveLabel;
+	}
 
 	protected String getBuildStartProperty(String propertyName) {
 		BuildDatabase buildDatabase = BuildDatabaseUtil.getBuildDatabase();
@@ -121,6 +148,10 @@ public abstract class BaseTestClassGroup implements TestClassGroup {
 				startProperties, propertyName);
 		}
 
+		return null;
+	}
+
+	protected String getParentBaseSlaveLabel() {
 		return null;
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -403,6 +403,7 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 		return JenkinsMaster.getSlavesPerHostDefault();
 	}
 
+	@Override
 	public Integer getMinimumSlaveRAM() {
 		JobProperty jobProperty = getJobProperty(
 			"test.batch.minimum.slave.ram");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/CompileModulesBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/CompileModulesBatchTestClassGroup.java
@@ -8,12 +8,16 @@ package com.liferay.jenkins.results.parser.test.clazz.group;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.PortalGitWorkingDirectory;
 import com.liferay.jenkins.results.parser.PortalTestClassJob;
+import com.liferay.jenkins.results.parser.test.clazz.TestClass;
+import com.liferay.jenkins.results.parser.test.clazz.TestClassBalancedListSplitter;
 
 import java.io.File;
 import java.io.IOException;
 
 import java.nio.file.PathMatcher;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import org.json.JSONObject;
@@ -34,6 +38,57 @@ public class CompileModulesBatchTestClassGroup
 		String batchName, PortalTestClassJob portalTestClassJob) {
 
 		super(batchName, portalTestClassJob);
+	}
+
+	@Override
+	protected void setAxisTestClassGroups() {
+		if (!containsTestClasses()) {
+			return;
+		}
+
+		int axisCount = getAxisCount();
+
+		if (axisCount == 0) {
+			return;
+		}
+
+		List<TestClass> testClasses = getTestClasses();
+
+		long totalWeight = 0;
+
+		for (TestClass testClass : testClasses) {
+			totalWeight += testClass.getWeight();
+		}
+
+		long maxListWeight = (totalWeight + axisCount - 1) / axisCount;
+
+		Collections.sort(
+			testClasses,
+			new Comparator<TestClass>() {
+
+				@Override
+				public int compare(TestClass testClass1, TestClass testClass2) {
+					return Long.compare(
+						testClass2.getWeight(), testClass1.getWeight());
+				}
+
+			});
+
+		TestClassBalancedListSplitter testClassBalancedListSplitter =
+			new TestClassBalancedListSplitter(maxListWeight);
+
+		for (List<TestClass> axisTestClasses :
+				testClassBalancedListSplitter.split(testClasses)) {
+
+			AxisTestClassGroup axisTestClassGroup =
+				TestClassGroupFactory.newAxisTestClassGroup(this);
+
+			for (TestClass testClass : axisTestClasses) {
+				axisTestClassGroup.addTestClass(testClass);
+			}
+
+			axisTestClassGroups.add(axisTestClassGroup);
+		}
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/SegmentTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/SegmentTestClassGroup.java
@@ -233,8 +233,12 @@ public class SegmentTestClassGroup extends BaseTestClassGroup {
 
 	@Override
 	protected String getBaseSlaveLabel() {
-		if (!JenkinsResultsParserUtil.isCloudCINode()) {
-			return _getBaseSlaveLabel();
+		String baseSlaveLabel = _getBaseSlaveLabel();
+
+		if (!JenkinsResultsParserUtil.isCloudCINode() ||
+			!JenkinsResultsParserUtil.isNullOrEmpty(baseSlaveLabel)) {
+
+			return baseSlaveLabel;
 		}
 
 		String slaveLabel = null;
@@ -252,7 +256,7 @@ public class SegmentTestClassGroup extends BaseTestClassGroup {
 			return slaveLabel;
 		}
 
-		return _getBaseSlaveLabel();
+		return baseSlaveLabel;
 	}
 
 	private String _getBaseSlaveLabel() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/SegmentTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/SegmentTestClassGroup.java
@@ -100,6 +100,7 @@ public class SegmentTestClassGroup extends BaseTestClassGroup {
 		return _batchTestClassGroup.getMaximumSlavesPerHost();
 	}
 
+	@Override
 	public Integer getMinimumSlaveRAM() {
 		return _batchTestClassGroup.getMinimumSlaveRAM();
 	}
@@ -232,34 +233,7 @@ public class SegmentTestClassGroup extends BaseTestClassGroup {
 	}
 
 	@Override
-	protected String getBaseSlaveLabel() {
-		String baseSlaveLabel = _getBaseSlaveLabel();
-
-		if (!JenkinsResultsParserUtil.isCloudCINode() ||
-			!JenkinsResultsParserUtil.isNullOrEmpty(baseSlaveLabel)) {
-
-			return baseSlaveLabel;
-		}
-
-		String slaveLabel = null;
-
-		try {
-			slaveLabel = JenkinsResultsParserUtil.getBuildProperty(
-				"jenkins.osb.jenkins.web.slave.label.minimum.ram",
-				String.valueOf(getMinimumSlaveRAM()));
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		if (!JenkinsResultsParserUtil.isNullOrEmpty(slaveLabel)) {
-			return slaveLabel;
-		}
-
-		return baseSlaveLabel;
-	}
-
-	private String _getBaseSlaveLabel() {
+	protected String getParentBaseSlaveLabel() {
 		BatchTestClassGroup batchTestClassGroup = getBatchTestClassGroup();
 
 		return batchTestClassGroup.getBaseSlaveLabel();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7362

- Balance modules-compile axes by `TestClassMethod` count using `TestClassBalancedListSplitter` so heavy modules stop dominating a single axis.
- Honor `test.batch.slave.label` in axis/segment `getBaseSlaveLabel()` on CI.
- Consolidate the shared `getBaseSlaveLabel` logic in `BaseTestClassGroup`.