### PR TITLE
LRCI-7712 Forward when a triggered suite passes a raw-context gate

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -422,11 +422,9 @@ public class PullRequest {
 			if (!Objects.equals(testSuiteName, "default")) {
 				Matcher matcher = _liferayContextPattern.matcher(testSuiteName);
 
-				if (!matcher.find()) {
-					continue;
+				if (matcher.find()) {
+					testSuiteName = matcher.group("testSuiteName");
 				}
-
-				testSuiteName = matcher.group("testSuiteName");
 			}
 
 			if (testSuiteNames.contains(testSuiteName)) {
@@ -636,11 +634,9 @@ public class PullRequest {
 			if (!Objects.equals(testSuiteName, "default")) {
 				Matcher matcher = _liferayContextPattern.matcher(testSuiteName);
 
-				if (!matcher.find()) {
-					continue;
+				if (matcher.find()) {
+					testSuiteName = matcher.group("testSuiteName");
 				}
-
-				testSuiteName = matcher.group("testSuiteName");
 			}
 
 			if (JenkinsResultsParserUtil.isNullOrEmpty(testSuiteName)) {


### PR DESCRIPTION
## What

`ci:forward` triggers a required suite (typically `sf`), and the test job is supposed to forward automatically once that suite passes. It wasn't — users had to comment `ci:forward` a second time after `sf` went green. See e.g. [liferay-search#1973](https://github.com/liferay-search/liferay-portal/pull/1973) (16:23 `ci:forward` triggered `sf`, `sf` passed 16:45, no forward; a 16:52 `ci:forward` then forwarded).

## Why

The auto-forward-on-completion path (`build-test-portal-source-format.xml` → `get-ci-forward-eligible`) calls `PullRequest.hasRequiredPassingTestSuites` / `hasRequiredCompletedTestSuites`, backed by `getPassingTestSuiteNames()` / `getCompletedTestSuiteNames()`. Those derived a suite name from each head-commit status by matching the context against `_liferayContextPattern` (`liferay/ci:test(:name)?`) and **skipped any non-matching status**. `pr-check`'s status uses the raw context `pr-check`, so it never counted as passing → eligibility was always false at completion → no forward.

`CIForwardProcessor` (the directly-invoked `forward-pullrequest` job) was unaffected because `_hasPassingStatus` already matches a raw context verbatim. LRCI-7669 fixed the plugins-ee comment handler but missed that the completion chain uses `PullRequest.hasRequired*` directly, which had no raw-context fallback.

## Fix

In both methods, when a status context doesn't match `_liferayContextPattern`, use the raw context as the suite name instead of skipping it — mirroring `CIForwardProcessor._hasPassingStatus` so both forward paths agree. `pr-check` (and any future non-`ci:test` gate) is now visible to the completion-chain eligibility check.

Safe: `hasRequired*` only checks `required ⊆ {passing/completed}`, so admitting extra context names can't make a required suite spuriously pass.

## Testing

`gradlew formatSource jar` clean. These methods read head-commit statuses over the network with no injection seam (no existing `PullRequest` unit test), so this mirrors LRCI-7669's no-unit-test precedent; verification is via a forward-gate test PR (post `pr-check`, then a single `ci:forward` that triggers `sf`, confirm it forwards on `sf` completion).

Ships via the normal jar republish (Nexus → `liferay-jenkins-ee/build.gradle` bump).

Ticket: LRCI-7712
