### PR TITLE
LRCI-7489 Add JOB_VARIANT to git.archive.dot.git.dir.required lookup

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -1344,7 +1344,7 @@ public abstract class BaseWorkspaceGitRepository
 				JenkinsResultsParserUtil.getBuildProperty(
 					"git.archive.dot.git.dir.required", getDirectoryName(),
 					System.getenv("CI_TEST_SUITE"), System.getenv("DIST_TYPE"),
-					jobName));
+					jobName, System.getenv("JOB_VARIANT")));
 		}
 		catch (IOException ioException) {
 			return false;


### PR DESCRIPTION
## Summary

The original `_isDotGitDirArchiveRequired` logic branched on both `JOB_NAME` and `JOB_VARIANT`. The LRCI-7447 property migration kept `JOB_NAME` in the lookup but omitted `JOB_VARIANT`, so entries keyed off variant patterns (`*modules-unit*`, `plugins-compile*`, `*rest-builder*`, `*service-builder*`, `*portal-license*`) never match and downstream batches lose the `.git` dir requirement.

## Ticket

https://liferay.atlassian.net/browse/LRCI-7489