### PR TITLE
LRCI-7703 Submit PR body via --body-file to preserve the pr-check marker

### DIFF
--- a/.claude/skills/pr-check-publish/SKILL.md
+++ b/.claude/skills/pr-check-publish/SKILL.md
@@ -41,12 +41,16 @@ Post a fresh comment on each run rather than editing a prior one, so the PR keep
 <!-- pr-check {"result": "success", "sha": "<tested-SHA>"} -->
 ```
 
-Write that body to a file and post it with `--body-file`:
+Post the body with `--body-file`, never inline `--body` (a literal `!` in an inline body gets shell-escaped and corrupts the marker). Use `mktemp` for the file so it stays out of the working tree, and remove it afterward.
 
 ```bash
+comment_file=$(mktemp)
+
 gh pr comment \
 	--body-file "${comment_file}" \
 	"<pr-url>"
+
+rm "${comment_file}"
 ```
 
 When the comment fails to post, surface the error — without it the webhook has nothing to parse, so the status and label will not appear.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -116,6 +116,21 @@ The webhook applies the status and label when it processes the `pull_request` ev
 
 Use a direct, to-the-point style. Avoid being verbose. Present the proposed title and body to the user before submitting, and proceed once they approve.
 
+Create the pull request with `--body-file`, never inline `--body` (a literal `!` in an inline body gets shell-escaped and corrupts the marker). Use `mktemp` for the file so it stays out of the working tree, and remove it afterward.
+
+```bash
+body_file=$(mktemp)
+
+gh pr create \
+	--base master \
+	--body-file "${body_file}" \
+	--head <github-username>:<branch-name> \
+	--repo <target-org/repo> \
+	--title "<title>"
+
+rm "${body_file}"
+```
+
 ### Transitioned Jira Ticket
 
 Fetch the input ticket (issue type, status, subtasks) and resolve the **target ticket** — the one whose status reflects active work and on which the PR URL is recorded:


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7703

## What Is Being Fixed

The pr and pr-check-publish skills described the pr-check marker format but not how to submit the body. Passing it inline through a double-quoted gh --body call lets the shell escape the marker's exclamation point to \!, which corrupts the `<!-- pr-check -->` comment. GitHub then renders it visibly and the webhook no longer recognizes it, so ci:forward reports no pr-check result and refuses to forward. Observed on liferay-commerce/liferay-portal#7709.

## How It Is Being Fixed

Both skills now mandate writing the body to a temporary mktemp file and posting it with --body-file instead of an inline --body. The file lands outside the working tree and is removed afterward, so the marker stays intact byte for byte and no stray body file can be committed.

## Why Are There No Tests?

The change touches only two SKILL.md documentation files; there is no code to exercise.

## PR Check

**pr-check: PASS** — tested on `fe94bb82dc36cdbad6f5de099f054d1d5630b9bd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "fe94bb82dc36cdbad6f5de099f054d1d5630b9bd"} -->
