### PR TITLE
LRCI-7499 Move line-separator anchor out of shared frontend regex property

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -778,7 +778,7 @@
 ## Source Formatter
 ##
 
-    source.formatter.frontend.file.regex=\\.(js|json|jsp|jspf|scss|ts|tsx)(${line.separator}|$)
+    source.formatter.frontend.file.regex=\\.(js|json|jsp|jspf|scss|ts|tsx)(\\R|$)
     source.formatter.include.subrepositories=false
     source.formatter.max.line.length=80
     source.formatter.processor.thread.count=5


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7499

## Summary

Fixes the `Invalid property key: |$)` warnings on every `ant all` / `ant compile` since LRCI-7433 landed.

## Mechanism

Ant's `<property file>` interpolates `${line.separator}` to a literal newline at property-load time. `update-gradle-properties` then writes the table to `.gradle/gradle.properties` via `<echoproperties>`, escaping the newline as `\n`. Bnd reloads the file with `Properties.load`, which unescapes `\n` back to a real newline and splits the value across two records — the trailing `|$)` becomes a malformed key.

## Fix

Use `\R` instead of `${line.separator}` so the value stays a single line through the pipeline. `\R` matches any Unicode line break, so the regex behaves identically on Linux, macOS, and Windows.

Existing checkouts keep emitting the warnings until `.gradle/gradle.properties` is regenerated (`git clean -xdf` + ant build, `ant setup-profile-portal`, or deleting the cache by hand).