### PR TITLE
LRCI-7603 Reorganize prepare-portal-ext-properties into phase-grouped macrodefs

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3731,6 +3731,121 @@ dl.store.antivirus.enabled=true</echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="prepare-portal-ext-properties-overrides">
+		<sequential>
+			<get-testcase-property property.name="database.jndi.enabled" />
+
+			<if>
+				<equals arg1="${database.jndi.enabled}" arg2="true" />
+				<then>
+					<replace
+						file="portal-impl/src/portal-ext.properties"
+					>
+						<replacetoken>jdbc.default.jndi.name=</replacetoken>
+						<replacevalue>jdbc.default.jndi.name=jdbc/LiferayPool</replacevalue>
+					</replace>
+				</then>
+			</if>
+
+			<if>
+				<equals arg1="${database.type}" arg2="oracle" />
+				<then>
+					<if>
+						<equals arg1="${database.version}" arg2="11.2.0.1.0" />
+						<then>
+							<property name="oracle.instance.name" value="xe" />
+						</then>
+						<elseif>
+							<and>
+								<equals arg1="${database.version}" arg2="12.2.0.1" />
+								<os family="windows" />
+							</and>
+							<then>
+								<property name="oracle.instance.name" value="orcl" />
+							</then>
+						</elseif>
+						<else>
+							<property name="oracle.instance.name" value="oracl" />
+						</else>
+					</if>
+
+					<replaceregexp
+						file="portal-impl/src/portal-ext.properties"
+						match="(jdbc:oracle:.*)oracl"
+						replace="\1${oracle.instance.name}"
+					/>
+				</then>
+			</if>
+
+			<if>
+				<isset property="set.permission.algorithm.5" />
+				<then>
+					<replace
+						file="portal-impl/src/portal-ext.properties"
+						token="#permissions.user.check.algorithm=5"
+						value="permissions.user.check.algorithm=5"
+					/>
+					<replace
+						file="portal-impl/src/portal-ext.properties"
+						token="#permissions.view.dynamic.inheritance=false"
+						value="permissions.view.dynamic.inheritance=false"
+					/>
+				</then>
+			</if>
+
+			<if>
+				<isset property="set.permission.algorithm.6" />
+				<then>
+					<replace
+						file="portal-impl/src/portal-ext.properties"
+						token="permissions.user.check.algorithm=5"
+						value=""
+					/>
+					<replace
+						file="portal-impl/src/portal-ext.properties"
+						token="permissions.view.dynamic.inheritance=false"
+						value=""
+					/>
+				</then>
+			</if>
+
+			<get-testcase-property property.name="portal.proxy.path" />
+			<propertycopy from="portal.proxy.path[${env.CI_TEST_SUITE}]" name="portal.proxy.path" silent="true" />
+
+			<if>
+				<isset property="portal.proxy.path" />
+				<then>
+					<echo append="true" file="portal-impl/src/portal-ext.properties">
+
+portal.proxy.path=/${portal.proxy.path}</echo>
+
+					<replace
+						file="portal-impl/src/portal-ext.properties"
+						token="web.server.http.port=8080"
+						value="web.server.http.port=88"
+					/>
+				</then>
+			</if>
+
+			<get-testcase-property property.name="setup.wizard.enabled" />
+
+			<if>
+				<equals arg1="${setup.wizard.enabled}" arg2="true" />
+				<then>
+					<replace
+						file="portal-impl/src/portal-ext.properties"
+						token="setup.wizard.enabled=false"
+						value=""
+					/>
+
+					<echo append="true" file="portal-impl/src/portal-ext.properties">
+
+include-and-override=${liferay.home}/portal-setup-wizard.properties</echo>
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="prepare-portal-licenses">
 		<sequential>
 			<get-testcase-property property.name="dxp.license.file" />
@@ -13253,20 +13368,6 @@ upgrade.database.auto.run=true</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="database.jndi.enabled" />
-
-		<if>
-			<equals arg1="${database.jndi.enabled}" arg2="true" />
-			<then>
-				<replace
-					file="portal-impl/src/portal-ext.properties"
-				>
-					<replacetoken>jdbc.default.jndi.name=</replacetoken>
-					<replacevalue>jdbc.default.jndi.name=jdbc/LiferayPool</replacevalue>
-				</replace>
-			</then>
-		</if>
-
 		<if>
 			<equals arg1="${database.partition.enabled}" arg2="true" />
 			<then>
@@ -13366,36 +13467,6 @@ custom.sql.function.isnotnull=CAST(? AS VARCHAR(32672)) IS NOT NULL</echo>
 		</if>
 
 		<if>
-			<equals arg1="${database.type}" arg2="oracle" />
-			<then>
-				<if>
-					<equals arg1="${database.version}" arg2="11.2.0.1.0" />
-					<then>
-						<property name="oracle.instance.name" value="xe" />
-					</then>
-					<elseif>
-						<and>
-							<equals arg1="${database.version}" arg2="12.2.0.1" />
-							<os family="windows" />
-						</and>
-						<then>
-							<property name="oracle.instance.name" value="orcl" />
-						</then>
-					</elseif>
-					<else>
-						<property name="oracle.instance.name" value="oracl" />
-					</else>
-				</if>
-
-				<replaceregexp
-					file="portal-impl/src/portal-ext.properties"
-					match="(jdbc:oracle:.*)oracl"
-					replace="\1${oracle.instance.name}"
-				/>
-			</then>
-		</if>
-
-		<if>
 			<and>
 				<isset property="google.drive.integration.client.id.1" />
 				<isset property="google.drive.integration.client.refresh.token.1" />
