### PR TITLE
LRCI-7718 Fold the skipped suites into the ci:forward comment

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/github/webhook/GitHubWebhookPayloadProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/github/webhook/GitHubWebhookPayloadProcessor.java
@@ -1814,8 +1814,6 @@ public class GitHubWebhookPayloadProcessor {
 				}
 			}
 
-			pullRequest.addComment(sb.toString());
-
 			List<String> skippedTestSuites = new ArrayList<>(
 				ciForwardRequiredTestSuites.length);
 
@@ -1824,19 +1822,11 @@ public class GitHubWebhookPayloadProcessor {
 
 				if (passingTestSuites.contains(ciForwardRequiredTestSuite)) {
 					skippedTestSuites.add(ciForwardRequiredTestSuite);
-
-					continue;
 				}
-
-				pullRequestTesterParameters.setCiTestSuiteName(
-					ciForwardRequiredTestSuite);
-
-				testPullRequest(pullRequestTesterParameters);
 			}
 
 			if (!skippedTestSuites.isEmpty()) {
-				sb = new StringBuilder();
-
+				sb.append("\n");
 				sb.append("Skipping previously passed test suites:\n");
 
 				for (String skippedTestSuite : skippedTestSuites) {
@@ -1844,12 +1834,21 @@ public class GitHubWebhookPayloadProcessor {
 					sb.append(skippedTestSuite);
 					sb.append("`\n");
 				}
+			}
 
-				if (_log.isInfoEnabled()) {
-					_log.info(sb.toString());
+			pullRequest.addComment(sb.toString());
+
+			for (String ciForwardRequiredTestSuite :
+					ciForwardRequiredTestSuites) {
+
+				if (skippedTestSuites.contains(ciForwardRequiredTestSuite)) {
+					continue;
 				}
 
-				pullRequest.addComment(sb.toString());
+				pullRequestTesterParameters.setCiTestSuiteName(
+					ciForwardRequiredTestSuite);
+
+				testPullRequest(pullRequestTesterParameters);
 			}
 
 			if (_ciForwardEligible) {


### PR DESCRIPTION
## What

A single `ci:forward` posts two comments: the "CI is automatically triggering …" trigger comment, then a separate "Skipping previously passed test suites:" comment. This folds the skipped suites into the trigger comment so `ci:forward` posts one comment instead of two.

## How

The skipped (previously passing) suites are determined from `getPassingTestSuites()`, which is already computed for the forward-eligibility check — so this needs no additional requests. The skip list is appended to the trigger comment before it is posted, and the suite-invocation loop is split out so it no longer drives a second comment.

Suite-checking logic is unchanged — which suites are triggered vs skipped is identical; only the comment composition changes.

Ticket: LRCI-7718 (subtask of LRCI-7713)
