### PR TITLE
LRCI-7361 Make yarn install args configurable via Gradle properties

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -618,6 +618,15 @@
     nodejs.npm.registry=
     #nodejs.npm.registry=https://registry.npm.taobao.org
 
+    nodejs.yarn.install.args=
+    #nodejs.yarn.install.args=install --frozen-lockfile --ignore-engines --network-timeout 120000 --offline
+
+    nodejs.yarn.install.frozen.lockfile=true
+
+    #nodejs.yarn.install.network.timeout=120000
+
+    nodejs.yarn.install.prefer.offline=true
+
     #
     # Add the --offline flag for Yarn commands.
     #

--- a/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/YarnPlugin.java
+++ b/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/YarnPlugin.java
@@ -48,9 +48,9 @@ public class YarnPlugin implements Plugin<Project> {
 					yarnInstallTask.setDescription(
 						"Installs Node packages from package.json.");
 					yarnInstallTask.setFrozenLockFile(
-						Boolean.parseBoolean(
-							System.getProperty(
-								"frozen.lockfile", Boolean.TRUE.toString())));
+						GradleUtil.getProperty(
+							yarnInstallTask.getProject(),
+							"nodejs.yarn.install.frozen.lockfile", true));
 				}
 
 			});

--- a/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
+++ b/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
@@ -41,6 +41,9 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 		if (Validator.isNotNull(networkTimeout)) {
 			_networkTimeout = Long.parseLong(networkTimeout);
 		}
+
+		_preferOffline = GradleUtil.getProperty(
+			getProject(), "nodejs.yarn.install.prefer.offline", true);
 	}
 
 	@Override
@@ -70,6 +73,11 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 		return GradleUtil.toBoolean(_frozenLockFile);
 	}
 
+	@Input
+	public boolean isPreferOffline() {
+		return _preferOffline;
+	}
+
 	public void setFrozenLockFile(Object frozenLockFile) {
 		_frozenLockFile = frozenLockFile;
 	}
@@ -88,6 +96,10 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 
 	public void setNetworkTimeout(long networkTimeout) {
 		_networkTimeout = networkTimeout;
+	}
+
+	public void setPreferOffline(boolean preferOffline) {
+		_preferOffline = preferOffline;
 	}
 
 	@Internal
@@ -118,7 +130,9 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 			completeArgs.add(String.valueOf(networkTimeout));
 		}
 
-		completeArgs.add("--prefer-offline");
+		if (isPreferOffline()) {
+			completeArgs.add("--prefer-offline");
+		}
 
 		return completeArgs;
 	}
@@ -140,5 +154,6 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 	private Object _frozenLockFile;
 	private final List<Object> _installArgs = new ArrayList<>();
 	private long _networkTimeout = 120000;
+	private boolean _preferOffline;
 
 }

--- a/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
+++ b/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
@@ -7,20 +7,34 @@ package com.liferay.gradle.plugins.node.task;
 
 import com.liferay.gradle.plugins.node.internal.util.FileUtil;
 import com.liferay.gradle.plugins.node.internal.util.GradleUtil;
+import com.liferay.gradle.util.Validator;
 
 import java.io.File;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
 
 /**
  * @author Peter Shin
  * @author David Truong
  */
 public class YarnInstallTask extends ExecutePackageManagerTask {
+
+	public YarnInstallTask() {
+		String installArgs = GradleUtil.getProperty(
+			getProject(), "nodejs.yarn.install.args", "");
+
+		if (Validator.isNotNull(installArgs)) {
+			installArgs = installArgs.trim();
+
+			setInstallArgs(installArgs.split("\\s+"));
+		}
+	}
 
 	@Override
 	public synchronized void executeNode() throws Exception {
@@ -31,6 +45,12 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 		}
 
 		super.executeNode();
+	}
+
+	@Input
+	@Optional
+	public List<String> getInstallArgs() {
+		return GradleUtil.toStringList(_installArgs);
 	}
 
 	@Input
@@ -47,6 +67,18 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 		_frozenLockFile = frozenLockFile;
 	}
 
