### PR TITLE
LRCI-7299 Parallelize modules-compile to shorten stable runtime

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -8712,50 +8712,17 @@ information. Make sure to commit in all format-javadoc results.
 					</then>
 				</if>
 
-				<loadresource property="modules.compile.task.groups">
+				<loadresource property="modules.compile.tasks">
 					<filterchain>
 						<replacestring from="-test:assemble" to="-test:compileTestIntegrationJava" />
-
-						<tokenfilter>
-							<replaceregex flags="g" pattern="(\S+ ){${test.module.groups.size}}" replace="\0," />
-						</tokenfilter>
 					</filterchain>
 					<propertyresource name="modules.test.class.group" />
 				</loadresource>
 
-				<get-gradle-module-dir-task-names gradle.task.names="${modules.compile.task.groups}" />
-
-				<for delimiter="|" list="${gradle.module.dir.task.names}" param="gradle.module.dir.task.name" trim="true">
-					<sequential>
-						<local name="gradle.module.dir" />
-						<local name="gradle.task.name" />
-
-						<propertyregex
-							input="@{gradle.module.dir.task.name}"
-							override="true"
-							property="gradle.module.dir"
-							regexp="([^=]+)=([^=]+)"
-							replace="\1"
-						/>
-
-						<propertyregex
-							input="@{gradle.module.dir.task.name}"
-							override="true"
-							property="gradle.task.name"
-							regexp="([^=]+)=([^=]+)"
-							replace="\2"
-						/>
-
-						<execute-gradle-task gradle.task.module.dir="${gradle.module.dir}" gradle.task.name="${gradle.task.name}">
-							<action>
-								<gradle-execute dir="${gradle.module.dir}" task="${gradle.task.name}">
-									<arg value="--continue" />
-									<arg value="--parallel" />
-								</gradle-execute>
-							</action>
-						</execute-gradle-task>
-					</sequential>
-				</for>
+				<gradle-execute dir="modules" task="${modules.compile.tasks}">
+					<arg value="--continue" />
+					<arg value="--parallel" />
+				</gradle-execute>
 			</test-action>
 
 			<test-set-up>

--- a/modules/init-ci.gradle
+++ b/modules/init-ci.gradle
@@ -1,0 +1,114 @@
+import groovy.xml.XmlUtil
+
+import java.util.concurrent.atomic.DoubleAdder
+
+File testResultsDir = null
+
+gradle.buildFinished {
+	gradle.rootProject.allprojects.each {
+		Project project ->
+
+		if (!project.ext.has("targetTaskName") || project.ext.has("reportWritten")) {
+			return
+		}
+
+		project.ext.reportWritten = true
+
+		_writeReport(
+			0.0d, "${project.path}:${project.ext.targetTaskName} was not executed. Please check the logs for details.", "", project.path, testResultsDir)
+	}
+}
+
+gradle.taskGraph.addTaskExecutionListener(
+	new TaskExecutionListener() {
+
+		void afterExecute(Task task, TaskState taskState) {
+			Project project = task.project
+
+			if (!project.ext.has("targetTaskName")) {
+				return
+			}
+
+			if (task.ext.has("startTime")) {
+				project.ext.compileDurationAdder.add((System.currentTimeMillis() - task.ext.startTime) / 1000.0d)
+			}
+
+			Throwable failure = taskState.failure
+
+			if ((task.name != project.ext.targetTaskName) && (failure == null)) {
+				return
+			}
+
+			double duration = project.ext.compileDurationAdder.sum()
+
+			project.ext.reportWritten = true
+
+			if (failure == null) {
+				_writeReport(duration, null, null, project.path, testResultsDir)
+			}
+			else {
+				StringWriter stringWriter = new StringWriter()
+
+				failure.printStackTrace(new PrintWriter(stringWriter))
+
+				_writeReport(
+					duration, "${task.path} failed. Please check the logs for details.", stringWriter.toString(), project.path, testResultsDir)
+			}
+		}
+
+		void beforeExecute(Task task) {
+			if (task.project.ext.has("targetTaskName")) {
+				task.ext.startTime = System.currentTimeMillis()
+			}
+		}
+
+	})
+
+gradle.taskGraph.whenReady {
+	TaskExecutionGraph taskGraph ->
+
+	taskGraph.allTasks.each {
+		Task task ->
+
+		if (!(task.name in ["assemble", "compileTestIntegrationJava"])) {
+			return
+		}
+
+		if (testResultsDir == null) {
+			testResultsDir = new File(gradle.rootProject.rootDir, "test-results")
+
+			testResultsDir.mkdirs()
+		}
+
+		Project project = task.project
+
+		project.ext.compileDurationAdder = new DoubleAdder()
+		project.ext.targetTaskName = task.name
+	}
+}
+
+private void _writeReport(
+	double duration, String failureMessage, String failureStacktrace, String projectPath, File testResultsDir) {
+
+	String className = "modules" + projectPath.replace(":", ".")
+	Date date = new Date()
+	int failureCount = (failureMessage == null) ? 0 : 1
+	String failureElementString = ""
+
+	if (failureMessage != null) {
+		failureElementString = "<failure message=\"${XmlUtil.escapeXml(failureMessage)}\">${XmlUtil.escapeXml(failureStacktrace ?: "")}</failure>"
+	}
+
+	File file = new File(testResultsDir, "TEST-${className}.xml")
+
+	file.text = """<?xml version="1.0" encoding="UTF-8"?>
+
+		<testsuite errors="${failureCount}" failures="${failureCount}" hostname="localhost" name="${className}" skipped="0" tests="1" time="${duration}" timestamp="${date.format("yyyy-MM-dd_kk:mm:ss")}">
+			<properties />
+			<testcase classname="${className}" name="assemble" time="${duration}">
+				${failureElementString}
+			</testcase>
+			<system-out></system-out>
+			<system-err></system-err>
+		</testsuite>"""
+}

