### PR TITLE
LRCI-7669 Webhook fix test 2 (passing pr-check status)

### DIFF
--- a/.lrci-7669-test-2.txt
+++ b/.lrci-7669-test-2.txt
@@ -1,0 +1,1 @@
+LRCI-7669 webhook fix test 2 175428


### PR DESCRIPTION
LRCI-7669 sandbox webhook test, scenario 2: pr-check and sf statuses present on head. Commenting ci:forward should list both as previously passed and proceed without triggering a pr-check suite. Will be closed after the test.