### PR TITLE
LRCI-7669 Webhook fix test 1 (no pr-check result)

### DIFF
--- a/.lrci-7669-test-1.txt
+++ b/.lrci-7669-test-1.txt
@@ -1,0 +1,1 @@
+LRCI-7669 webhook fix test 1 175411


### PR DESCRIPTION
LRCI-7669 sandbox webhook test, scenario 1: no pr-check evidence. After the fixed webhook is deployed, commenting ci:forward should list only ci:test:sf as triggering, post the missing-result guidance comment, and NOT invoke a pr-check suite. Will be closed after the test.