### PR TITLE
LRCI-7713 Clarify why a pull request was not forwarded

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.json.JSONArray;
@@ -613,6 +614,22 @@ public class CIForwardProcessor {
 	}
 
 	private String _getPRCheckStatusLine() {
+		String state = _getSenderSHAStatusState("pr-check");
+
+		if (Objects.equals(state, "error") ||
+			Objects.equals(state, "failure")) {
+
+			return _getTestSuiteStatusLine(
+				":x:",
+				JenkinsResultsParserUtil.combine(
+					"The `pr-check` failed on the current commit. Fix the ",
+					"reported problems and push, then rerun the `/pr-check` ",
+					"Claude Code skill and publish the result with ",
+					"`/pr-check-publish` before commenting `ci:forward` ",
+					"again."),
+				"pr-check");
+		}
+
 		if (_pullRequest.hasLabel("pr-check - skipped")) {
 			return _getTestSuiteStatusLine(
 				":warning:",
@@ -675,6 +692,31 @@ public class CIForwardProcessor {
 		}
 
 		return sb.toString();
+	}
+
+	private String _getSenderSHAStatusState(String statusContext) {
+		JSONObject statusJSONObject =
+			_pullRequest.getSenderSHAStatusJSONObject();
+
+		if (statusJSONObject == null) {
+			return null;
+		}
+
+		JSONArray statusesJSONArray = statusJSONObject.optJSONArray("statuses");
+
+		if (statusesJSONArray == null) {
+			return null;
+		}
+
+		for (int i = 0; i < statusesJSONArray.length(); i++) {
+			JSONObject statusesJSONObject = statusesJSONArray.getJSONObject(i);
+
+			if (statusContext.equals(statusesJSONObject.getString("context"))) {
+				return statusesJSONObject.getString("state");
+			}
+		}
+
+		return null;
 	}
 
 	private String _getSuccessCommentBody(String forwardedPullRequestURL) {
@@ -912,36 +954,8 @@ public class CIForwardProcessor {
 	}
 
 	private boolean _hasPassingStatus(String statusContext) {
-		JSONObject statusJSONObject =
-			_pullRequest.getSenderSHAStatusJSONObject();
-
-		if (statusJSONObject == null) {
-			return false;
-		}
-
-		JSONArray statusesJSONArray = statusJSONObject.optJSONArray("statuses");
-
-		if (statusesJSONArray == null) {
-			return false;
-		}
-
-		for (int i = 0; i < statusesJSONArray.length(); i++) {
-			JSONObject statusesJSONObject = statusesJSONArray.getJSONObject(i);
-
-			String context = statusesJSONObject.getString("context");
-
-			if (!context.equals(statusContext)) {
-				continue;
-			}
-
-			String state = statusesJSONObject.getString("state");
-
-			if (state.equals("success")) {
-				return true;
-			}
-		}
-
-		return false;
+		return Objects.equals(
+			_getSenderSHAStatusState(statusContext), "success");
 	}
 
 	private boolean _isForwardEligible() throws IOException {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -622,11 +622,9 @@ public class CIForwardProcessor {
 			return _getTestSuiteStatusLine(
 				":x:",
 				JenkinsResultsParserUtil.combine(
-					"The `pr-check` failed on the current commit. Fix the ",
-					"reported problems and push, then rerun the `/pr-check` ",
-					"Claude Code skill and publish the result with ",
-					"`/pr-check-publish` before commenting `ci:forward` ",
-					"again."),
+					"`pr-check` failed. Fix the failures and push, then rerun ",
+					"the `/pr-check` Claude Code skill and publish the result ",
+					"with `/pr-check-publish`."),
 				"pr-check");
 		}
 
@@ -634,9 +632,9 @@ public class CIForwardProcessor {
 			return _getTestSuiteStatusLine(
 				":warning:",
 				JenkinsResultsParserUtil.combine(
-					"This pull request has a skipped `pr-check`. Please send ",
-					"this pull request manually using the `/pr` Claude Code ",
-					"skill."),
+					"Pull requests with a skipped `pr-check` may not be ",
+					"forwarded. Please send this pull request manually using ",
+					"the `/pr` Claude Code skill."),
 				"pr-check");
 		}
 
@@ -646,9 +644,9 @@ public class CIForwardProcessor {
 			return _getTestSuiteStatusLine(
 				":warning:",
 				JenkinsResultsParserUtil.combine(
-					"The `pr-check` result is for a different commit. Please ",
-					"rerun the `/pr-check` Claude Code skill and publish the ",
-					"result with `/pr-check-publish` on the current commit."),
+					"The `pr-check` result does not match the current head ",
+					"commit. Please rerun the `/pr-check` Claude Code skill ",
+					"and publish the result with `/pr-check-publish`."),
 				"pr-check");
 		}
 
@@ -814,7 +812,7 @@ public class CIForwardProcessor {
 
 				sb.append(
 					_getTestSuiteStatusLine(
-						":warning:", "Not completed",
+						":warning:", "Not Completed",
 						requiredCompletedTestSuiteName));
 
 				continue;
@@ -868,8 +866,7 @@ public class CIForwardProcessor {
 					JenkinsResultsParserUtil.combine(
 						"This test suite failed. Fix the failures and push, ",
 						"then rerun the `/pr-check` Claude Code skill and ",
-						"publish the result with `/pr-check-publish` on the ",
-						"new commit before commenting `ci:forward` again."),
+						"publish the result with `/pr-check-publish`."),
 					requiredPassingTestSuiteName));
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -612,27 +612,36 @@ public class CIForwardProcessor {
 		return sb.toString();
 	}
 
