### PR TITLE
LRCI-7362 Stop slave label catch-all from shadowing RAM lookup

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -642,8 +642,9 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 		String slaveLabel = null;
 
 		try {
-			slaveLabel = JenkinsResultsParserUtil.getBuildProperty(
-				"jenkins.osb.jenkins.web.slave.label", getBatchJobName(),
+			slaveLabel = JenkinsResultsParserUtil.getProperty(
+				JenkinsResultsParserUtil.getBuildProperties(),
+				"jenkins.osb.jenkins.web.slave.label", false, getBatchJobName(),
 				getTestSuiteName());
 
 			if (JenkinsResultsParserUtil.isNullOrEmpty(slaveLabel)) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7362

**What is being fixed:** After [`6ed0183c85ca6`](https://github.com/liferay/liferay-portal/commit/6ed0183c85ca6) prioritized the parent label resolution chain ahead of the RAM-keyed lookup in `AxisTestClassGroup` and `SegmentTestClassGroup`, batches with `test.batch.minimum.slave.ram=24` (e.g. `js-unit`, `*playwright*`, `modules-integration*`) started landing on the 16 GB cloud fleet on cloud-CI nodes. The unsuffixed `jenkins.osb.jenkins.web.slave.label=${cloud.fleet.primary.label}` catch-all defined in `liferay-jenkins-ee` returns the 16 GB primary label for any job without a specific override, and that non-empty value short-circuits the chain in `BatchTestClassGroup.getBaseSlaveLabel` before the `jenkins.osb.jenkins.web.slave.label.minimum.ram[<ram>]` step ever runs. The result was a measurable slowdown on memory-heavy batches; for `js-unit` we observed ~2.5× wall-clock time on a 16 GB instance versus a 32 GB instance.

**How it is being fixed:** Switch the `jenkins.osb.jenkins.web.slave.label` lookup at `BatchTestClassGroup.java:645` from the convenience `getBuildProperty(name, opts)` overload to the explicit `getProperty(props, base, useBasePropertyAsDefault, opts)` overload, passing `useBasePropertyAsDefault=false`. With this flag the lookup returns `null` when no `[<jobName>][<testSuite>]` keyed variant matches, allowing the next step in the resolution chain — the RAM-keyed minimum-slave-RAM lookup — to fire as intended. Job-name-specific overrides (`test-portal-acceptance-pullrequest(*)`, `app-server-bundle-builder`, etc.) still win when explicitly defined; only the implicit catch-all is bypassed. A companion change to the BeanShell mirror in `liferay-jenkins-ee/commands/build-common.xml` and the deletion of the now-unused catch-all line from `commands/build-aws.properties` will land in a separate `liferay-jenkins-ee` change.