--- a/modules/init-ci.gradle
+++ b/modules/init-ci.gradle
@@ -105,9 +105,7 @@ private void _writeReport(
 
 		<testsuite errors="${failureCount}" failures="${failureCount}" hostname="localhost" name="${className}" skipped="0" tests="1" time="${duration}" timestamp="${date.format("yyyy-MM-dd_kk:mm:ss")}">
 			<properties />
-			<testcase classname="${className}" name="assemble" time="${duration}">
-				${failureElementString}
-			</testcase>
+			<testcase classname="${className}" name="assemble" time="${duration}">$failureElementString</testcase>
 			<system-out></system-out>
 			<system-err></system-err>
 		</testsuite>"""

--- a/modules/init.gradle
+++ b/modules/init.gradle
@@ -115,3 +115,15 @@ if (Boolean.getBoolean("build.performance.logger.enabled")) {
 
 		})
 }
+
+if (System.getenv("JENKINS_HOME")) {
+	gradle.rootProject {
+		Project rootProject ->
+
+		File scriptFile = rootProject.file("init-ci.gradle")
+
+		if (scriptFile.exists()) {
+			apply from: scriptFile
+		}
+	}
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7299

Follow-up to #2040, incorporating @drewbrokke's review feedback.

**Why this matters:** `modules-compile` is the longest running build
in our stable job, which runs multiple times a day. A single batch
can take nearly 1.5 hours, dragging stable out to 2–3 hours per run.
Cutting this down saves CI server hours and returns a stable result
faster.

**What is being fixed:** `modules-compile` was effectively single-
threaded — each module's `assemble` ran in its own `gradle-execute`
call, stretching the axis across 13 nodes for hours.

**How it is being fixed:** All module tasks are dispatched in one
parallel Gradle invocation, with a `TaskExecutionListener` in
`init-ci.gradle` emitting the per-module JUnit XMLs that the old
loop produced. Per-module durations now track every tracked task via
`task.ext.startTime` so reports reflect real compile work rather than
lifecycle-task no-ops.

**Measured impact:** `modules-compile` is sharded across parallel CI
builds. Total CI server time is the sum across all builds; run
wall-clock is the slowest build in the shard.

| Configuration | Builds | Total CI time | Slowest build (run wall-clock) |
| --- | --- | --- | --- |
| Current `modules-compile` | 13 | 540 min (9–10 hr) | 85 min |
| With this PR | 13 | 175 min (~3 hr) | 27 min |
| With this PR + additional tuning I'm testing | 6 | 79 min (<1.5 hr) | 18 min |

**Effect on stable:** Under the right conditions, stable should
finish in around 1 hour instead of 2–3 hours, with no single build
dominating the run.

cc: @pyoo47