### PR TITLE
LRCI-7447 Decouple workspace artifact caches from build.caching.enabled

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -404,10 +404,10 @@ public abstract class BaseWorkspaceGitRepository
 
 		try {
 			if (gitArchiveEnabled) {
-				checkAvailableGitArchive();
+				promoteGitArchive();
 
 				if (isSnapshot()) {
-					useGitArchive();
+					downloadGitArchive();
 				}
 			}
 
@@ -415,7 +415,7 @@ public abstract class BaseWorkspaceGitRepository
 				prepareGitWorkingDirectory();
 
 				if (gitArchiveEnabled) {
-					prepareGitArchive();
+					uploadGitArchive();
 				}
 			}
 
@@ -584,18 +584,66 @@ public abstract class BaseWorkspaceGitRepository
 		validateKeys(_REQUIRED_KEYS);
 	}
 
-	protected void checkAvailableGitArchive() throws IOException {
-		if (_snapshot) {
+	protected void downloadGitArchive() throws IOException {
+		if (!JenkinsResultsParserUtil.isCloudCINode()) {
 			return;
 		}
 
-		if (_isGitArchiveAvailable() && _isDotGitArchiveAvailable()) {
-			CloudBucketUtil.touchS3File(_getGitArchiveS3BucketPath());
-			CloudBucketUtil.touchS3File(_getDotGitArchiveS3BucketPath());
+		String baseRepositoryDir = JenkinsResultsParserUtil.getBuildProperty(
+			"base.repository.dir");
 
-			_setSnapshot(true);
+		File gitArchiveFile = new File(baseRepositoryDir, _getGitArchiveName());
 
-			_updateBuildDatabase();
+		CloudBucketUtil.downloadS3File(
+			gitArchiveFile, _getGitArchiveS3BucketPath());
+
+		File directory = getDirectory();
+
+		if (directory.exists()) {
+			_deleteGitRepository();
+		}
+
+		JenkinsResultsParserUtil.unzip(gitArchiveFile, directory);
+
+		JenkinsResultsParserUtil.delete(gitArchiveFile);
+
+		if (_isDotGitDirArchiveRequired()) {
+			File dotGitArchiveFile = new File(
+				baseRepositoryDir, _getDotGitArchiveName());
+
+			CloudBucketUtil.downloadS3File(
+				dotGitArchiveFile, _getDotGitArchiveS3BucketPath());
+
+			JenkinsResultsParserUtil.unzip(dotGitArchiveFile, directory);
+
+			JenkinsResultsParserUtil.delete(dotGitArchiveFile);
+
+			GitUtil.ExecutionResult executionResult =
+				GitUtil.executeBashCommands(
+					GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+					GitUtil.MILLIS_TIMEOUT, directory, "git reset");
+
+			if (executionResult.getExitValue() != 0) {
+				throw new RuntimeException(
+					JenkinsResultsParserUtil.combine(
+						"Unable to reset Git directory: " + directory,
+						executionResult.getStandardError()));
+			}
+
+			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+			gitWorkingDirectory.checkoutLocalGitBranch(
+				gitWorkingDirectory.createLocalGitBranch(
+					getBranchName(), true, "HEAD"));
+
+			String upstreamBranchName = getUpstreamBranchName();
+
+			if (!gitWorkingDirectory.localGitBranchExists(upstreamBranchName)) {
+				gitWorkingDirectory.createLocalGitBranch(
+					upstreamBranchName, true, getBaseBranchSHA());
+			}
+
+			gitWorkingDirectory.displayLog();
 		}
 	}
 
@@ -700,40 +748,6 @@ public abstract class BaseWorkspaceGitRepository
 		return _snapshot;
 	}
 
-	protected void prepareGitArchive() throws IOException {
-		if (!JenkinsResultsParserUtil.isCloudCINode()) {
-			return;
-		}
-
-		String jobName = _getJobName();
-
-		if (!jobName.contains("-batch") && !jobName.contains("-downstream")) {
-			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
-
-			File archiveFile = gitWorkingDirectory.archive(
-				_getGitArchiveName());
-
-			CloudBucketUtil.uploadS3File(
-				_getGitArchiveS3BucketPath(), archiveFile);
-
-			JenkinsResultsParserUtil.delete(archiveFile);
-
-			File dotGitDirArchiveFile = _archiveDotGitDir();
-
-			CloudBucketUtil.uploadS3File(
-				_getGitArchiveS3BucketPath(dotGitDirArchiveFile.getName()),
-				dotGitDirArchiveFile);
-
-			JenkinsResultsParserUtil.delete(dotGitDirArchiveFile);
-		}
-
-		if (!jobName.contains("root-cause-analysis-tool")) {
-			_setSnapshot(true);
-		}
-
-		_updateBuildDatabase();
-	}
-
 	protected void prepareGitWorkingDirectory() {
 		File dotGitFolder = new File(getDirectory(), ".git");
 
@@ -783,6 +797,21 @@ public abstract class BaseWorkspaceGitRepository
 		gitWorkingDirectory.displayLog();
 	}
 
+	protected void promoteGitArchive() throws IOException {
+		if (_snapshot) {
+			return;
+		}
+
+		if (_isGitArchiveAvailable() && _isDotGitArchiveAvailable()) {
+			CloudBucketUtil.touchS3File(_getGitArchiveS3BucketPath());
+			CloudBucketUtil.touchS3File(_getDotGitArchiveS3BucketPath());
+
+			_setSnapshot(true);
+
+			_updateBuildDatabase();
+		}
+	}
+
 	protected void setSetUp(boolean setUp) {
 		_setUp = setUp;
 	}
@@ -790,67 +819,38 @@ public abstract class BaseWorkspaceGitRepository
 	protected void setUpAdditionalCaches() throws IOException {
 	}
 
-	protected void useGitArchive() throws IOException {
+	protected void uploadGitArchive() throws IOException {
 		if (!JenkinsResultsParserUtil.isCloudCINode()) {
 			return;
 		}
 
-		String baseRepositoryDir = JenkinsResultsParserUtil.getBuildProperty(
-			"base.repository.dir");
+		String jobName = _getJobName();
 
-		File gitArchiveFile = new File(baseRepositoryDir, _getGitArchiveName());
-
-		CloudBucketUtil.downloadS3File(
-			gitArchiveFile, _getGitArchiveS3BucketPath());
-
-		File directory = getDirectory();
-
-		if (directory.exists()) {
-			_deleteGitRepository();
-		}
-
-		JenkinsResultsParserUtil.unzip(gitArchiveFile, directory);
-
-		JenkinsResultsParserUtil.delete(gitArchiveFile);
-
-		if (_isDotGitDirArchiveRequired()) {
-			File dotGitArchiveFile = new File(
-				baseRepositoryDir, _getDotGitArchiveName());
-
-			CloudBucketUtil.downloadS3File(
-				dotGitArchiveFile, _getDotGitArchiveS3BucketPath());
-
-			JenkinsResultsParserUtil.unzip(dotGitArchiveFile, directory);
-
-			JenkinsResultsParserUtil.delete(dotGitArchiveFile);
-
-			GitUtil.ExecutionResult executionResult =
-				GitUtil.executeBashCommands(
-					GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-					GitUtil.MILLIS_TIMEOUT, directory, "git reset");
-
-			if (executionResult.getExitValue() != 0) {
-				throw new RuntimeException(
-					JenkinsResultsParserUtil.combine(
-						"Unable to reset Git directory: " + directory,
-						executionResult.getStandardError()));
-			}
-
+		if (!jobName.contains("-batch") && !jobName.contains("-downstream")) {
 			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
 
-			gitWorkingDirectory.checkoutLocalGitBranch(
-				gitWorkingDirectory.createLocalGitBranch(
-					getBranchName(), true, "HEAD"));
+			File archiveFile = gitWorkingDirectory.archive(
+				_getGitArchiveName());
 
-			String upstreamBranchName = getUpstreamBranchName();
+			CloudBucketUtil.uploadS3File(
+				_getGitArchiveS3BucketPath(), archiveFile);
 
-			if (!gitWorkingDirectory.localGitBranchExists(upstreamBranchName)) {
-				gitWorkingDirectory.createLocalGitBranch(
-					upstreamBranchName, true, getBaseBranchSHA());
-			}
+			JenkinsResultsParserUtil.delete(archiveFile);
 
-			gitWorkingDirectory.displayLog();
+			File dotGitDirArchiveFile = _archiveDotGitDir();
+
+			CloudBucketUtil.uploadS3File(
+				_getGitArchiveS3BucketPath(dotGitDirArchiveFile.getName()),
+				dotGitDirArchiveFile);
+
+			JenkinsResultsParserUtil.delete(dotGitDirArchiveFile);
 		}
+
+		if (!jobName.contains("root-cause-analysis-tool")) {
+			_setSnapshot(true);
+		}
+
+		_updateBuildDatabase();
 	}
 
 	private File _archiveDotGitDir() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -589,23 +589,10 @@ public abstract class BaseWorkspaceGitRepository
 			return;
 		}
 
-		boolean useSnapshot = false;
-
-		if (_isDotGitDirArchiveRequired()) {
-			if (_isGitArchiveAvailable() && _isDotGitArchiveAvailable()) {
-				CloudBucketUtil.touchS3File(_getGitArchiveS3BucketPath());
-				CloudBucketUtil.touchS3File(_getDotGitArchiveS3BucketPath());
-
-				useSnapshot = true;
-			}
-		}
-		else if (_isGitArchiveAvailable()) {
+		if (_isGitArchiveAvailable() && _isDotGitArchiveAvailable()) {
 			CloudBucketUtil.touchS3File(_getGitArchiveS3BucketPath());
+			CloudBucketUtil.touchS3File(_getDotGitArchiveS3BucketPath());
 
-			useSnapshot = true;
-		}
-
-		if (useSnapshot) {
 			_setSnapshot(true);
 
 			_updateBuildDatabase();
@@ -731,15 +718,13 @@ public abstract class BaseWorkspaceGitRepository
 
 			JenkinsResultsParserUtil.delete(archiveFile);
 
-			if (_isDotGitDirArchiveRequired()) {
-				File dotGitDirArchiveFile = _archiveDotGitDir();
+			File dotGitDirArchiveFile = _archiveDotGitDir();
 
-				CloudBucketUtil.uploadS3File(
-					_getGitArchiveS3BucketPath(dotGitDirArchiveFile.getName()),
-					dotGitDirArchiveFile);
+			CloudBucketUtil.uploadS3File(
+				_getGitArchiveS3BucketPath(dotGitDirArchiveFile.getName()),
+				dotGitDirArchiveFile);
 
-				JenkinsResultsParserUtil.delete(dotGitDirArchiveFile);
-			}
+			JenkinsResultsParserUtil.delete(dotGitDirArchiveFile);
 		}
 
 		if (!jobName.contains("root-cause-analysis-tool")) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -1394,10 +1394,6 @@ public abstract class BaseWorkspaceGitRepository
 	}
 
 	private boolean _isDotGitDirArchiveRequired() {
-		if (!_snapshot) {
-			return true;
-		}
-
 		try {
 			return Boolean.parseBoolean(
 				JenkinsResultsParserUtil.getBuildProperty(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -568,69 +568,6 @@ public abstract class BaseWorkspaceGitRepository
 		validateKeys(_REQUIRED_KEYS);
 	}
 
-	protected void downloadGitArchive() throws IOException {
-		if (!JenkinsResultsParserUtil.isCloudCINode()) {
-			return;
-		}
-
-		String baseRepositoryDir = JenkinsResultsParserUtil.getBuildProperty(
-			"base.repository.dir");
-
-		File gitArchiveFile = new File(baseRepositoryDir, _getGitArchiveName());
-
-		CloudBucketUtil.downloadS3File(
-			gitArchiveFile, _getGitArchiveS3BucketPath());
-
-		File directory = getDirectory();
-
-		if (directory.exists()) {
-			_deleteGitRepository();
-		}
-
-		JenkinsResultsParserUtil.unzip(gitArchiveFile, directory);
-
-		JenkinsResultsParserUtil.delete(gitArchiveFile);
-
-		if (_isDotGitDirArchiveRequired()) {
-			File dotGitArchiveFile = new File(
-				baseRepositoryDir, _getDotGitArchiveName());
-
-			CloudBucketUtil.downloadS3File(
-				dotGitArchiveFile, _getDotGitArchiveS3BucketPath());
-
-			JenkinsResultsParserUtil.unzip(dotGitArchiveFile, directory);
-
-			JenkinsResultsParserUtil.delete(dotGitArchiveFile);
-
-			GitUtil.ExecutionResult executionResult =
-				GitUtil.executeBashCommands(
-					GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-					GitUtil.MILLIS_TIMEOUT, directory, "git reset");
-
-			if (executionResult.getExitValue() != 0) {
-				throw new RuntimeException(
-					JenkinsResultsParserUtil.combine(
-						"Unable to reset Git directory: " + directory,
-						executionResult.getStandardError()));
-			}
-
-			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
-
-			gitWorkingDirectory.checkoutLocalGitBranch(
-				gitWorkingDirectory.createLocalGitBranch(
-					getBranchName(), true, "HEAD"));
-
-			String upstreamBranchName = getUpstreamBranchName();
-
-			if (!gitWorkingDirectory.localGitBranchExists(upstreamBranchName)) {
-				gitWorkingDirectory.createLocalGitBranch(
-					upstreamBranchName, true, getBaseBranchSHA());
-			}
-
-			gitWorkingDirectory.displayLog();
-		}
-	}
-
 	protected synchronized LocalGitBranch getLocalGitBranch() {
 		if (_localGitBranch != null) {
 			return _localGitBranch;
@@ -712,59 +649,28 @@ public abstract class BaseWorkspaceGitRepository
 		return _propertyOptions;
 	}
 
-	protected boolean isGitArchiveEnabled() {
-		try {
-			return Boolean.parseBoolean(
-				JenkinsResultsParserUtil.getBuildProperty(
-					"git.archive.enabled", System.getenv("CI_TEST_SUITE"),
-					System.getenv("JOB_NAME")));
-		}
-		catch (IOException ioException) {
-			return true;
-		}
-	}
-
 	protected boolean isSetUp() {
 		return _setUp;
 	}
 
-	protected boolean isSnapshot() {
-		return _snapshot;
-	}
-
 	protected void prepareGitWorkingDirectory() throws IOException {
-		if (!isGitArchiveEnabled()) {
+		if (!_isGitArchiveEnabled()) {
 			_initializeGitWorkingDirectory();
 
 			return;
 		}
 
-		promoteGitArchive();
+		_promoteGitArchive();
 
-		if (isSnapshot()) {
-			downloadGitArchive();
+		if (_snapshot) {
+			_downloadGitArchive();
 
 			return;
 		}
 
 		_initializeGitWorkingDirectory();
 
-		uploadGitArchive();
-	}
-
-	protected void promoteGitArchive() throws IOException {
-		if (_snapshot) {
-			return;
-		}
-
-		if (_isGitArchiveAvailable() && _isDotGitArchiveAvailable()) {
-			CloudBucketUtil.touchS3File(_getGitArchiveS3BucketPath());
-			CloudBucketUtil.touchS3File(_getDotGitArchiveS3BucketPath());
-
-			_setSnapshot(true);
-
-			_updateBuildDatabase();
-		}
+		_uploadGitArchive();
 	}
 
 	protected void setSetUp(boolean setUp) {
@@ -772,40 +678,6 @@ public abstract class BaseWorkspaceGitRepository
 	}
 
 	protected void setUpAdditionalCaches() throws IOException {
-	}
-
-	protected void uploadGitArchive() throws IOException {
-		if (!JenkinsResultsParserUtil.isCloudCINode()) {
-			return;
-		}
-
-		String jobName = _getJobName();
-
-		if (!jobName.contains("-batch") && !jobName.contains("-downstream")) {
-			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
-
-			File archiveFile = gitWorkingDirectory.archive(
-				_getGitArchiveName());
-
-			CloudBucketUtil.uploadS3File(
-				_getGitArchiveS3BucketPath(), archiveFile);
-
-			JenkinsResultsParserUtil.delete(archiveFile);
-
-			File dotGitDirArchiveFile = _archiveDotGitDir();
-
-			CloudBucketUtil.uploadS3File(
-				_getGitArchiveS3BucketPath(dotGitDirArchiveFile.getName()),
-				dotGitDirArchiveFile);
-
-			JenkinsResultsParserUtil.delete(dotGitDirArchiveFile);
-		}
-
-		if (!jobName.contains("root-cause-analysis-tool")) {
-			_setSnapshot(true);
-		}
-
-		_updateBuildDatabase();
 	}
 
 	private File _archiveDotGitDir() {
@@ -1178,6 +1050,69 @@ public abstract class BaseWorkspaceGitRepository
 		}
 	}
 
+	private void _downloadGitArchive() throws IOException {
+		if (!JenkinsResultsParserUtil.isCloudCINode()) {
+			return;
+		}
+
+		String baseRepositoryDir = JenkinsResultsParserUtil.getBuildProperty(
+			"base.repository.dir");
+
+		File gitArchiveFile = new File(baseRepositoryDir, _getGitArchiveName());
+
+		CloudBucketUtil.downloadS3File(
+			gitArchiveFile, _getGitArchiveS3BucketPath());
+
+		File directory = getDirectory();
+
+		if (directory.exists()) {
+			_deleteGitRepository();
+		}
+
+		JenkinsResultsParserUtil.unzip(gitArchiveFile, directory);
+
+		JenkinsResultsParserUtil.delete(gitArchiveFile);
+
+		if (_isDotGitDirArchiveRequired()) {
+			File dotGitArchiveFile = new File(
+				baseRepositoryDir, _getDotGitArchiveName());
+
+			CloudBucketUtil.downloadS3File(
+				dotGitArchiveFile, _getDotGitArchiveS3BucketPath());
+
+			JenkinsResultsParserUtil.unzip(dotGitArchiveFile, directory);
+
+			JenkinsResultsParserUtil.delete(dotGitArchiveFile);
+
+			GitUtil.ExecutionResult executionResult =
+				GitUtil.executeBashCommands(
+					GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+					GitUtil.MILLIS_TIMEOUT, directory, "git reset");
+
+			if (executionResult.getExitValue() != 0) {
+				throw new RuntimeException(
+					JenkinsResultsParserUtil.combine(
+						"Unable to reset Git directory: " + directory,
+						executionResult.getStandardError()));
+			}
+
+			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+			gitWorkingDirectory.checkoutLocalGitBranch(
+				gitWorkingDirectory.createLocalGitBranch(
+					getBranchName(), true, "HEAD"));
+
+			String upstreamBranchName = getUpstreamBranchName();
+
+			if (!gitWorkingDirectory.localGitBranchExists(upstreamBranchName)) {
+				gitWorkingDirectory.createLocalGitBranch(
+					upstreamBranchName, true, getBaseBranchSHA());
+			}
+
+			gitWorkingDirectory.displayLog();
+		}
+	}
+
 	private void _downloadGitRepository() {
 		try {
 			File baseGitRepositoryDir =
@@ -1430,8 +1365,35 @@ public abstract class BaseWorkspaceGitRepository
 		return _isArchiveAvailable(_getGitArchiveS3BucketPath());
 	}
 
+	private boolean _isGitArchiveEnabled() {
+		try {
+			return Boolean.parseBoolean(
+				JenkinsResultsParserUtil.getBuildProperty(
+					"git.archive.enabled", System.getenv("CI_TEST_SUITE"),
+					System.getenv("JOB_NAME")));
+		}
+		catch (IOException ioException) {
+			return true;
+		}
+	}
+
 	private boolean _isPullRequest() {
 		return PullRequest.isValidGitHubPullRequestURL(getGitHubURL());
+	}
+
+	private void _promoteGitArchive() throws IOException {
+		if (_snapshot) {
+			return;
+		}
+
+		if (_isGitArchiveAvailable() && _isDotGitArchiveAvailable()) {
+			CloudBucketUtil.touchS3File(_getGitArchiveS3BucketPath());
+			CloudBucketUtil.touchS3File(_getDotGitArchiveS3BucketPath());
+
+			_setSnapshot(true);
+
+			_updateBuildDatabase();
+		}
 	}
 
 	private void _setBaseBranchHeadSHA(String branchSHA) {
@@ -1482,6 +1444,40 @@ public abstract class BaseWorkspaceGitRepository
 		BuildDatabase buildDatabase = BuildDatabaseUtil.getBuildDatabase();
 
 		buildDatabase.putWorkspaceGitRepository(getDirectoryName(), this);
+	}
+
+	private void _uploadGitArchive() throws IOException {
+		if (!JenkinsResultsParserUtil.isCloudCINode()) {
+			return;
+		}
+
+		String jobName = _getJobName();
+
+		if (!jobName.contains("-batch") && !jobName.contains("-downstream")) {
+			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+			File archiveFile = gitWorkingDirectory.archive(
+				_getGitArchiveName());
+
+			CloudBucketUtil.uploadS3File(
+				_getGitArchiveS3BucketPath(), archiveFile);
+
+			JenkinsResultsParserUtil.delete(archiveFile);
+
+			File dotGitDirArchiveFile = _archiveDotGitDir();
+
+			CloudBucketUtil.uploadS3File(
+				_getGitArchiveS3BucketPath(dotGitDirArchiveFile.getName()),
+				dotGitDirArchiveFile);
+
+			JenkinsResultsParserUtil.delete(dotGitDirArchiveFile);
+		}
+
+		if (!jobName.contains("root-cause-analysis-tool")) {
+			_setSnapshot(true);
+		}
+
+		_updateBuildDatabase();
 	}
 
 	private void _validateSHAInRemoteGitRef(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -1394,12 +1394,18 @@ public abstract class BaseWorkspaceGitRepository
 	}
 
 	private boolean _isDotGitDirArchiveRequired() {
+		String jobName = System.getenv("JOB_NAME");
+
+		if (JenkinsResultsParserUtil.isTopLevelJobName(jobName)) {
+			return true;
+		}
+
 		try {
 			return Boolean.parseBoolean(
 				JenkinsResultsParserUtil.getBuildProperty(
 					"git.archive.dot.git.dir.required", getDirectoryName(),
 					System.getenv("CI_TEST_SUITE"), System.getenv("DIST_TYPE"),
-					System.getenv("JOB_NAME")));
+					jobName));
 		}
 		catch (IOException ioException) {
 			return false;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -1348,16 +1348,6 @@ public abstract class BaseWorkspaceGitRepository
 		return "";
 	}
 
-	private String _getJobVariant() {
-		String jobVariant = System.getenv("JOB_VARIANT");
-
-		if (jobVariant != null) {
-			return jobVariant;
-		}
-
-		return "";
-	}
-
 	private String _getSenderBranchHeadName() {
 		return getSenderBranchName() + "__" + getSenderBranchSHAShort();
 	}
@@ -1419,58 +1409,20 @@ public abstract class BaseWorkspaceGitRepository
 	}
 
 	private boolean _isDotGitDirArchiveRequired() {
-		String directoryName = getDirectoryName();
+		if (!_snapshot) {
+			return true;
+		}
 
-		String jobVariant = _getJobVariant();
-
-		if (directoryName.contains("liferay-plugins")) {
-			if (!_snapshot || jobVariant.startsWith("plugins-compile")) {
-				return true;
-			}
-
+		try {
+			return Boolean.parseBoolean(
+				JenkinsResultsParserUtil.getBuildProperty(
+					"git.archive.dot.git.dir.required", getDirectoryName(),
+					System.getenv("DIST_TYPE"), System.getenv("JOB_NAME"),
+					System.getenv("CI_TEST_SUITE")));
+		}
+		catch (IOException ioException) {
 			return false;
 		}
-
-		if (directoryName.contains("liferay-portal")) {
-			if (!_snapshot) {
-				return true;
-			}
-
-			String jobName = _getJobName();
-
-			if (JenkinsResultsParserUtil.isTopLevelJobName(jobName) ||
-				jobName.equals("app-server-bundle-builder") ||
-				jobName.equals("forward-pullrequest") ||
-				jobName.equals("publish-testray-report") ||
-				jobName.equals("test-portal-source-format") ||
-				jobName.contains("validation") ||
-				jobVariant.contains("modules-unit") ||
-				jobVariant.contains("plugins-compile") ||
-				jobVariant.contains("rest-builder") ||
-				jobVariant.contains("service-builder")) {
-
-				return true;
-			}
-		}
-
-		if (directoryName.equals("liferay-release-tool-ee")) {
-			if (!_snapshot ||
-				(!JenkinsResultsParserUtil.isNullOrEmpty(jobVariant) &&
-				 jobVariant.startsWith("portal-license"))) {
-
-				return true;
-			}
-
-			String distType = System.getenv("DIST_TYPE");
-
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(distType) &&
-				"release".equalsIgnoreCase(distType)) {
-
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private boolean _isFullDotGitDirArchiveRequired() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -400,24 +400,8 @@ public abstract class BaseWorkspaceGitRepository
 
 		System.out.println(toString());
 
-		boolean gitArchiveEnabled = isGitArchiveEnabled();
-
 		try {
-			if (gitArchiveEnabled) {
-				promoteGitArchive();
-
-				if (isSnapshot()) {
-					downloadGitArchive();
-				}
-			}
-
-			if (!isSnapshot()) {
-				prepareGitWorkingDirectory();
-
-				if (gitArchiveEnabled) {
-					uploadGitArchive();
-				}
-			}
+			prepareGitWorkingDirectory();
 
 			setUpAdditionalCaches();
 		}
@@ -748,53 +732,24 @@ public abstract class BaseWorkspaceGitRepository
 		return _snapshot;
 	}
 
-	protected void prepareGitWorkingDirectory() {
-		File dotGitFolder = new File(getDirectory(), ".git");
+	protected void prepareGitWorkingDirectory() throws IOException {
+		if (!isGitArchiveEnabled()) {
+			_initializeGitWorkingDirectory();
 
-		if (JenkinsResultsParserUtil.isCloudCINode() &&
-			!dotGitFolder.exists()) {
-
-			_downloadGitRepository();
-
-			_fetchCommitFileSHA();
+			return;
 		}
 
-		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+		promoteGitArchive();
 
-		if (_rebase) {
-			gitWorkingDirectory.createLocalGitBranch(
-				getUpstreamBranchName(), true, getBaseBranchSHA());
+		if (isSnapshot()) {
+			downloadGitArchive();
+
+			return;
 		}
 
-		LocalGitBranch localGitBranch = getLocalGitBranch();
+		_initializeGitWorkingDirectory();
 
-		gitWorkingDirectory.checkoutLocalGitBranch(localGitBranch);
-
-		LocalGitBranch baseLocalGitBranch =
-			gitWorkingDirectory.createLocalGitBranch(
-				getUpstreamBranchName(), true, getBaseBranchSHA());
-
-		if (_rebase) {
-			gitWorkingDirectory.rebase(
-				true, baseLocalGitBranch, localGitBranch);
-		}
-
-		gitWorkingDirectory.reset("--hard " + localGitBranch.getSHA());
-
-		if ((_patchSHAs != null) && !_patchSHAs.isEmpty()) {
-			for (String patchSHA : _patchSHAs) {
-				try {
-					gitWorkingDirectory.cherryPick(patchSHA.trim());
-				}
-				catch (Exception exception) {
-					gitWorkingDirectory.reset("--hard");
-				}
-			}
-		}
-
-		gitWorkingDirectory.clean();
-
-		gitWorkingDirectory.displayLog();
+		uploadGitArchive();
 	}
 
 	protected void promoteGitArchive() throws IOException {
@@ -1370,6 +1325,55 @@ public abstract class BaseWorkspaceGitRepository
 				"/", name, "/tree/", upstreamBranchName));
 
 		return _upstreamRemoteGitRef;
+	}
+
+	private void _initializeGitWorkingDirectory() {
+		File dotGitFolder = new File(getDirectory(), ".git");
+
+		if (JenkinsResultsParserUtil.isCloudCINode() &&
+			!dotGitFolder.exists()) {
+
+			_downloadGitRepository();
+
+			_fetchCommitFileSHA();
+		}
+
+		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+		if (_rebase) {
+			gitWorkingDirectory.createLocalGitBranch(
+				getUpstreamBranchName(), true, getBaseBranchSHA());
+		}
+
+		LocalGitBranch localGitBranch = getLocalGitBranch();
+
+		gitWorkingDirectory.checkoutLocalGitBranch(localGitBranch);
+
+		LocalGitBranch baseLocalGitBranch =
+			gitWorkingDirectory.createLocalGitBranch(
+				getUpstreamBranchName(), true, getBaseBranchSHA());
+
+		if (_rebase) {
+			gitWorkingDirectory.rebase(
+				true, baseLocalGitBranch, localGitBranch);
+		}
+
+		gitWorkingDirectory.reset("--hard " + localGitBranch.getSHA());
+
+		if ((_patchSHAs != null) && !_patchSHAs.isEmpty()) {
+			for (String patchSHA : _patchSHAs) {
+				try {
+					gitWorkingDirectory.cherryPick(patchSHA.trim());
+				}
+				catch (Exception exception) {
+					gitWorkingDirectory.reset("--hard");
+				}
+			}
+		}
+
+		gitWorkingDirectory.clean();
+
+		gitWorkingDirectory.displayLog();
 	}
 
 	private boolean _isArchiveAvailable(String s3Path) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -697,8 +697,8 @@ public abstract class BaseWorkspaceGitRepository
 		try {
 			return Boolean.parseBoolean(
 				JenkinsResultsParserUtil.getBuildProperty(
-					"git.archive.enabled", System.getenv("JOB_NAME"),
-					System.getenv("CI_TEST_SUITE")));
+					"git.archive.enabled", System.getenv("CI_TEST_SUITE"),
+					System.getenv("JOB_NAME")));
 		}
 		catch (IOException ioException) {
 			return true;
@@ -1417,8 +1417,8 @@ public abstract class BaseWorkspaceGitRepository
 			return Boolean.parseBoolean(
 				JenkinsResultsParserUtil.getBuildProperty(
 					"git.archive.dot.git.dir.required", getDirectoryName(),
-					System.getenv("DIST_TYPE"), System.getenv("JOB_NAME"),
-					System.getenv("CI_TEST_SUITE")));
+					System.getenv("CI_TEST_SUITE"), System.getenv("DIST_TYPE"),
+					System.getenv("JOB_NAME")));
 		}
 		catch (IOException ioException) {
 			return false;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -400,25 +400,26 @@ public abstract class BaseWorkspaceGitRepository
 
 		System.out.println(toString());
 
-		try {
-			if (JenkinsResultsParserUtil.isBuildCachingEnabled(
-					System.getenv("JOB_NAME"),
-					System.getenv("CI_TEST_SUITE"))) {
+		boolean gitArchiveEnabled = isGitArchiveEnabled();
 
+		try {
+			if (gitArchiveEnabled) {
 				checkAvailableGitArchive();
+
+				if (isSnapshot()) {
+					useGitArchive();
+				}
 			}
 
 			if (!isSnapshot()) {
 				prepareGitWorkingDirectory();
 
-				prepareGitArchive();
-
-				setSetUp(true);
+				if (gitArchiveEnabled) {
+					prepareGitArchive();
+				}
 			}
 
-			if (!isSetUp() && isSnapshot()) {
-				useGitArchive();
-			}
+			setUpAdditionalCaches();
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
@@ -692,6 +693,18 @@ public abstract class BaseWorkspaceGitRepository
 		return _propertyOptions;
 	}
 
+	protected boolean isGitArchiveEnabled() {
+		try {
+			return Boolean.parseBoolean(
+				JenkinsResultsParserUtil.getBuildProperty(
+					"git.archive.enabled", System.getenv("JOB_NAME"),
+					System.getenv("CI_TEST_SUITE")));
+		}
+		catch (IOException ioException) {
+			return true;
+		}
+	}
+
 	protected boolean isSetUp() {
 		return _setUp;
 	}
@@ -787,6 +800,9 @@ public abstract class BaseWorkspaceGitRepository
 
 	protected void setSetUp(boolean setUp) {
 		_setUp = setUp;
+	}
+
+	protected void setUpAdditionalCaches() throws IOException {
 	}
 
 	protected void useGitArchive() throws IOException {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -131,48 +131,6 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			"liferay-portal-ee", getUpstreamBranchName() + "-private");
 	}
 
-	@Override
-	public synchronized void setUp() {
-		if (isSetUp()) {
-			return;
-		}
-
-		System.out.println(toString());
-
-		try {
-			boolean buildCachingEnabled =
-				JenkinsResultsParserUtil.isBuildCachingEnabled(
-					System.getenv("JOB_NAME"), System.getenv("CI_TEST_SUITE"));
-
-			if (buildCachingEnabled) {
-				checkAvailableGitArchive();
-			}
-
-			if (!isSnapshot()) {
-				prepareGitWorkingDirectory();
-
-				if (buildCachingEnabled) {
-					_setUpBinariesCache();
-
-					prepareGitArchive();
-				}
-
-				setSetUp(true);
-			}
-
-			if (!isSetUp() && isSnapshot()) {
-				useGitArchive();
-
-				_setUpBinariesCache();
-			}
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		setSetUp(true);
-	}
-
 	public void setUpPortalProfile() {
 		String upstreamBranchName = getUpstreamBranchName();
 
@@ -254,6 +212,25 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		propertyOptions.add(getUpstreamBranchName());
 
 		return propertyOptions;
+	}
+
+	protected boolean isBinariesCacheEnabled() {
+		try {
+			return Boolean.parseBoolean(
+				JenkinsResultsParserUtil.getBuildProperty(
+					"binaries.cache.enabled", System.getenv("JOB_NAME"),
+					System.getenv("CI_TEST_SUITE")));
+		}
+		catch (IOException ioException) {
+			return true;
+		}
+	}
+
+	@Override
+	protected void setUpAdditionalCaches() throws IOException {
+		if (isBinariesCacheEnabled()) {
+			_setUpBinariesCache();
+		}
 	}
 
 	private String _getLiferayFacesURL(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -218,8 +218,8 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		try {
 			return Boolean.parseBoolean(
 				JenkinsResultsParserUtil.getBuildProperty(
-					"binaries.cache.enabled", System.getenv("JOB_NAME"),
-					System.getenv("CI_TEST_SUITE")));
+					"binaries.cache.enabled", System.getenv("CI_TEST_SUITE"),
+					System.getenv("JOB_NAME")));
 		}
 		catch (IOException ioException) {
 			return true;


### PR DESCRIPTION
## Summary

- Decouples git archive and binaries cache from `build.caching.enabled`. Each is now controlled by its own property: `git.archive.enabled` and `binaries.cache.enabled`.
- Migrates `_isDotGitDirArchiveRequired` from hardcoded directory/job/variant logic to a property `git.archive.dot.git.dir.required` keyed by `(directory, CI_TEST_SUITE, DIST_TYPE, JOB_NAME)`.
- Simplifies `checkAvailableGitArchive` and `prepareGitArchive` (drops dead code that became unreachable after the migration; top-level builds always git clone, so the .git is always present).
- Companion property entries on liferay-jenkins-ee.

## Ticket

https://liferay.atlassian.net/browse/LRCI-7447