### PR TITLE
LRCI-7299 Tune modules-compile axis count and pin to slave-mem

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1439,6 +1439,7 @@
 
     test.batch.aspectj.enabled=false
 
+    test.batch.axis.count[modules-compile]=6
     test.batch.axis.count[modules-integration-analytics-cloud]=1
     test.batch.axis.count[playwright-compile]=1
     test.batch.axis.count[playwright-js-smoke*]=1
@@ -1448,7 +1449,6 @@
     test.batch.axis.max.size[functional-*]=7
     test.batch.axis.max.size[functional-*][analytics-cloud*]=5
     test.batch.axis.max.size[js-unit]=50
-    test.batch.axis.max.size[modules-compile]=35
     test.batch.axis.max.size[modules-integration-project-templates]=10
     test.batch.axis.max.size[modules-integration-project-templates-jdk17_zulu]=5
     test.batch.axis.max.size[modules-integration-project-templates-jdk21_zulu]=5
@@ -2426,6 +2426,7 @@
     test.batch.size[workspaces-compile]=1
     test.batch.size[workspaces-compile-jdk11]=1
 
+    test.batch.slave.label[modules-compile]=slave-mem
     test.batch.slave.label[playwright-js-tomcat101-postgresql163][analytics-cloud]=slave-1
 
     test.batch.target.axis.class.size[playwright-*]=20


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7299

Follow-up tuning to brianchandotcom/liferay-portal#173548.

- Set `test.batch.axis.count[modules-compile]=6`.
- Pin `modules-compile` to `slave-mem`.
- Drop `test.batch.axis.max.size[modules-compile]=35`, superseded by the explicit axis count.

**Measured impact:** Brings `modules-compile` down to 6 builds totaling 79 minutes of CI time, with the slowest build finishing in 18 minutes — vs. 13 builds, 175 minutes total, and 27 minutes slowest under parallelization alone.