-	private String _getPRCheckMessage() {
+	private String _getPRCheckStatusLine() {
 		if (_pullRequest.hasLabel("pr-check - skipped")) {
-			return JenkinsResultsParserUtil.combine(
-				"Pull requests with a skipped `pr-check` may not be ",
-				"forwarded. Please send this pull request manually using ",
-				"the `pr` Claude Code skill.");
+			return _getTestSuiteStatusLine(
+				":warning:",
+				JenkinsResultsParserUtil.combine(
+					"This pull request has a skipped `pr-check`. Please send ",
+					"this pull request manually using the `/pr` Claude Code ",
+					"skill."),
+				"pr-check");
 		}
 
 		if (_pullRequest.hasLabel("pr-check - failure") ||
 			_pullRequest.hasLabel("pr-check - success")) {
 
-			return JenkinsResultsParserUtil.combine(
-				"The `pr-check` result does not match the current head ",
-				"commit. Please rerun the `/pr-check` Claude Code skill ",
-				"and publish the result with `/pr-check-publish`.");
+			return _getTestSuiteStatusLine(
+				":warning:",
+				JenkinsResultsParserUtil.combine(
+					"The `pr-check` result is for a different commit. Please ",
+					"rerun the `/pr-check` Claude Code skill and publish the ",
+					"result with `/pr-check-publish` on the current commit."),
+				"pr-check");
 		}
 
-		return JenkinsResultsParserUtil.combine(
-			"This pull request has no `pr-check` result. Please run the ",
-			"`/pr-check` Claude Code skill and publish the result with ",
-			"`/pr-check-publish`.");
+		return _getTestSuiteStatusLine(
+			":x:",
+			JenkinsResultsParserUtil.combine(
+				"This pull request has no `pr-check` result. Please run the ",
+				"`/pr-check` Claude Code skill and publish the result with ",
+				"`/pr-check-publish`."),
+			"pr-check");
 	}
 
 	private String[] _getRequiredCompletedTestSuiteNames() throws IOException {
@@ -720,62 +729,110 @@ public class CIForwardProcessor {
 		return filteredComments;
 	}
 
+	private String _getTestSuiteStatusLine(
+		String marker, String message, String testSuiteName) {
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("- ");
+		sb.append(marker);
+		sb.append(" ");
+
+		if (testSuiteName.equals("pr-check")) {
+			sb.append("**pr-check**");
+		}
+		else {
+			sb.append("ci:test:**");
+			sb.append(testSuiteName);
+			sb.append("**");
+		}
+
+		sb.append(" - ");
+		sb.append(message);
+		sb.append("\n");
+
+		return sb.toString();
+	}
+
 	private String _getUnsuccessfulCommentBody() throws IOException {
 		StringBuilder sb = new StringBuilder();
+
+		sb.append("This pull request will not be forwarded to `");
+		sb.append(_recipientUsername);
+		sb.append("` because not all required checks passed:\n");
 
 		List<String> incompleteRequiredCompletedTestSuiteNames =
 			_getIncompleteRequiredCompletedTestSuiteNames();
 
-		if (!incompleteRequiredCompletedTestSuiteNames.isEmpty()) {
-			sb.append("Not all required test suite(s) completed:\n");
+		for (String requiredCompletedTestSuiteName :
+				_getRequiredCompletedTestSuiteNames()) {
 
-			for (String requiredCompletedTestSuiteName :
-					_getRequiredCompletedTestSuiteNames()) {
+			if (incompleteRequiredCompletedTestSuiteNames.contains(
+					requiredCompletedTestSuiteName)) {
 
-				sb.append("`");
-				sb.append(requiredCompletedTestSuiteName);
-				sb.append("`\n");
+				sb.append(
+					_getTestSuiteStatusLine(
+						":warning:", "Not completed",
+						requiredCompletedTestSuiteName));
+
+				continue;
 			}
+
+			sb.append(
+				_getTestSuiteStatusLine(
+					":white_check_mark:", "Completed",
+					requiredCompletedTestSuiteName));
 		}
 
 		List<String> failedRequiredPassingTestSuiteNames =
 			_getFailedRequiredPassingTestSuiteNames();
 
-		if (!failedRequiredPassingTestSuiteNames.isEmpty()) {
-			sb.append("Not all required test suite(s) passed:\n");
+		for (String requiredPassingTestSuiteName :
+				_getRequiredPassingTestSuiteNames()) {
 
-			for (String requiredPassingTestSuiteName :
-					_getRequiredPassingTestSuiteNames()) {
+			if (!failedRequiredPassingTestSuiteNames.contains(
+					requiredPassingTestSuiteName)) {
 
-				sb.append("`");
-				sb.append(requiredPassingTestSuiteName);
-				sb.append("`");
+				sb.append(
+					_getTestSuiteStatusLine(
+						":white_check_mark:", "Passed",
+						requiredPassingTestSuiteName));
 
-				if (requiredPassingTestSuiteName.equals("pr-check") &&
-					failedRequiredPassingTestSuiteNames.contains("pr-check")) {
-
-					sb.append(" - ");
-					sb.append(_getPRCheckMessage());
-				}
-
-				if (requiredPassingTestSuiteName.equals("stable")) {
-					sb.append(" - If you believe that the stable test ");
-					sb.append("failures were caused by flaky tests, please ");
-					sb.append("contact QA for confirmation and rerun the ");
-					sb.append("test.");
-				}
-
-				sb.append("\n");
+				continue;
 			}
+
+			if (requiredPassingTestSuiteName.equals("pr-check")) {
+				sb.append(_getPRCheckStatusLine());
+
+				continue;
+			}
+
+			if (requiredPassingTestSuiteName.equals("stable")) {
+				sb.append(
+					_getTestSuiteStatusLine(
+						":x:",
+						JenkinsResultsParserUtil.combine(
+							"This test suite failed. If you believe the ",
+							"failures were caused by flaky tests, please ",
+							"contact QA for confirmation and rerun the test."),
+						requiredPassingTestSuiteName));
+
+				continue;
+			}
+
+			sb.append(
+				_getTestSuiteStatusLine(
+					":x:",
+					JenkinsResultsParserUtil.combine(
+						"This test suite failed. Fix the failures and push, ",
+						"then rerun the `/pr-check` Claude Code skill and ",
+						"publish the result with `/pr-check-publish` on the ",
+						"new commit before commenting `ci:forward` again."),
+					requiredPassingTestSuiteName));
 		}
 
-		sb.append("\nPull request will not be forwarded to ");
-		sb.append("`");
-		sb.append(_recipientUsername);
-		sb.append("`.\n");
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(_consoleLogURL)) {
-			sb.append("[Console](");
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(_consoleLogURL)) {
+			sb.append("\n[Console](");
 			sb.append(_consoleLogURL);
 			sb.append(")\n");
 		}


### PR DESCRIPTION
## What

Makes the `ci:forward` "not forwarded" comment say, per required check, what passed, what blocked the forward, and what to do — instead of a bare list of suite names.

## How

- **Render each required check as a status line** — `getUnsuccessfulCommentBody` now renders one bullet per required check, each leading with a status marker (✅ passed / ⚠️ warning / ❌ failed), with actionable guidance for anything that blocks the forward.
- **Derive the pr-check status from its commit status** — the pr-check state is read from its commit status on the head commit, so a pr-check that failed on the current commit renders as a failure; the pr-check label is reserved for the out-of-sync and skipped cases. The head commit statuses are read in one place.
- **Wordsmith** — terse, consistent phrasing; `pr-check` treated as a proper noun.

Forward decision logic is unchanged — `execute()` already posts this comment when a pull request is ineligible to forward. The companion `liferay-jenkins-ee` change (LRCI-7713) makes the source-format completion path reach `execute()` so the comment is no longer silently skipped.

## Testing

`gradlew formatSource jar` and the module unit tests pass. The comment-body methods read head commit statuses over the network with no injection seam (no existing unit test for this class), so verification is via the rendered examples and a live forward-gate run.

Ticket: LRCI-7713
