### PR TITLE
LRCI-7669 Webhook fix test 3 (passing pr-check, rendering check)

### DIFF
--- a/.lrci-7669-test-3.txt
+++ b/.lrci-7669-test-3.txt
@@ -1,0 +1,1 @@
+LRCI-7669 webhook fix test 3 190637


### PR DESCRIPTION
LRCI-7669 sandbox webhook retest: pr-check and sf statuses on head. Expect both skipped as previously passed, with pr-check rendered without the ci:test prefix. Will be closed immediately after the ci:forward comment is verified, before auto-forward fires.