### PR TITLE
LRCI-7366 Make yarn install args configurable via Gradle properties

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -458,8 +458,6 @@
 
     #gradle.update.file.versions.excludes=**/gradle-plugins-target-platform/,**/gradle-plugins-workspace/
 
-    #gradle.yarn.install.network.timeout=120000
-
     org.gradle.caching=true
     org.gradle.console=plain
     org.gradle.daemon=true
@@ -617,6 +615,15 @@
     #
     nodejs.npm.registry=
     #nodejs.npm.registry=https://registry.npm.taobao.org
+
+    nodejs.yarn.install.args=
+    #nodejs.yarn.install.args=install --offline --ignore-engines --network-timeout 120000 --frozen-lockfile
+
+    nodejs.yarn.install.frozen.lockfile=true
+
+    #nodejs.yarn.install.network.timeout=120000
+
+    nodejs.yarn.install.prefer.offline=true
 
     #
     # Add the --offline flag for Yarn commands.

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -208,18 +208,6 @@ portalYarnInstall {
 	dependsOn ":yarnInstall"
 }
 
-gradle.allprojects {
-	Project project ->
-
-	String gradleYarnInstallNetworkTimeout = GradleUtil.getProperty(project, "gradle.yarn.install.network.timeout", (String)null)
-
-	if (gradleYarnInstallNetworkTimeout) {
-		tasks.withType(com.liferay.gradle.plugins.node.task.YarnInstallTask) {
-			networkTimeout = Long.parseLong(gradleYarnInstallNetworkTimeout)
-		}
-	}
-}
-
 gradle.beforeProject {
 	Project project ->
 

--- a/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/YarnPlugin.java
+++ b/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/YarnPlugin.java
@@ -48,9 +48,9 @@ public class YarnPlugin implements Plugin<Project> {
 					yarnInstallTask.setDescription(
 						"Installs Node packages from package.json.");
 					yarnInstallTask.setFrozenLockFile(
-						Boolean.parseBoolean(
-							System.getProperty(
-								"frozen.lockfile", Boolean.TRUE.toString())));
+						GradleUtil.getProperty(
+							yarnInstallTask.getProject(),
+							"nodejs.yarn.install.frozen.lockfile", true));
 				}
 
 			});

--- a/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
+++ b/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
@@ -41,6 +41,9 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 		if (Validator.isNotNull(networkTimeout)) {
 			_networkTimeout = Long.parseLong(networkTimeout);
 		}
+
+		_preferOffline = GradleUtil.getProperty(
+			getProject(), "nodejs.yarn.install.prefer.offline", true);
 	}
 
 	@Override
@@ -70,6 +73,11 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 		return GradleUtil.toBoolean(_frozenLockFile);
 	}
 
+	@Input
+	public boolean isPreferOffline() {
+		return _preferOffline;
+	}
+
 	public void setFrozenLockFile(Object frozenLockFile) {
 		_frozenLockFile = frozenLockFile;
 	}
@@ -88,6 +96,10 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 
 	public void setNetworkTimeout(long networkTimeout) {
 		_networkTimeout = networkTimeout;
+	}
+
+	public void setPreferOffline(boolean preferOffline) {
+		_preferOffline = preferOffline;
 	}
 
 	@Internal
@@ -118,7 +130,9 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 			completeArgs.add(String.valueOf(networkTimeout));
 		}
 
-		completeArgs.add("--prefer-offline");
+		if (isPreferOffline()) {
+			completeArgs.add("--prefer-offline");
+		}
 
 		return completeArgs;
 	}
@@ -140,5 +154,6 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 	private Object _frozenLockFile;
 	private final List<Object> _installArgs = new ArrayList<>();
 	private long _networkTimeout = 120000;
+	private boolean _preferOffline;
 
 }

--- a/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
+++ b/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
@@ -7,20 +7,34 @@ package com.liferay.gradle.plugins.node.task;
 
 import com.liferay.gradle.plugins.node.internal.util.FileUtil;
 import com.liferay.gradle.plugins.node.internal.util.GradleUtil;
+import com.liferay.gradle.util.Validator;
 
 import java.io.File;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
 
 /**
  * @author Peter Shin
  * @author David Truong
  */
 public class YarnInstallTask extends ExecutePackageManagerTask {
+
+	public YarnInstallTask() {
+		String installArgs = GradleUtil.getProperty(
+			getProject(), "nodejs.yarn.install.args", "");
+
+		if (Validator.isNotNull(installArgs)) {
+			installArgs = installArgs.trim();
+
+			setInstallArgs(installArgs.split("\\s+"));
+		}
+	}
 
 	@Override
 	public synchronized void executeNode() throws Exception {
@@ -31,6 +45,12 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 		}
 
 		super.executeNode();
+	}
+
+	@Input
+	@Optional
+	public List<String> getInstallArgs() {
+		return GradleUtil.toStringList(_installArgs);
 	}
 
 	@Input
@@ -47,6 +67,18 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 		_frozenLockFile = frozenLockFile;
 	}
 
+	public void setInstallArgs(Iterable<?> installArgs) {
+		_installArgs.clear();
+
+		for (Object installArg : installArgs) {
+			_installArgs.add(installArg);
+		}
+	}
+
+	public void setInstallArgs(Object... installArgs) {
+		setInstallArgs(Arrays.asList(installArgs));
+	}
+
 	public void setNetworkTimeout(long networkTimeout) {
 		_networkTimeout = networkTimeout;
 	}
@@ -55,6 +87,14 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 	@Override
 	protected List<String> getCompleteArgs() {
 		List<String> completeArgs = super.getCompleteArgs();
+
+		List<String> installArgs = getInstallArgs();
+
+		if (!installArgs.isEmpty()) {
+			completeArgs.addAll(installArgs);
+
+			return completeArgs;
+		}
 
 		completeArgs.add("install");
 
@@ -91,6 +131,7 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 	}
 
 	private Object _frozenLockFile;
+	private final List<Object> _installArgs = new ArrayList<>();
 	private long _networkTimeout = 120000;
 
 }

--- a/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
+++ b/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
@@ -34,6 +34,13 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 
 			setInstallArgs(installArgs.split("\\s+"));
 		}
+
+		String networkTimeout = GradleUtil.getProperty(
+			getProject(), "nodejs.yarn.install.network.timeout", (String)null);
+
+		if (Validator.isNotNull(networkTimeout)) {
+			_networkTimeout = Long.parseLong(networkTimeout);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

- Adds `nodejs.yarn.install.args` as a full-override property on `YarnInstallTask` — when set, replaces the entire post-`super` args list. Read in the constructor via `GradleUtil.getProperty`.
- Migrates `frozen.lockfile` (read via `System.getProperty` in `YarnPlugin`) to `nodejs.yarn.install.frozen.lockfile` (read via `GradleUtil.getProperty`). Default `true` — same as today.
- Renames `gradle.yarn.install.network.timeout` → `nodejs.yarn.install.network.timeout` in `modules/build.gradle` and `build.properties` docs. Single unified `nodejs.*` family.
- Promotes the hardcoded `--prefer-offline` flag to its own property `nodejs.yarn.install.prefer.offline`. Default `true` — same as today.

Zero behavior change for any caller today. All defaults match current values; the new properties are escape hatches for CI to override per branch / repo / job via `liferay-jenkins-ee`'s `portal.build.properties[<key>]` mechanism.

Ticket: https://liferay.atlassian.net/browse/LRCI-7366