### PR TITLE
LRCI-7604 Record pr-check results on the GitHub PR

### DIFF
--- a/.claude/skills/pr-check-publish/SKILL.md
+++ b/.claude/skills/pr-check-publish/SKILL.md
@@ -2,55 +2,58 @@
 
 allowed-tools: [Bash]
 argument-hint: "<pr-url>"
-description: Publish pr-check success signals to an existing GitHub PR. Use when the user wants to mark an existing PR as pr-check-passed, or when the `pr` skill publishes results after creating a PR.
+description: Comment a pr-check run on an existing GitHub PR with a marker the webhook parses to apply the commit status and label. Use after rerunning pr-check on an open PR.
 name: pr-check-publish
 
 ---
 
 # Publish pr-check Results
 
-Record on a GitHub PR that pr-check passed locally for its head SHA, so reviewers and the GitHub PR UI can see the signal alongside CI.
+Post the `pr-check` Results Summary as a comment on an existing GitHub PR, ending the comment with a hidden marker. The webhook parses that marker and applies the `pr-check` commit status to the tested SHA and the `pr-check - <state>` label to the PR — this skill never writes the status or label itself, so it works the same whether or not the user has write access on the target repository.
+
+Newly created PRs do not need this skill: the `pr` skill writes the same Results Summary and marker into the PR description at creation, and the webhook reads it from there. Reach for this skill only to record a later run — for example after pushing more commits and rerunning `pr-check` on an open PR — where the description no longer reflects the current head.
 
 ## Input
 
 ### Pull Request
 
-`${ARGUMENTS}` carries a PR URL of the form `https://github.com/<target-org>/liferay-portal/pull/<number>`. When missing or malformed, abort and ask the user for the URL. Parse the URL to extract `<target-org>/<target-repo>` and `<PR-number>`.
+`${ARGUMENTS}` carries a PR URL of the form `https://github.com/<target-org>/liferay-portal/pull/<number>`. When missing or malformed, abort and ask the user for the URL.
 
-### Head Fork
+### Results Summary
 
-Resolve the PR's head SHA and head repository (`<head-fork-owner>/<head-fork-repo>`). The head fork is the repository that hosts the branch and SHA — typically the developer's fork — and is used as the fallback when the developer lacks write access on the target repository.
+Use the **Results Summary** block emitted by the `pr-check` run in the current session — the overall state line, the tested SHA, and the per-validation table. When no Results Summary is available (pr-check has not run this session), abort and ask the user to run `pr-check` first; this skill records a run, it does not perform one.
 
 ## Expected Output
 
-### Posted Commit Status
+### Posted Comment
 
-Post a `pr-check` commit status to the head SHA using the call below. Try the target repository first, because the GitHub PR UI only renders statuses recorded against the base repository's view of the SHA. Fall back to the head fork only when the target call fails (typically a cross-fork PR where the developer lacks write access on the target).
+Post a fresh comment on each run rather than editing a prior one, so the PR keeps a chronological record. The comment body is the Results Summary verbatim, a blank line, then the marker — an HTML comment, invisible in rendered Markdown, of the form `<!-- pr-check result=<state> sha=<tested-SHA> -->`, where `<state>` is `success` when the overall state is `PASS` and `failure` when it is `FAIL`, and `<tested-SHA>` is the full 40-character SHA from the Results Summary:
 
-```bash
-gh api \
-	--field "context=pr-check" \
-	--field "description=All pr-check validations passed locally" \
-	--field "state=success" \
-	--method POST \
-	"repos/<owner>/<repo>/statuses/<head-SHA>"
+```markdown
+**pr-check: PASS** — tested on `<tested-SHA>`
+
+| Validation | Result |
+| --- | --- |
+| Source Format | PASS |
+| Full Portal Build | PASS |
+| Java Unit Tests | PASS |
+
+<!-- pr-check result=success sha=<tested-SHA> -->
 ```
 
-Substitute `<owner>/<repo>` in this order:
+Write that body to a file and post it with `--body-file`:
 
-1. `<target-org>/<target-repo>` — the PR's base repository.
+```bash
+gh pr comment \
+	--body-file "${comment_file}" \
+	"<pr-url>"
+```
 
-1. `<head-fork-owner>/<head-fork-repo>` — only when the previous call fails.
-
-When both calls fail, surface the error and continue with **Applied Label** — the two signals are independent.
-
-### Applied Label
-
-Apply the `pr-check - success` label to the PR on the target repository, creating the label first when it does not exist (color `c7e8cb`). On error, continue and note it in the summary.
+When the comment fails to post, surface the error — without it the webhook has nothing to parse, so the status and label will not appear.
 
 ### Summary
 
 Report back to the user with:
 
-- Whether the commit status posted, which repository it landed on (target repository or head fork fallback), and the SHA.
-- Whether the label applied, or that it was skipped because of cross-fork limitations.
+- The comment URL and the tested SHA the marker records.
+- That the `pr-check` commit status and `pr-check - <state>` label are applied by the webhook once it processes the comment, and so may lag the comment by a moment.

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -30,7 +30,7 @@ git diff --name-status "$(git merge-base HEAD master)...HEAD"
 
 ## Expected Output
 
-**`PASS`** or **`FAIL`**.
+**`PASS`** or **`FAIL`**, followed by a **Results Summary** table the `pr` and `pr-check-publish` skills reuse to record what was tested on the GitHub PR.
 
 The procedure runs in two passes over the validations, in the order below. The order is dependency-driven: drift first (later validations see the regenerated tree), then formatting, then build, then tests.
 
@@ -89,3 +89,23 @@ When the validation's **Command** is a build (gradle, ant, npm, jest), bound the
 Decide PASS/FAIL from the build tool's success markers in the captured output (`BUILD SUCCESSFUL` / `BUILD FAILED`, `Tests: N passed, M failed`, etc.). Apply only to build commands. Leave inert commands like `git status --porcelain` and `git diff --quiet` untouched.
 
 When all validations pass, report `PASS`. When any fail, report `FAIL` and surface the failed validations.
+
+## Results Summary
+
+After the two passes complete, emit a Results Summary block. It is the canonical record of what was tested, embedded verbatim by the `pr` skill into the PR description and reused by the `pr-check-publish` skill when recording a run on an existing PR.
+
+Capture the tested commit with `git rev-parse HEAD` **after** Pass 2 completes, so the SHA reflects the tree that was actually exercised — including any autocommits the validations made, such as the `<TICKET> SF` source-format commit. This is the commit the `pr` skill pushes as the PR head and the commit the webhook binds the `pr-check` status to, so a reviewer can tell whether the current head is the one that was tested.
+
+The block is the overall state and tested SHA, followed by a table with one row per **matched** validation — the validations that actually ran, in the execution order above. Validations whose `## Match` regex did not fire are omitted rather than listed as skipped, so the table reflects only what the diff exercised.
+
+```markdown
+**pr-check: PASS** — tested on `<head-SHA>`
+
+| Validation | Result |
+| --- | --- |
+| Source Format | PASS |
+| Full Portal Build | PASS |
+| Java Unit Tests | PASS |
+```
+
+The overall state is `PASS` only when every row is `PASS`; any `FAIL` row makes it `FAIL`.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -17,7 +17,7 @@ Create a GitHub PR for the current branch, transition the linked Jira ticket to 
 
 - The current branch is a development branch, not `master` or any other protected branch.
 
