### PR TITLE
LPD-95275 Skip Full Portal Build for properties-only changes

### DIFF
--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -78,6 +78,7 @@ In your next turn, compose a single bash script that:
 
 - computes the diff: `git diff --name-only "$(git merge-base HEAD master)...HEAD"`
 - for each validation, tests its regex against the diff and prints the validation name when it fires (a leading `!` in the regex inverts: fire when any diff path does *not* match the rest)
+- ` &! ` in the regex splits it into an include side and an exclude side. The validation fires when a diff path matches the include side but not the exclude side.
 - runs as a single Bash tool invocation
 
 From the script's output, sum the matched validations' `## Time Estimate` values for the cumulative total. The matching is mechanical; consult each file's prose `## Trigger` only when a result needs human-judgment context (e.g., Service Builder output-only catch-up).

--- a/.claude/skills/pr-check/validations/full-portal-build.md
+++ b/.claude/skills/pr-check/validations/full-portal-build.md
@@ -16,7 +16,7 @@
 
 ## Match
 
-`^(portal-impl|portal-kernel|portal-test|portal-web|support-tomcat|util-bridges|util-java|util-slf4j|util-taglib)/`
+`^(portal-impl|portal-kernel|portal-test|portal-web|support-tomcat|util-bridges|util-java|util-slf4j|util-taglib)/ &! \.properties$`
 
 ## Command
 

--- a/.claude/skills/pr-check/validations/full-portal-build.md
+++ b/.claude/skills/pr-check/validations/full-portal-build.md
@@ -4,7 +4,7 @@
 
 - portal-core changed: `portal-impl/**`, `portal-kernel/**`, `portal-test/**`, `portal-web/**`, `support-tomcat/**`, `util-bridges/**`, `util-java/**`, `util-slf4j/**`, `util-taglib/**`. Mandatory in this case — no Gradle deploy path covers these sources.
 
-	A portal-core change consisting solely of `*.properties` files — for example, a feature-flag line added to `portal-impl/src/portal.properties` — does not fire this validation. Properties carry no compilable source, and they remain covered by Source Format and Structural Smoke.
+	A portal-core change of only `*.properties` files does not fire this validation. `ant all` gives no signal for them, and **Source Format** covers them instead.
 
 - OR the deploy set is large enough that one full build is cheaper than per-module deploys. Compare:
 

--- a/.claude/skills/pr-check/validations/full-portal-build.md
+++ b/.claude/skills/pr-check/validations/full-portal-build.md
@@ -4,6 +4,8 @@
 
 - portal-core changed: `portal-impl/**`, `portal-kernel/**`, `portal-test/**`, `portal-web/**`, `support-tomcat/**`, `util-bridges/**`, `util-java/**`, `util-slf4j/**`, `util-taglib/**`. Mandatory in this case — no Gradle deploy path covers these sources.
 
+	A portal-core change consisting solely of `*.properties` files — for example, a feature-flag line added to `portal-impl/src/portal.properties` — does not fire this validation. Properties carry no compilable source, and they remain covered by Source Format and Structural Smoke.
+
 - OR the deploy set is large enough that one full build is cheaper than per-module deploys. Compare:
 
 	- **Full Portal Build cost** = 8 min (the `ant all` baseline).


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95275

## What Is Being Fixed

The Full Portal Build validation triggers `ant all` on any portal-core change, including a change that only edits `*.properties` files (for example a feature-flag line in `portal-impl/src/portal.properties`). `ant all` validates no properties content, so the ~8 minute build produces no signal.

## How It Is Being Fixed

Pass 1 matching gains an `&!` and-not operator: a `## Match` value split on ` &! ` fires only when a diff path matches the include side but not the exclude side. Full Portal Build uses it to skip changes whose every portal-core file is a `*.properties` file, while still firing when a non-`*.properties` file is also touched. Source Format continues to cover properties files.

This supersedes #2118, which added the exemption as `## Trigger` prose only — the `## Match` regex still matched, so it never took effect. That commit is kept as the base here, with the matcher change layered on top.

## Why Are There No Tests?

The change edits Markdown under `.claude/skills/pr-check`; the matcher is exercised by the skill itself.

cc @victorg1991 — original author of the base commit (#2118).