@@ -13435,73 +13506,6 @@ portal.security.manager.strategy=liferay</echo>
 				<echo append="true" file="portal-impl/src/portal-ext.properties">
 
 javascript.fast.load=false</echo>
-			</then>
-		</if>
-
-		<if>
-			<isset property="set.permission.algorithm.5" />
-			<then>
-				<replace
-					file="portal-impl/src/portal-ext.properties"
-					token="#permissions.user.check.algorithm=5"
-					value="permissions.user.check.algorithm=5"
-				/>
-				<replace
-					file="portal-impl/src/portal-ext.properties"
-					token="#permissions.view.dynamic.inheritance=false"
-					value="permissions.view.dynamic.inheritance=false"
-				/>
-			</then>
-		</if>
-
-		<if>
-			<isset property="set.permission.algorithm.6" />
-			<then>
-				<replace
-					file="portal-impl/src/portal-ext.properties"
-					token="permissions.user.check.algorithm=5"
-					value=""
-				/>
-				<replace
-					file="portal-impl/src/portal-ext.properties"
-					token="permissions.view.dynamic.inheritance=false"
-					value=""
-				/>
-			</then>
-		</if>
-
-		<get-testcase-property property.name="portal.proxy.path" />
-		<propertycopy from="portal.proxy.path[${env.CI_TEST_SUITE}]" name="portal.proxy.path" silent="true" />
-
-		<if>
-			<isset property="portal.proxy.path" />
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-
-portal.proxy.path=/${portal.proxy.path}</echo>
-
-				<replace
-					file="portal-impl/src/portal-ext.properties"
-					token="web.server.http.port=8080"
-					value="web.server.http.port=88"
-				/>
-			</then>
-		</if>
-
-		<get-testcase-property property.name="setup.wizard.enabled" />
-
-		<if>
-			<equals arg1="${setup.wizard.enabled}" arg2="true" />
-			<then>
-				<replace
-					file="portal-impl/src/portal-ext.properties"
-					token="setup.wizard.enabled=false"
-					value=""
-				/>
-
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-
-include-and-override=${liferay.home}/portal-setup-wizard.properties</echo>
 			</then>
 		</if>
 
@@ -13566,6 +13570,8 @@ outgoingSMTPPort="25000"
 feature.flag.LPD-11342=true</echo>
 			</then>
 		</if>
+
+		<prepare-portal-ext-properties-overrides />
 
 		<apply-portal-ext-properties />
 	</target>

--- a/build-test.xml
+++ b/build-test.xml
@@ -13323,14 +13323,6 @@ ${update.properties}</echo>
 		<prepare-portal-ext-properties-dl-store />
 
 		<if>
-			<equals arg1="${database.type}" arg2="oracle" />
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties"><![CDATA[
-jdbc.default.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_TIMEOUT=0]]></echo>
-			</then>
-		</if>
-
-		<if>
 			<not>
 				<isset property="commerce.enabled" />
 			</not>
@@ -13348,6 +13340,15 @@ enterprise.product.commerce.enabled=false</echo>
 			</then>
 		</if>
 
+		<get-testcase-property property.name="custom.properties" />
+
+		<if>
+			<isset property="custom.properties" />
+			<then>
+				<prepare-custom-properties custom.properties="${custom.properties}" />
+			</then>
+		</if>
+
 		<get-testcase-property property.name="database.auto.upgrade.enabled" />
 
 		<if>
@@ -13359,12 +13360,15 @@ upgrade.database.auto.run=true</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="custom.properties" />
-
 		<if>
-			<isset property="custom.properties" />
+			<or>
+				<equals arg1="${database.partition.copy}" arg2="true" />
+				<equals arg1="${database.partition.export.and.import}" arg2="true" />
+			</or>
+
 			<then>
-				<prepare-custom-properties custom.properties="${custom.properties}" />
+				<echo append="true" file="portal-impl/src/portal-ext.properties">
+feature.flag.LPD-11342=true</echo>
 			</then>
 		</if>
 
@@ -13376,29 +13380,22 @@ database.partition.enabled=true</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="liferay.online.properties" />
-		<propertycopy from="liferay.online.properties[${env.CI_TEST_SUITE}]" name="liferay.online.properties" silent="true" />
+		<if>
+			<equals arg1="${database.type}" arg2="oracle" />
+			<then>
+				<echo append="true" file="portal-impl/src/portal-ext.properties"><![CDATA[
+jdbc.default.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_TIMEOUT=0]]></echo>
+			</then>
+		</if>
 
 		<if>
-			<equals arg1="${liferay.online.properties}" arg2="true" />
+			<equals arg1="${database.type}" arg2="db2" />
 			<then>
-				<prepare-liferay-online-properties />
+				<echo append="true" file="portal-impl/src/portal-ext.properties">
 
-				<get-testcase-property property.name="data.archive.type" />
-
-				<if>
-					<contains string="${data.archive.type}" substring="partition-large" />
-					<then>
-						<echo append="true" file="portal-impl/src/portal-ext.properties">
-locales=es_ES,en_US,en_GB
-locales.enabled=es_ES,en_US,en_GB
-admin.default.role.names=User
-layout.user.public.layouts.power.user.required=true
-layout.user.private.layouts.power.user.required=true
-passwords.encryption.algorithm.legacy=SHA
-company.default.web.id=www.able.com</echo>
-					</then>
-				</if>
+hibernate.dialect=com.liferay.portal.dao.orm.hibernate.DB2Dialect
+custom.sql.function.isnull=CAST(? AS VARCHAR(32672)) IS NULL
+custom.sql.function.isnotnull=CAST(? AS VARCHAR(32672)) IS NOT NULL</echo>
 			</then>
 		</if>
 