-- The `pr-check` skill must pass. Skip only when `${ARGUMENTS}` contains `--skip-pr-check`.
+- The `pr-check` skill must pass. Skip only when `${ARGUMENTS}` contains `--skip-pr-check`. A skip requires a reason: take it from the text following the flag when present, otherwise prompt the user for one. The reason is recorded in the **PR Check** section, which is written for a skip rather than omitted.
 
 ## Input
 
@@ -94,11 +94,27 @@ Explain the approach taken across all commits. Describe the key changes and the 
 ## Why Are There No Tests?
 
 This optional section is only included when the commits do not add any tests. It should contain the rationale provided by the user.
+
+## PR Check
+
+<pr-check Results Summary>
+
+<!-- pr-check result=<state> sha=<tested-SHA> -->
 ```
 
-Use a direct, to-the-point style. Avoid being verbose. Present the proposed title and body to the user before submitting, and proceed once they approve.
+The **PR Check** section is the Results Summary block emitted by the `pr-check` skill that ran as the precondition — the overall state line, the tested SHA, and the per-validation table, pasted verbatim — followed by a hidden marker. The marker is an HTML comment, invisible in rendered Markdown, of the form `<!-- pr-check result=<state> sha=<tested-SHA> -->`, where `<state>` is `success` when the overall state is `PASS` and `failure` when it is `FAIL`, and `<tested-SHA>` is the full 40-character SHA from the Results Summary. The webhook reads the `result` and `sha` fields to apply the `pr-check` commit status to that SHA and the `pr-check - <state>` label to the PR, so this skill records no status or label itself.
 
-When pr-check passes, invoke the `pr-check-publish` skill with the newly created PR URL.
+When pr-check was skipped via `--skip-pr-check`, still write the section, but as a skip rather than a run. Under the same `## PR Check` heading, the body is a single `**pr-check: SKIPPED** — <reason>` line with no table, and the marker carries the reason as a quoted `reason` field, `result=skipped`, and the PR head SHA. Marker keys are written in alphabetical order (`reason`, `result`, `sha`). Keep the reason plain text without double quotes.
+
+```markdown
+**pr-check: SKIPPED** — <reason>
+
+<!-- pr-check reason="<reason>" result=skipped sha=<head-SHA> -->
+```
+
+The webhook applies the status and label when it processes the `pull_request` event for the newly opened PR, so no publish step is needed at creation. Use the `pr-check-publish` skill only to record a later pr-check run on an existing PR.
+
+Use a direct, to-the-point style. Avoid being verbose. Present the proposed title and body to the user before submitting, and proceed once they approve.
 
 ### Transitioned Jira Ticket
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7604

## What Is Being Fixed

The pr-check skill reported PASS or FAIL only in the developer's
terminal, leaving no trace on the PR for reviewers and no record of
which commit was actually checked.

## How It Is Being Fixed

pr-check now emits a Results Summary — the overall state, the tested SHA
(git rev-parse HEAD captured after the run, so it covers the SF
autocommit), and a per-validation table. The pr skill embeds that
summary in the PR description as a PR Check section when it opens a PR,
and the pr-check-publish skill posts it as a comment when recording a
later run on an existing PR. Each rendering ends with a hidden marker,
<!-- pr-check result=<state> sha=<tested-SHA> -->, so the webhook can
bind a pr-check commit status to the exact tested commit and apply a
pr-check label. The webhook reads the marker on pull_request.opened for
the description and issue_comment.created for the comment. A
--skip-pr-check run is recorded too, as a result=skipped marker carrying
the reason, so a deliberate bypass stays visible rather than looking
like no run happened. The publish path no longer writes the status or
label itself, which removes the cross-fork write-access fallback the
previous direct approach needed.

## Why Are There No Tests?

The change is limited to .claude skill documentation (Markdown), which
has no automated test coverage.