### PR TITLE
LRCI-7584 Gate Structural Smoke to skip tooling-only diffs

### DIFF
--- a/.claude/skills/pr-check/validations/structural-smoke.md
+++ b/.claude/skills/pr-check/validations/structural-smoke.md
@@ -2,11 +2,11 @@
 
 ## Trigger
 
-Always, except when the entire diff is documentation or language properties (`*.md`, `Language*.properties`) — the smoke baseline does not exercise documentation.
+Always, except when every diff path matches `*.md`, `.claude/**`, `.editorconfig`, `.gitattributes`, `.github/**`, `.gitignore`, `.project`, `Language*.properties`, `cloud/**`, or `workspaces/**` — no smoke assertion reads these paths, so a failure would only signal baseline drift in the checkout.
 
 ## Match
 
-`!\.md$|/Language(_[a-zA-Z_]+)?\.properties$`
+`!\.md$|^\.(claude/|editorconfig$|gitattributes$|github/|gitignore$|project$)|/Language(_[a-zA-Z_]+)?\.properties$|^(cloud|workspaces)/`
 
 ## Command
 


### PR DESCRIPTION
[LRCI-7584](https://liferay.atlassian.net/browse/LRCI-7584)

## Summary

- The Structural Smoke validation in the `pr-check` skill previously fired on any non-doc, non-language-properties diff, running its fixed five-class set against the working tree regardless of whether the diff could affect any assertion those tests make.
- For diffs confined to repo-level tooling — `.claude/**`, `.github/**`, `cloud/**`, `workspaces/**`, or top-level dotfiles (`.editorconfig`, `.gitattributes`, `.gitignore`, `.project`) — the outcome was determined entirely by local baseline drift in the developer's checkout, producing a guaranteed false fail. Reported by Alejandro on LPD-92314.
- Extend the exclusion regex to skip those tooling paths while keeping `.classpath` in scope since `LibraryReferenceTest` reads it.