@@ -13418,51 +13415,6 @@ jdbc.test.password=${database.password}</echo>
 					match="(jdbc.test.url.*)(lportal)"
 					replace="\1lportal1"
 				/>
-			</then>
-		</if>
-
-		<if>
-			<or>
-				<equals arg1="ms.exchange.enabled" arg2="" />
-				<not>
-					<isset property="ms.exchange.enabled" />
-				</not>
-			</or>
-			<then>
-				<get-testcase-property property.name="ms.exchange.enabled" />
-			</then>
-		</if>
-
-		<if>
-			<equals arg1="${ms.exchange.enabled}" arg2="true" />
-
-			<then>
-				<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.mail.settings.configuration.MailSettingCompanyConfiguration.config"><![CDATA[
-enablePOPServerNotifications=b"true"
-incomingPOPPort="995"
-incomingPOPServer="outlook.office365.com"
-outgoingSMTPPort="587"
-outgoingSMTPServer="smtp.office365.com"
-popUserName="qa-exchange-pop-test@liferay0.onmicrosoft.com"
-smtpUserName="qa-exchange-pop-test@liferay0.onmicrosoft.com"
-storeProtocol="pop3s"
-]]>
-				</echo>
-
-				<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.mail.settings.configuration.MailSettingSystemConfiguration.config"><![CDATA[
-popServerSubdomain=""
-]]></echo>
-			</then>
-		</if>
-
-		<if>
-			<equals arg1="${database.type}" arg2="db2" />
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-
-hibernate.dialect=com.liferay.portal.dao.orm.hibernate.DB2Dialect
-custom.sql.function.isnull=CAST(? AS VARCHAR(32672)) IS NULL
-custom.sql.function.isnotnull=CAST(? AS VARCHAR(32672)) IS NOT NULL</echo>
 			</then>
 		</if>
 
@@ -13506,6 +13458,66 @@ portal.security.manager.strategy=liferay</echo>
 				<echo append="true" file="portal-impl/src/portal-ext.properties">
 
 javascript.fast.load=false</echo>
+			</then>
+		</if>
+
+		<get-testcase-property property.name="liferay.online.properties" />
+		<propertycopy from="liferay.online.properties[${env.CI_TEST_SUITE}]" name="liferay.online.properties" silent="true" />
+
+		<if>
+			<equals arg1="${liferay.online.properties}" arg2="true" />
+			<then>
+				<prepare-liferay-online-properties />
+
+				<get-testcase-property property.name="data.archive.type" />
+
+				<if>
+					<contains string="${data.archive.type}" substring="partition-large" />
+					<then>
+						<echo append="true" file="portal-impl/src/portal-ext.properties">
+locales=es_ES,en_US,en_GB
+locales.enabled=es_ES,en_US,en_GB
+admin.default.role.names=User
+layout.user.public.layouts.power.user.required=true
+layout.user.private.layouts.power.user.required=true
+passwords.encryption.algorithm.legacy=SHA
+company.default.web.id=www.able.com</echo>
+					</then>
+				</if>
+			</then>
+		</if>
+
+		<if>
+			<or>
+				<equals arg1="ms.exchange.enabled" arg2="" />
+				<not>
+					<isset property="ms.exchange.enabled" />
+				</not>
+			</or>
+			<then>
+				<get-testcase-property property.name="ms.exchange.enabled" />
+			</then>
+		</if>
+
+		<if>
+			<equals arg1="${ms.exchange.enabled}" arg2="true" />
+
+			<then>
+				<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.mail.settings.configuration.MailSettingCompanyConfiguration.config"><![CDATA[
+enablePOPServerNotifications=b"true"
+incomingPOPPort="995"
+incomingPOPServer="outlook.office365.com"
+outgoingSMTPPort="587"
+outgoingSMTPServer="smtp.office365.com"
+popUserName="qa-exchange-pop-test@liferay0.onmicrosoft.com"
+smtpUserName="qa-exchange-pop-test@liferay0.onmicrosoft.com"
+storeProtocol="pop3s"
+]]>
+				</echo>
+
+				<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.mail.settings.configuration.MailSettingSystemConfiguration.config"><![CDATA[
+popServerSubdomain=""
+]]></echo>
 			</then>
 		</if>
 
@@ -13556,18 +13568,6 @@ javascript.fast.load=false</echo>
 				<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.mail.settings.configuration.MailSettingCompanyConfiguration.config"><![CDATA[
 outgoingSMTPPort="25000"
 ]]></echo>