+	public void setInstallArgs(Iterable<?> installArgs) {
+		_installArgs.clear();
+
+		for (Object installArg : installArgs) {
+			_installArgs.add(installArg);
+		}
+	}
+
+	public void setInstallArgs(Object... installArgs) {
+		setInstallArgs(Arrays.asList(installArgs));
+	}
+
 	public void setNetworkTimeout(long networkTimeout) {
 		_networkTimeout = networkTimeout;
 	}
@@ -55,6 +87,14 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 	@Override
 	protected List<String> getCompleteArgs() {
 		List<String> completeArgs = super.getCompleteArgs();
+
+		List<String> installArgs = getInstallArgs();
+
+		if (!installArgs.isEmpty()) {
+			completeArgs.addAll(installArgs);
+
+			return completeArgs;
+		}
 
 		completeArgs.add("install");
 
@@ -91,6 +131,7 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 	}
 
 	private Object _frozenLockFile;
+	private final List<Object> _installArgs = new ArrayList<>();
 	private long _networkTimeout = 120000;
 
 }

--- a/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
+++ b/modules/sdk/gradle-plugins-node/src/main/java/com/liferay/gradle/plugins/node/task/YarnInstallTask.java
@@ -34,6 +34,13 @@ public class YarnInstallTask extends ExecutePackageManagerTask {
 
 			setInstallArgs(installArgs.split("\\s+"));
 		}
+
+		String networkTimeout = GradleUtil.getProperty(
+			getProject(), "nodejs.yarn.install.network.timeout", (String)null);
+
+		if (Validator.isNotNull(networkTimeout)) {
+			_networkTimeout = Long.parseLong(networkTimeout);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Supersedes #2067 (closed after rebase + alphabetized-flags fix).

## Goal

Make the `gradle-plugins-node` module configurable from CI, so yarn install behavior can be tuned per branch / repo / job via `liferay-jenkins-ee` without further code changes to the plugin. This is the prerequisite for LRCI-7361's broader offline-mode rework (`--offline --frozen-lockfile` on `portalYarnInstall`) — once these knobs land and the plugin is published, CI can try the settings on a per-job basis before committing to a global flip.

## Summary

- Adds `nodejs.yarn.install.args` as a full-override property on `YarnInstallTask` — when set, replaces the entire post-`super` args list. Read in the constructor via `GradleUtil.getProperty`.
- Migrates `frozen.lockfile` (read via `System.getProperty` in `YarnPlugin`) to `nodejs.yarn.install.frozen.lockfile` (read via `GradleUtil.getProperty`). Default `true` — same as today.
- Adds `nodejs.yarn.install.network.timeout` (read in the `YarnInstallTask` constructor) alongside the existing `gradle.yarn.install.network.timeout` allprojects block in `modules/build.gradle`. Both property names work during transition; the legacy block is left in place.
- Promotes the hardcoded `--prefer-offline` flag to its own property `nodejs.yarn.install.prefer.offline`. Default `true` — same as today.

Zero behavior change for any caller today. All defaults match current values; the new properties are escape hatches for CI to override per branch / repo / job via `liferay-jenkins-ee`'s `portal.build.properties[<key>]` mechanism.

The eventual removal of the legacy `gradle.yarn.install.network.timeout` allprojects block is deferred to a follow-up that gates on the new `gradle-plugins-node` version being published and pinned by master. The same coordination applies to backports across `release-2026.q1` and `release-2026.q2`, which both carry the LRCI-6896 allprojects block today.

## Code review feedback

Applied from [bchan-bot's review](https://github.com/brianchandotcom/liferay-portal/pull/175563#issuecomment-4579908916):
- **Rule 903 (alphabetize flags)**: reordered the commented example to `install --frozen-lockfile --ignore-engines --network-timeout 120000 --offline`.

Skipped:
- **Rule 301 (`Long.parseLong` → `GetterUtil.getLong`)**: doesn't apply — `GetterUtil` is not on the `gradle-plugins-node` classpath. Zero `GetterUtil` usages exist across `modules/sdk/gradle-plugins*`; raw `parseLong` / `parseInt` is the established pattern (e.g. `SourceFormatterDefaultsPlugin.java:243`).
- **Rule 203 (no early return)**: `ExecutePackageManagerTask.getCompleteArgs` already uses an early `return completeArgs` inside `if (!isUseNpm())`; adopting would require refactoring the parent first.

Ticket: https://liferay.atlassian.net/browse/LRCI-7361