### PR TITLE
LRCI-7448 Tolerate missing liferay-jenkins-ee outside CI

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1429,11 +1429,7 @@ public class JenkinsResultsParserUtil {
 		throws IOException {
 
 		if (_getCacheURL() == null) {
-			System.out.println(
-				combine(
-					"Build properties are not loaded. Set the environment ",
-					"variable \"CACHE_DIR\" to a directory containing a ",
-					JENKINS_REPOSITORY_NAME, " checkout."));
+			System.out.println("WARNING: Unable to get build properties");
 		}
 
 		Properties properties = new SecureProperties();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1428,6 +1428,14 @@ public class JenkinsResultsParserUtil {
 	public static Properties getBuildProperties(boolean checkCache)
 		throws IOException {
 
+		if (_getCacheURL() == null) {
+			System.out.println(
+				combine(
+					"Build properties are not loaded. Set the environment ",
+					"variable \"CACHE_DIR\" to a directory containing a ",
+					JENKINS_REPOSITORY_NAME, " checkout."));
+		}
+
 		Properties properties = new SecureProperties();
 
 		synchronized (_buildProperties) {
@@ -6766,12 +6774,7 @@ public class JenkinsResultsParserUtil {
 			return _cacheURL;
 		}
 
-		throw new RuntimeException(
-			combine(
-				"Unable to locate local ", JENKINS_REPOSITORY_NAME,
-				" repository at ", cacheDirPath,
-				". Set the environment variable \"CACHE_DIR\" to a directory ",
-				"containing a ", JENKINS_REPOSITORY_NAME, " checkout."));
+		return null;
 	}
 
 	private static String _getCanonicalPath(File canonicalFile) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1430,6 +1430,8 @@ public class JenkinsResultsParserUtil {
 
 		if (_getCacheURL() == null) {
 			System.out.println("WARNING: Unable to get build properties");
+
+			return new SecureProperties();
 		}
 
 		Properties properties = new SecureProperties();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7448

Fixes `ExceptionInInitializerError` on `PortalGitWorkingDirectory` for portal devs without the private `liferay-jenkins-ee` repo — broke the `validateBranch` Gradle task and anything else loading jenkins-results-parser classes.

`_getCacheURL()` returns `null` instead of throwing on the non-CI / no-local-checkout branch. `getBuildProperties()` prints an actionable warning per call when the cache URL is unavailable. CI behavior unchanged.