-			</then>
-		</if>
-
-		<if>
-			<or>
-				<equals arg1="${database.partition.copy}" arg2="true" />
-				<equals arg1="${database.partition.export.and.import}" arg2="true" />
-			</or>
-
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-feature.flag.LPD-11342=true</echo>
 			</then>
 		</if>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -3593,6 +3593,144 @@ module.framework.properties.blacklist.portal.profile.names=${blacklist.portal.pr
 		</sequential>
 	</macrodef>
 
+	<macrodef name="prepare-portal-ext-properties-dl-store">
+		<sequential>
+			<get-testcase-property property.name="store.migration.test" />
+
+			<if>
+				<or>
+					<equals arg1="aws.store.enabled" arg2="" />
+					<not>
+						<isset property="aws.store.enabled" />
+					</not>
+				</or>
+				<then>
+					<get-testcase-property property.name="aws.store.enabled" />
+				</then>
+			</if>
+
+			<if>
+				<and>
+					<equals arg1="${aws.store.enabled}" arg2="true" />
+					<not>
+						<equals arg1="${store.migration.test}" arg2="true" />
+					</not>
+				</and>
+				<then>
+					<echo append="true" file="portal-impl/src/portal-ext.properties">
+
+dl.store.impl=com.liferay.portal.store.s3.S3Store</echo>
+				</then>
+			</if>
+
+			<if>
+				<or>
+					<equals arg1="azure.store.enabled" arg2="" />
+					<not>
+						<isset property="azure.store.enabled" />
+					</not>
+				</or>
+				<then>
+					<get-testcase-property property.name="azure.store.enabled" />
+				</then>
+			</if>
+
+			<if>
+				<and>
+					<equals arg1="${azure.store.enabled}" arg2="true" />
+					<not>
+						<equals arg1="${store.migration.test}" arg2="true" />
+					</not>
+				</and>
+				<then>
+					<echo append="true" file="portal-impl/src/portal-ext.properties">
+
+dl.store.impl=com.liferay.portal.store.azure.AzureStore</echo>
+				</then>
+			</if>
+
+			<if>
+				<or>
+					<equals arg1="gcs.store.enabled" arg2="" />
+					<not>
+						<isset property="gcs.store.enabled" />
+					</not>
+				</or>
+				<then>
+					<get-testcase-property property.name="gcs.store.enabled" />
+				</then>
+			</if>
+
+			<if>
+				<and>
+					<equals arg1="${gcs.store.enabled}" arg2="true" />
+					<not>
+						<equals arg1="${store.migration.test}" arg2="true" />
+					</not>
+				</and>
+				<then>
+					<echo append="true" file="portal-impl/src/portal-ext.properties">
+dl.store.impl=com.liferay.portal.store.gcs.GCSStore</echo>
+				</then>
+			</if>
+
+			<if>
+				<or>
+					<equals arg1="ibm.store.enabled" arg2="" />
+					<not>
+						<isset property="ibm.store.enabled" />
+					</not>
+				</or>
+				<then>
+					<get-testcase-property property.name="ibm.store.enabled" />
+				</then>
+			</if>
+
+			<if>
+				<and>
+					<equals arg1="${ibm.store.enabled}" arg2="true" />
+					<not>
+						<equals arg1="${store.migration.test}" arg2="true" />
+					</not>
+				</and>
+
+				<then>
+					<echo append="true" file="portal-impl/src/portal-ext.properties">
+dl.store.impl=com.liferay.portal.store.s3.IBMS3Store</echo>
+				</then>
+			</if>
+
+			<get-testcase-property property.name="dl.store.antivirus.enabled" />
+			<propertycopy from="dl.store.antivirus.enabled[${env.CI_TEST_SUITE}]" name="dl.store.antivirus.enabled" silent="true" />
+
+			<if>
+				<equals arg1="${dl.store.antivirus.enabled}" arg2="true" />
+				<then>
+					<is-cloud-ci-node />
+
+					<if>
+						<equals arg1="${is.cloud.ci.node}" arg2="true" />
+						<then>
+							<property name="clamd.docker.image" value="clamav/clamav:stable" />
+							<pull-clamd-docker-container image="${clamd.docker.image}" />
+							<start-docker-container image="${clamd.docker.image}" name="clamd">\
+								--expose=3310 \
+							</start-docker-container>
+						</then>
+					</if>
+
+					<echo append="true" file="portal-impl/src/portal-ext.properties">
+dl.store.antivirus.enabled=true</echo>
+
+					<property name="osgi.module.configuration.file.names" value="com.liferay.antivirus.clamd.scanner.internal.configuration.ClamdAntivirusScannerConfiguration.config" />
+					<property name="osgi.module.configurations" value="hostname=&quot;clamd&quot;${line.separator}port=I&quot;3310&quot;" />
+
+					<antcall target="deploy-osgi-module-configurations" />
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="prepare-portal-licenses">
 		<sequential>
 			<get-testcase-property property.name="dxp.license.file" />
@@ -13067,65 +13205,13 @@ ${update.properties}</echo>
 
 		<prepare-portal-ext-properties-clustering />
 
+		<prepare-portal-ext-properties-dl-store />
+
 		<if>
 			<equals arg1="${database.type}" arg2="oracle" />
 			<then>
 				<echo append="true" file="portal-impl/src/portal-ext.properties"><![CDATA[
 jdbc.default.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_TIMEOUT=0]]></echo>
-			</then>
-		</if>
-
-		<get-testcase-property property.name="store.migration.test" />
-
-		<if>
-			<or>
-				<equals arg1="aws.store.enabled" arg2="" />
-				<not>
-					<isset property="aws.store.enabled" />
-				</not>
-			</or>
-			<then>
-				<get-testcase-property property.name="aws.store.enabled" />
-			</then>
-		</if>
-
-		<if>
-			<and>
-				<equals arg1="${aws.store.enabled}" arg2="true" />
-				<not>
-					<equals arg1="${store.migration.test}" arg2="true" />
-				</not>
-			</and>
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-
-dl.store.impl=com.liferay.portal.store.s3.S3Store</echo>
-			</then>
-		</if>
-
-		<if>
-			<or>
-				<equals arg1="azure.store.enabled" arg2="" />
-				<not>
-					<isset property="azure.store.enabled" />
-				</not>
-			</or>
-			<then>
-				<get-testcase-property property.name="azure.store.enabled" />
-			</then>
-		</if>
-
-		<if>
-			<and>
-				<equals arg1="${azure.store.enabled}" arg2="true" />
-				<not>
-					<equals arg1="${store.migration.test}" arg2="true" />
-				</not>
-			</and>
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-
-dl.store.impl=com.liferay.portal.store.azure.AzureStore</echo>
 			</then>
 		</if>
 
@@ -13215,35 +13301,6 @@ company.default.web.id=www.able.com</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="dl.store.antivirus.enabled" />
-		<propertycopy from="dl.store.antivirus.enabled[${env.CI_TEST_SUITE}]" name="dl.store.antivirus.enabled" silent="true" />
-
-		<if>
-			<equals arg1="${dl.store.antivirus.enabled}" arg2="true" />
-			<then>
-				<is-cloud-ci-node />
-
-				<if>
-					<equals arg1="${is.cloud.ci.node}" arg2="true" />
-					<then>
-						<property name="clamd.docker.image" value="clamav/clamav:stable" />
-						<pull-clamd-docker-container image="${clamd.docker.image}" />
-						<start-docker-container image="${clamd.docker.image}" name="clamd">\
-							--expose=3310 \
-						</start-docker-container>
-					</then>
-				</if>
-
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-dl.store.antivirus.enabled=true</echo>
-
-				<property name="osgi.module.configuration.file.names" value="com.liferay.antivirus.clamd.scanner.internal.configuration.ClamdAntivirusScannerConfiguration.config" />
-				<property name="osgi.module.configurations" value="hostname=&quot;clamd&quot;${line.separator}port=I&quot;3310&quot;" />
-
-				<antcall target="deploy-osgi-module-configurations" />
-			</then>
-		</if>
-
 		<get-testcase-property property.name="external.database.enabled" />
 
 		<if>
@@ -13260,32 +13317,6 @@ jdbc.test.password=${database.password}</echo>
 					match="(jdbc.test.url.*)(lportal)"
 					replace="\1lportal1"
 				/>
-			</then>
-		</if>
-
-		<get-testcase-property property.name="store.migration.test" />
-
-		<if>
-			<or>
-				<equals arg1="gcs.store.enabled" arg2="" />
-				<not>
-					<isset property="gcs.store.enabled" />
-				</not>
-			</or>
-			<then>
-				<get-testcase-property property.name="gcs.store.enabled" />
-			</then>
-		</if>
-
-		<if>
-			<or>
-				<equals arg1="ibm.store.enabled" arg2="" />
-				<not>
-					<isset property="ibm.store.enabled" />
-				</not>
-			</or>
-			<then>
-				<get-testcase-property property.name="ibm.store.enabled" />
 			</then>
 		</if>
 
@@ -13320,33 +13351,6 @@ storeProtocol="pop3s"
 				<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.mail.settings.configuration.MailSettingSystemConfiguration.config"><![CDATA[
 popServerSubdomain=""
 ]]></echo>
