### PR TITLE
LRCI-7575 Add Environment seam for System.getenv injection

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultEnvironment.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultEnvironment.java
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+/**
+ * @author Calum Ragan
+ */
+public class DefaultEnvironment implements Environment {
+
+	@Override
+	public String get(String name) {
+		return System.getenv(name);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Environment.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Environment.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+/**
+ * @author Calum Ragan
+ */
+public interface Environment {
+
+	public String get(String name);
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1929,7 +1929,7 @@ public class JenkinsResultsParserUtil {
 	public static String getEnvironmentVariable(
 		String environmentVariableName) {
 
-		String environmentVariableValue = System.getenv(
+		String environmentVariableValue = _environment.get(
 			environmentVariableName);
 
 		if ((environmentVariableValue == null) ||
@@ -4995,6 +4995,10 @@ public class JenkinsResultsParserUtil {
 		_buildPropertiesURLs = urls;
 	}
 
+	public static void setEnvironment(Environment environment) {
+		_environment = environment;
+	}
+
 	public static void sleep(long duration) {
 		try {
 			Thread.sleep(duration);
@@ -7421,6 +7425,7 @@ public class JenkinsResultsParserUtil {
 		"(?<ecrDockerImageName>((?<repository>[^/\\s]+)/)?" +
 			"(?<name>[^/:\\s]+)(:(?<version>[^@:\\s]+))?)" +
 				"(@sha256:[^\\s]+)?");
+	private static Environment _environment = new DefaultEnvironment();
 	private static final List<String> _forbiddenRedactTokens = Arrays.asList(
 		"admin", "liferay", "test");
 	private static JSONArray _gitDirectoriesJSONArray;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -7425,7 +7425,7 @@ public class JenkinsResultsParserUtil {
 		"(?<ecrDockerImageName>((?<repository>[^/\\s]+)/)?" +
 			"(?<name>[^/:\\s]+)(:(?<version>[^@:\\s]+))?)" +
 				"(@sha256:[^\\s]+)?");
-	private static Environment _environment = new DefaultEnvironment();
+	private static volatile Environment _environment = new DefaultEnvironment();
 	private static final List<String> _forbiddenRedactTokens = Arrays.asList(
 		"admin", "liferay", "test");
 	private static JSONArray _gitDirectoriesJSONArray;

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -18,6 +18,8 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.mockito.Mockito;
+
 /**
  * @author Peter Yoo
  */
@@ -84,6 +86,37 @@ public class JenkinsResultsParserUtilTest
 			_fixURLMultipleTimes(
 				"https://test-1-1.liferay.com/job(master)?" +
 					"AXIS_VARIABLE=0 1&label_exp=!master&job=test(7.2.x)"));
+	}
+
+	@Test
+	public void testGetEnvironmentVariable() {
+		Environment environment = mockEnvironment();
+
+		Mockito.when(
+			environment.get("JENKINS_URL")
+		).thenReturn(
+			"https://test-1-1"
+		);
+
+		testEquals(
+			"https://test-1-1",
+			JenkinsResultsParserUtil.getEnvironmentVariable("JENKINS_URL"));
+	}
+
+	@Test
+	public void testGetEnvironmentVariableWithMissingVariable() {
+		mockEnvironment();
+
+		try {
+			JenkinsResultsParserUtil.getEnvironmentVariable(
+				"MISSING_ENVIRONMENT_VARIABLE");
+
+			errorCollector.addError(
+				new Throwable(
+					"A missing environment variable should throw an exception"));
+		}
+		catch (RuntimeException runtimeException) {
+		}
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -113,9 +113,14 @@ public class JenkinsResultsParserUtilTest
 
 			errorCollector.addError(
 				new Throwable(
-					"A missing environment variable should throw an exception"));
+					"A missing environment variable should throw an " +
+						"exception"));
 		}
 		catch (RuntimeException runtimeException) {
+			testEquals(
+				"Unable to find required environment variable " +
+					"'MISSING_ENVIRONMENT_VARIABLE'",
+				runtimeException.getMessage());
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -24,9 +24,12 @@ import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.io.SAXReader;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ErrorCollector;
+
+import org.mockito.Mockito;
 
 /**
  * @author Peter Yoo
@@ -36,6 +39,11 @@ public class Test {
 	@Before
 	public void setUp() throws Exception {
 		JenkinsResultsParserUtil.clearCache();
+	}
+
+	@After
+	public void tearDown() {
+		JenkinsResultsParserUtil.setEnvironment(new DefaultEnvironment());
 	}
 
 	@Rule
@@ -286,6 +294,14 @@ public class Test {
 		}
 
 		return _simpleClassNames;
+	}
+
+	protected Environment mockEnvironment() {
+		Environment environment = Mockito.mock(Environment.class);
+
+		JenkinsResultsParserUtil.setEnvironment(environment);
+
+		return environment;
 	}
 
 	protected String read(File file) throws IOException {


### PR DESCRIPTION
## Summary

- Adds an `Environment` interface and `DefaultEnvironment` (wraps `System.getenv`) so `jenkins-results-parser` unit tests can inject fixed environment values instead of reading the host's real environment.
- `JenkinsResultsParserUtil.getEnvironmentVariable(...)` now routes through a swappable instance; `setEnvironment(...)` lets tests install a mock. Production behavior is unchanged (defaults to `DefaultEnvironment`); the seam covers only that one method, leaving the other direct `System.getenv` sites untouched.
- The `Test` base class gains a `mockEnvironment()` helper and a `tearDown()` that restores the default after every test.

Part of LRCI-6664 (Initiative 2) — a minimal proof-of-concept seam before the larger seams planned in Initiative 3.

## Notes For Review

- `setEnvironment` is `public` because Liferay checkstyle (`MissingModifierCheck`) forbids package-private methods; this adds one method to the exported `com.liferay.jenkins.results.parser` API.
- Strict-stubs Mockito was intentionally dropped — the module's Mockito 4.5.1 predates the `withSettings().strictness()` API (added in 4.6.0).

## Test Plan

- [x] `gradlew test --tests JenkinsResultsParserUtilTest` — all 14 pass, including `testGetEnvironmentVariable` (injected `JENKINS_URL` asserted regardless of host) and `testGetEnvironmentVariableWithMissingVariable` (missing variable throws).
- [x] `gradlew jar` builds.
- [x] `gradlew formatSource` clean.