### PR TITLE
LPD-95275 Skip Full Portal Build for portal.properties-only changes

### DIFF
--- a/.claude/skills/pr-check/validations/full-portal-build.md
+++ b/.claude/skills/pr-check/validations/full-portal-build.md
@@ -4,6 +4,8 @@
 
 - portal-core changed: `portal-impl/**`, `portal-kernel/**`, `portal-test/**`, `portal-web/**`, `support-tomcat/**`, `util-bridges/**`, `util-java/**`, `util-slf4j/**`, `util-taglib/**`. Mandatory in this case — no Gradle deploy path covers these sources.
 
+	A portal-core change consisting solely of `*.properties` files — for example, a feature-flag line added to `portal-impl/src/portal.properties` — does not fire this validation. Properties carry no compilable source, and they remain covered by Source Format and Structural Smoke.
+
 - OR the deploy set is large enough that one full build is cheaper than per-module deploys. Compare:
 
 	- **Full Portal Build cost** = 8 min (the `ant all` baseline).


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95275

## What Is Being Fixed

The pr-check Full Portal Build validation triggers `ant all` on any portal-core change. A feature-flag line added to `portal-impl/src/portal.properties` matches the portal-core trigger, but a properties file carries no compilable source, so the full build yields no signal while costing roughly eight minutes.

## How It Is Being Fixed

The Full Portal Build validation's Trigger gains an exemption: a portal-core change consisting solely of `*.properties` files does not fire the validation. Source Format and Structural Smoke still cover those files, so nothing is lost. The wording follows the existing "does not fire this validation" convention used by the other validation docs.

## Why Are There No Tests?

This change only edits a Markdown documentation file under `.claude/skills/pr-check`; there is no code to test.

## PR Check

**pr-check: PASS** — tested on `2fdd880584dc9fd1f8a5e65c4e1de518f450a717`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "2fdd880584dc9fd1f8a5e65c4e1de518f450a717"} -->