-			</then>
-		</if>
-
-		<if>
-			<and>
-				<equals arg1="${gcs.store.enabled}" arg2="true" />
-				<not>
-					<equals arg1="${store.migration.test}" arg2="true" />
-				</not>
-			</and>
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-dl.store.impl=com.liferay.portal.store.gcs.GCSStore</echo>
-			</then>
-		</if>
-
-		<if>
-			<and>
-				<equals arg1="${ibm.store.enabled}" arg2="true" />
-				<not>
-					<equals arg1="${store.migration.test}" arg2="true" />
-				</not>
-			</and>
-
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-dl.store.impl=com.liferay.portal.store.s3.IBMS3Store</echo>
 			</then>
 		</if>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -3404,6 +3404,118 @@ tenantId=&quot;${ms.exchange.tenant.id}&quot;</echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="prepare-portal-ext-properties-default">
+		<sequential>
+			<delete file="portal-impl/src/portal-ext.properties" />
+
+			<if>
+				<and>
+					<isset property="test.base.dir.name" />
+					<available file="${test.base.dir.name}/portal.properties" />
+				</and>
+				<then>
+					<copy
+						file="${test.base.dir.name}/portal.properties"
+						tofile="portal-impl/src/portal-ext.properties"
+					/>
+				</then>
+			</if>
+
+			<propertycopy from="database.partition.enabled[${env.CI_TEST_SUITE}]" name="database.partition.enabled" override="true" silent="true" />
+
+			<if>
+				<or>
+					<equals arg1="database.partition.enabled" arg2="" />
+					<not>
+						<isset property="database.partition.enabled" />
+					</not>
+				</or>
+				<then>
+					<get-testcase-property property.name="database.partition.enabled" />
+				</then>
+			</if>
+
+			<get-testcase-property property.name="liferay.online.properties" />
+			<get-testcase-property property.name="portal.version" />
+
+			<if>
+				<and>
+					<isset property="portal.version" />
+					<or>
+						<equals arg1="database.partition.enabled" arg2="true" />
+						<isset property="liferay.online.properties" />
+					</or>
+				</and>
+				<then>
+					<property name="database.max.pool.size" value="50" />
+				</then>
+				<else>
+					<property name="database.max.pool.size" value="30" />
+				</else>
+			</if>
+
+			<get-database-property property.name="database.driver" />
+			<get-database-property property.name="database.password" />
+			<get-database-property property.name="database.url" />
+			<get-database-property property.name="database.username" />
+			<get-database-property property.name="database.version" />
+
+			<local name="database.url.parameters" />
+
+			<prepare-database-url-parameters url="${database.url}" />
+
+			<echo append="true" file="portal-impl/src/portal-ext.properties">
+
+liferay.home=${liferay.home}
+
+upgrade.database.dl.storage.check.disabled=true
+
+jdbc.default.jndi.name=
+jdbc.default.driverClassName=${database.driver}
+jdbc.default.url=${database.url}${database.url.parameters}
+jdbc.default.username=${database.username}
+jdbc.default.password=${database.password}
+
+#
+# HikariCP
+#
+
+jdbc.default.connectionTimeout=600000
+jdbc.default.maximumPoolSize=${database.max.pool.size}
+jdbc.default.minimumIdle=0
+
+enterprise.product.notification.enabled=false
+company.security.strangers.verify=false
+passwords.default.policy.change.required=false
+default.admin.password=${test.portal.default.admin.password}
+browser.launcher.url=
+setup.wizard.enabled=false
+initial.system.check.enabled=true
+memory.scheduler.org.quartz.threadPool.threadCount=1
+persisted.scheduler.org.quartz.threadPool.threadCount=1
+virtual.hosts.default.site.name=
+virtual.hosts.valid.hosts=*
+com.liferay.portal.servlet.filters.strip.StripFilter=true
+web.server.http.port=8080
+admin.email.from.address=test@liferay.com
+announcements.email.to.address=noreply@liferay.com
+login.secure.forgot.password=false
+captcha.enforce.disabled=true
+			</echo>
+
+			<mkdir dir="${liferay.home}/osgi/configs" />
+
+			<echo file="${liferay.home}/osgi/configs/com.liferay.captcha.configuration.CaptchaConfiguration.config"><![CDATA[createAccountCaptchaEnabled="false"
+maxChallenges="-1"
+sendPasswordCaptchaEnabled="false"]]></echo>
+
+			<echo file="${liferay.home}/osgi/configs/com.liferay.mail.settings.configuration.MailSettingSystemConfiguration.config"><![CDATA[
+sendBlacklist=[]
+jndiName=""
+]]></echo>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="prepare-portal-licenses">
 		<sequential>
 			<get-testcase-property property.name="dxp.license.file" />
