### PR TITLE
LRCI-7490 Remove lazy redact-token initialization

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -134,10 +134,6 @@ public class JenkinsResultsParserUtil {
 	public static boolean debug;
 
 	public static void addRedactToken(String token) {
-		if (_redactTokens.isEmpty()) {
-			_initializeRedactTokens();
-		}
-
 		if (_forbiddenRedactTokens.contains(token)) {
 			return;
 		}
@@ -4840,12 +4836,6 @@ public class JenkinsResultsParserUtil {
 	public static String redact(String string) {
 		if (isNullOrEmpty(string)) {
 			return string;
-		}
-
-		if (_redactTokens.isEmpty()) {
-			synchronized (_redactTokens) {
-				_initializeRedactTokens();
-			}
 		}
 
 		synchronized (_redactTokens) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7490

## What is being fixed

`JenkinsResultsParserUtil` fails to load with
`NoClassDefFoundError: Could not initialize class` whenever
`_getCacheURL()` returns null (e.g. a portal-CE developer without a
sibling `liferay-jenkins-ee` checkout). Self-regression from LRCI-7448.

The static initializer installs `SecurePrintStream`, then prints
`"Securing standard error and out"`. The print flows through
`redact()` → `if (_redactTokens.isEmpty()) _initializeRedactTokens()`
→ `getBuildProperties()` → prints the LRCI-7448 warning → back
through `redact()`. The cycle never advances because `_redactTokens`
stays empty. `StackOverflowError` bubbles out wrapped as
`ExceptionInInitializerError`.

## How it is being fixed

`_initializeRedactTokens()` is already invoked once from the static
block, before `SecurePrintStream` is installed. The lazy retry in
`redact()` and `addRedactToken()` had nothing to recover — its inputs
(env vars, filesystem, `isCINode()`) do not change at runtime — and
it was the only edge closing the recursion. Delete it.

Verified by reverting the fix and running
`CACHE_DIR=/tmp/lrci-7490-no-jrp gradlew test --tests JenkinsResultsParserUtilTest`
— 12 / 12 fail with the cycle above; with the fix, 12 / 12 pass.

cc: @pyoo47