### PR TITLE
LRCI-7652 Require a passing pr-check status to forward pull requests

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -417,10 +417,14 @@ public class CIForwardProcessor {
 		for (String requiredPassingTestSuiteName :
 				requiredPassingTestSuiteNames) {
 
-			if (!passingTestSuiteNames.contains(requiredPassingTestSuiteName)) {
-				failingRequiredPassingTestSuiteNames.add(
-					requiredPassingTestSuiteName);
+			if (passingTestSuiteNames.contains(requiredPassingTestSuiteName) ||
+				_hasPassingStatus(requiredPassingTestSuiteName)) {
+
+				continue;
 			}
+
+			failingRequiredPassingTestSuiteNames.add(
+				requiredPassingTestSuiteName);
 		}
 
 		return failingRequiredPassingTestSuiteNames;
@@ -608,6 +612,29 @@ public class CIForwardProcessor {
 		return sb.toString();
 	}
 
+	private String _getPRCheckMessage() {
+		if (_pullRequest.hasLabel("pr-check - skipped")) {
+			return JenkinsResultsParserUtil.combine(
+				"Pull requests with a skipped `pr-check` may not be ",
+				"forwarded. Please send this pull request manually using ",
+				"the `pr` Claude Code skill.");
+		}
+
+		if (_pullRequest.hasLabel("pr-check - failure") ||
+			_pullRequest.hasLabel("pr-check - success")) {
+
+			return JenkinsResultsParserUtil.combine(
+				"The `pr-check` result does not match the current head ",
+				"commit. Please rerun the `/pr-check` Claude Code skill ",
+				"and publish the result with `/pr-check-publish`.");
+		}
+
+		return JenkinsResultsParserUtil.combine(
+			"This pull request has no `pr-check` result. Please run the ",
+			"`/pr-check` Claude Code skill and publish the result with ",
+			"`/pr-check-publish`.");
+	}
+
 	private String[] _getRequiredCompletedTestSuiteNames() throws IOException {
 		return _getBuildPropertyAsArray(
 			JenkinsResultsParserUtil.combine(
@@ -724,6 +751,13 @@ public class CIForwardProcessor {
 				sb.append(requiredPassingTestSuiteName);
 				sb.append("`");
 
+				if (requiredPassingTestSuiteName.equals("pr-check") &&
+					failedRequiredPassingTestSuiteNames.contains("pr-check")) {
+
+					sb.append(" - ");
+					sb.append(_getPRCheckMessage());
+				}
+
 				if (requiredPassingTestSuiteName.equals("stable")) {
 					sb.append(" - If you believe that the stable test ");
 					sb.append("failures were caused by flaky tests, please ");
@@ -818,6 +852,39 @@ public class CIForwardProcessor {
 
 			return false;
 		}
+	}
+
+	private boolean _hasPassingStatus(String statusContext) {
+		JSONObject statusJSONObject =
+			_pullRequest.getSenderSHAStatusJSONObject();
+
+		if (statusJSONObject == null) {
+			return false;
+		}
+
+		JSONArray statusesJSONArray = statusJSONObject.optJSONArray("statuses");
+
+		if (statusesJSONArray == null) {
+			return false;
+		}
+
+		for (int i = 0; i < statusesJSONArray.length(); i++) {
+			JSONObject statusesJSONObject = statusesJSONArray.getJSONObject(i);
+
+			String context = statusesJSONObject.getString("context");
+
+			if (!context.equals(statusContext)) {
+				continue;
+			}
+
+			String state = statusesJSONObject.getString("state");
+
+			if (state.equals("success")) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private boolean _isForwardEligible() throws IOException {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7652

## What Is Being Fixed

Requested by Wes and Peter: pull requests reach upstream through `ci:forward` without ever running `pr-check`, letting service builder and REST builder issues land that local validation would have caught. Last week 53% of direct PRs to the forward receiver carried no `pr-check` result, and 27% of checked PRs had a result bound to a commit that was no longer the head.

## How It Is Being Fixed

A required passing suite in `ci.forward.required.passing.suites` now also passes when the head commit carries a successful commit status whose context matches the suite name verbatim, so `pr-check` is enforced by adding its context to the existing property — and any future status-based check is a property edit with no code change. The status is read from the head commit rather than the label because labels are pull-request-level and can be stale after new pushes. The rejection comment gives `pr-check`-specific guidance distinguishing a skipped run (the pull request must be sent manually), a missing result, and a result that no longer matches the head commit. `ci:forward:force` keeps reading the separate force property list, so force bypasses `pr-check` unless it is added there. Enforcement is activated by appending `pr-check` to the property in liferay-jenkins-ee, in a separate change.

## Why Are There No Tests?

`CIForwardProcessor` operates on live GitHub-backed `PullRequest` objects and the module has no mock seam for them; no existing test covers this class. The change was verified by the module unit suite (66/74 pass; the 8 failures are the pre-existing `BaseRelevantRuleTestCase` worktree-naming environment issue, unrelated to this class) and will be exercised against a real PR via a locally built jar on a liferay-jenkins-ee branch before the property flip.

## PR Check

**pr-check: PASS** — tested on `706c721c306933a5e07317e32c563757dc123ffb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

The 8 `BaseRelevantRuleTestCase` unit failures and the portal snapshot setup gaps are pre-existing local worktree environment issues unrelated to this diff; the module itself compiles, deploys, formats, and passes its other 66 tests.

<!-- pr-check {"result": "success", "sha": "706c721c306933a5e07317e32c563757dc123ffb"} -->