@@ -12874,113 +12986,7 @@ ${update.properties}</echo>
 	</target>
 
 	<target name="prepare-portal-ext-properties">
-		<delete file="portal-impl/src/portal-ext.properties" />
-
-		<if>
-			<and>
-				<isset property="test.base.dir.name" />
-				<available file="${test.base.dir.name}/portal.properties" />
-			</and>
-			<then>
-				<copy
-					file="${test.base.dir.name}/portal.properties"
-					tofile="portal-impl/src/portal-ext.properties"
-				/>
-			</then>
-		</if>
-
-		<propertycopy from="database.partition.enabled[${env.CI_TEST_SUITE}]" name="database.partition.enabled" override="true" silent="true" />
-
-		<if>
-			<or>
-				<equals arg1="database.partition.enabled" arg2="" />
-				<not>
-					<isset property="database.partition.enabled" />
-				</not>
-			</or>
-			<then>
-				<get-testcase-property property.name="database.partition.enabled" />
-			</then>
-		</if>
-
-		<get-testcase-property property.name="liferay.online.properties" />
-		<get-testcase-property property.name="portal.version" />
-
-		<if>
-			<and>
-				<isset property="portal.version" />
-				<or>
-					<equals arg1="database.partition.enabled" arg2="true" />
-					<isset property="liferay.online.properties" />
-				</or>
-			</and>
-			<then>
-				<property name="database.max.pool.size" value="50" />
-			</then>
-			<else>
-				<property name="database.max.pool.size" value="30" />
-			</else>
-		</if>
-
-		<get-database-property property.name="database.driver" />
-		<get-database-property property.name="database.password" />
-		<get-database-property property.name="database.url" />
-		<get-database-property property.name="database.username" />
-		<get-database-property property.name="database.version" />
-
-		<local name="database.url.parameters" />
-
-		<prepare-database-url-parameters url="${database.url}" />
-
-		<echo append="true" file="portal-impl/src/portal-ext.properties">
-
-liferay.home=${liferay.home}
-
-upgrade.database.dl.storage.check.disabled=true
-
-jdbc.default.jndi.name=
-jdbc.default.driverClassName=${database.driver}
-jdbc.default.url=${database.url}${database.url.parameters}
-jdbc.default.username=${database.username}
-jdbc.default.password=${database.password}
-
-#
-# HikariCP
-#
-
-jdbc.default.connectionTimeout=600000
-jdbc.default.maximumPoolSize=${database.max.pool.size}
-jdbc.default.minimumIdle=0
-
-enterprise.product.notification.enabled=false
-company.security.strangers.verify=false
-passwords.default.policy.change.required=false
-default.admin.password=${test.portal.default.admin.password}
-browser.launcher.url=
-setup.wizard.enabled=false
-initial.system.check.enabled=true
-memory.scheduler.org.quartz.threadPool.threadCount=1
-persisted.scheduler.org.quartz.threadPool.threadCount=1
-virtual.hosts.default.site.name=
-virtual.hosts.valid.hosts=*
-com.liferay.portal.servlet.filters.strip.StripFilter=true
-web.server.http.port=8080
-admin.email.from.address=test@liferay.com
-announcements.email.to.address=noreply@liferay.com
-login.secure.forgot.password=false
-captcha.enforce.disabled=true
-		</echo>
-
-		<mkdir dir="${liferay.home}/osgi/configs" />
-
-		<echo file="${liferay.home}/osgi/configs/com.liferay.captcha.configuration.CaptchaConfiguration.config"><![CDATA[createAccountCaptchaEnabled="false"
-maxChallenges="-1"
-sendPasswordCaptchaEnabled="false"]]></echo>
-
-		<echo file="${liferay.home}/osgi/configs/com.liferay.mail.settings.configuration.MailSettingSystemConfiguration.config"><![CDATA[
-sendBlacklist=[]
-jndiName=""
-]]></echo>
+		<prepare-portal-ext-properties-default />
 
 		<if>
 			<equals arg1="${database.type}" arg2="oracle" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -3404,6 +3404,76 @@ tenantId=&quot;${ms.exchange.tenant.id}&quot;</echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="prepare-portal-ext-properties-clustering">
