### PR TITLE
LRCI-7506 Restore binaries cache before publishing git archive

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -1455,7 +1455,7 @@ public abstract class BaseWorkspaceGitRepository
 
 		String jobName = _getJobName();
 
-		if (!jobName.contains("-batch") && !jobName.contains("-downstream")) {
+		if (JenkinsResultsParserUtil.isTopLevelJobName(jobName)) {
 			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
 
 			File archiveFile = gitWorkingDirectory.archive(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -404,6 +404,8 @@ public abstract class BaseWorkspaceGitRepository
 			prepareGitWorkingDirectory();
 
 			setUpAdditionalCaches();
+
+			_uploadGitArchive();
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
@@ -669,8 +671,6 @@ public abstract class BaseWorkspaceGitRepository
 		}
 
 		_initializeGitWorkingDirectory();
-
-		_uploadGitArchive();
 	}
 
 	protected void setSetUp(boolean setUp) {
@@ -1447,7 +1447,9 @@ public abstract class BaseWorkspaceGitRepository
 	}
 
 	private void _uploadGitArchive() throws IOException {
-		if (!JenkinsResultsParserUtil.isCloudCINode()) {
+		if (!_isGitArchiveEnabled() || _snapshot ||
+			!JenkinsResultsParserUtil.isCloudCINode()) {
+
 			return;
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7506

**What is being fixed:** LRCI-7447 inlined `_uploadGitArchive` at the end of `prepareGitWorkingDirectory`'s non-snapshot path. The upload step does more than push to S3 — via `PortalGitWorkingDirectory.archive()` it also runs `setup-sdk` + `setup-yarn` to bake `node_modules` into the archive. That work depends on the S3 binaries cache being on disk, but `setUpAdditionalCaches` (the binaries cache restore) ran after `prepareGitWorkingDirectory`. So `setup-yarn` was hitting Verdaccio over the network instead of the offline mirror, taking 6+ minutes and flaking when Verdaccio glitched (most recently observed on `release-2026.q1` as missing CKEditor 46.0.3 packages during yarn install).

**How it is being fixed:** Move the `_uploadGitArchive()` call out of `prepareGitWorkingDirectory` and into `setUp()`, ordered after `setUpAdditionalCaches()`. The new order matches pre-LRCI-7447: clone → binaries cache restore → archive (with setup-yarn) → upload. The snapshot path is unchanged.

A follow-up commit replaces the `!jobName.contains("-batch") && !jobName.contains("-downstream")` predicate with `JenkinsResultsParserUtil.isTopLevelJobName(jobName)`, matching the canonical predicate already used in `_isDotGitDirArchiveRequired`.