+		<sequential>
+			<if>
+				<not>
+					<isset property="cluster.enabled" />
+				</not>
+				<then>
+					<get-testcase-property property.name="cluster.enabled" />
+				</then>
+			</if>
+
+			<if>
+				<equals arg1="${cluster.enabled}" arg2="true" />
+				<then>
+					<echo append="true" file="portal-impl/src/portal-ext.properties">
+cluster.link.autodetect.address=
+
+cluster.link.channel.logic.name.control=control-channel-logic-name
+cluster.link.channel.logic.name.transport.0=transport-channel-logic-name
+
+cluster.link.enabled=true
+
+web.server.display.node=true</echo>
+					<echo file="${liferay.home}/osgi/configs/com.liferay.portal.store.file.system.configuration.FileSystemStoreConfiguration.config">rootDir=&quot;${liferay.home}/data/document_library&quot;</echo>
+				</then>
+			</if>
+
+			<get-testcase-property property.name="cluster.jdbc.ping" />
+
+			<if>
+				<equals arg1="${cluster.jdbc.ping}" arg2="true" />
+				<then>
+					<echo append="true" file="portal-impl/src/portal-ext.properties">
+
+cluster.link.channel.properties.control=${project.dir}/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/clustering_jdbc_ping.xml</echo>
+				</then>
+			</if>
+
+			<get-testcase-property property.name="cluster.node.ip" />
+
+			<if>
+				<equals arg1="${cluster.node.ip}" arg2="true" />
+				<then>
+					<echo append="true" file="portal-impl/src/portal-ext.properties">
+cluster.link.bind.addr["cluster-link-control"]=${ip.address}
+cluster.link.bind.addr["cluster-link-udp"]=${ip.address}</echo>
+				</then>
+			</if>
+
+			<get-testcase-property property.name="cluster.tcp.jdbc.ping" />
+
+			<if>
+				<equals arg1="${cluster.tcp.jdbc.ping}" arg2="true" />
+				<then>
+					<echo append="true" file="portal-impl/src/portal-ext.properties">
+
+cluster.link.channel.properties.control=${project.dir}/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/clustering_tcp_jdbc_ping.xml
+cluster.link.channel.properties.transport.0=${project.dir}/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/clustering_tcp_jdbc_ping.xml</echo>
+
+					<replace
+						file="portal-impl/src/portal-ext.properties"
+					>
+						<replacetoken>cluster.link.autodetect.address=</replacetoken>
+						<replacevalue></replacevalue>
+					</replace>
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="prepare-portal-ext-properties-default">
 		<sequential>
 			<delete file="portal-impl/src/portal-ext.properties" />
@@ -12995,6 +13065,8 @@ ${update.properties}</echo>
 	<target name="prepare-portal-ext-properties">
 		<prepare-portal-ext-properties-default />
 
+		<prepare-portal-ext-properties-clustering />
+
 		<if>
 			<equals arg1="${database.type}" arg2="oracle" />
 			<then>
@@ -13072,72 +13144,6 @@ dl.store.impl=com.liferay.portal.store.azure.AzureStore</echo>
 				<echo append="true" file="portal-impl/src/portal-ext.properties">
 
 enterprise.product.commerce.enabled=false</echo>
-			</then>
-		</if>
-
-		<if>
-			<not>
-				<isset property="cluster.enabled" />
-			</not>
-			<then>
-				<get-testcase-property property.name="cluster.enabled" />
-			</then>
-		</if>
-
-		<if>
-			<equals arg1="${cluster.enabled}" arg2="true" />
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-cluster.link.autodetect.address=
-
-cluster.link.channel.logic.name.control=control-channel-logic-name
-cluster.link.channel.logic.name.transport.0=transport-channel-logic-name
-
-cluster.link.enabled=true
-
-web.server.display.node=true</echo>
-				<echo file="${liferay.home}/osgi/configs/com.liferay.portal.store.file.system.configuration.FileSystemStoreConfiguration.config">rootDir=&quot;${liferay.home}/data/document_library&quot;</echo>
-			</then>
-		</if>
-
-		<get-testcase-property property.name="cluster.jdbc.ping" />
-
-		<if>
-			<equals arg1="${cluster.jdbc.ping}" arg2="true" />
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-
-cluster.link.channel.properties.control=${project.dir}/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/clustering_jdbc_ping.xml</echo>
-			</then>
-		</if>
-
-		<get-testcase-property property.name="cluster.node.ip" />
-
-		<if>
-			<equals arg1="${cluster.node.ip}" arg2="true" />
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-cluster.link.bind.addr["cluster-link-control"]=${ip.address}
-cluster.link.bind.addr["cluster-link-udp"]=${ip.address}</echo>
-			</then>
-		</if>
-
-		<get-testcase-property property.name="cluster.tcp.jdbc.ping" />
-
-		<if>
-			<equals arg1="${cluster.tcp.jdbc.ping}" arg2="true" />
-			<then>
-				<echo append="true" file="portal-impl/src/portal-ext.properties">
-
-cluster.link.channel.properties.control=${project.dir}/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/clustering_tcp_jdbc_ping.xml
-cluster.link.channel.properties.transport.0=${project.dir}/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/clustering/clusteringframework/dependencies/clustering_tcp_jdbc_ping.xml</echo>
-
-				<replace
-					file="portal-impl/src/portal-ext.properties"
-				>
-					<replacetoken>cluster.link.autodetect.address=</replacetoken>
-					<replacevalue></replacevalue>
-				</replace>
 			</then>
 		</if>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -13525,13 +13525,6 @@ include-and-override=${liferay.home}/portal-setup-wizard.properties</echo>
 			</then>
 		</if>
 
-		<if>
-			<isset property="test.set.default.portal.properties" />
-			<then>
-				<echo file="portal-impl/src/portal-ext.properties">liferay.home=${liferay.home}</echo>
-			</then>
-		</if>
-
 		<get-testcase-property property.name="test.smtp.server.enabled" />
 
 		<if>

--- a/build-test.xml
+++ b/build-test.xml
@@ -3516,6 +3516,10 @@ jndiName=""
 
 			<echo append="true" file="portal-impl/src/portal-ext.properties">
 analytics.cloud.domain.allowed=*</echo>
+
+			<echo append="true" file="portal-impl/src/portal-ext.properties">
+
+module.framework.properties.blacklist.portal.profile.names=${blacklist.portal.profile.names}</echo>
 		</sequential>
 	</macrodef>
 
@@ -13423,10 +13427,6 @@ portal.security.manager.strategy=liferay</echo>
 javascript.fast.load=false</echo>
 			</then>
 		</if>
-
-		<echo append="true" file="portal-impl/src/portal-ext.properties">
-
-module.framework.properties.blacklist.portal.profile.names=${blacklist.portal.profile.names}</echo>
 
 		<if>
 			<isset property="set.permission.algorithm.5" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -3513,6 +3513,9 @@ sendPasswordCaptchaEnabled="false"]]></echo>
 sendBlacklist=[]
 jndiName=""
 ]]></echo>
+
+			<echo append="true" file="portal-impl/src/portal-ext.properties">
+analytics.cloud.domain.allowed=*</echo>
 		</sequential>
 	</macrodef>
 
@@ -13553,9 +13556,6 @@ outgoingSMTPPort="25000"
 feature.flag.LPD-11342=true</echo>
 			</then>
 		</if>
-
-		<echo append="true" file="portal-impl/src/portal-ext.properties">
-analytics.cloud.domain.allowed=*</echo>
 
 		<apply-portal-ext-properties />
 	</target>


### PR DESCRIPTION
Refactors the ~700-line `prepare-portal-ext-properties` target in `build-test.xml` into cohesive, phase-grouped macrodefs so it is easier to read and safer to modify. Behavior-preserving.

## Structure

Four macrodefs (declared alphabetically in the macrodef section, between `prepare-portal-elasticsearch-osgi-configuration` and `prepare-portal-licenses`):

- `prepare-portal-ext-properties-default` — the unconditional baseline (file reset, seed copy, DB connection resolution, the default property block, base OSGi configs, and the relocated analytics/blacklist defaults)
- `prepare-portal-ext-properties-clustering` — the cluster.enabled / jdbc.ping / node.ip / tcp.jdbc.ping chain (internal order preserved)
- `prepare-portal-ext-properties-dl-store` — the S3/Azure/GCS/IBM and antivirus document-library store blocks
- `prepare-portal-ext-properties-overrides` — the conditional `<replace>`/`<replaceregexp>` blocks (JNDI, Oracle URL, permission algorithm 5/6, proxy path, setup wizard)

The target now reads: `default` -> `clustering` -> `dl-store` -> conditional appends (now sorted alphabetically by condition property) -> `overrides` -> `apply`.

## Behavior preservation

Eight small commits, each verified individually (whitespace-stripped/sorted diff = pure relocation per commit). The cumulative diff against the pre-refactor baseline reduces to exactly one semantic change plus the macrodef structure:

- The only behavioral change is dropping the redundant second `store.migration.test` fetch (the value is immutable, so the second fetch was a no-op).
- `overrides` runs last so its `<replace>` blocks see the fully-appended file; the one real cross-block edge (external-DB `jdbc.test.url` append feeding the Oracle URL `replaceregexp`) is preserved.

Also removes a dead block: `test.set.default.portal.properties` is never set anywhere in liferay-portal or liferay-jenkins-ee, so its handling was unreachable.

`ant format-source-current-branch` passes.

## Testing

This target is CI-only and cannot run locally, so the change still needs a Poshi functional batch run to confirm empirically. Opening for review.