### PR TITLE
LRCI-7729 Add three pr-check coverage gaps surfaced by the upstream failure analysis

### DIFF
--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -44,6 +44,8 @@ The procedure runs in two passes over the validations, in the order below. The o
 
 1. [Module Registration](validations/module-registration.md)
 
+1. [Portlet Title](validations/portlet-title.md)
+
 1. [Full Portal Build](validations/full-portal-build.md)
 
 1. [Per-Module Compile](validations/per-module-compile.md)

--- a/.claude/skills/pr-check/validations/baseline.md
+++ b/.claude/skills/pr-check/validations/baseline.md
@@ -2,19 +2,19 @@
 
 ## Trigger
 
-An exported-package API changed: Java under an `*-api` module, a `bnd.bnd` with an `Export-Package`, or a `packageinfo`. The bnd baseline task diffs the exported API against the last release and fails on a missing or excessive `Bundle-Version`/`packageinfo` bump — which no drift check sees, since the `bnd.bnd` carrying the bump never changes.
+An exported package API changed: Java under an `*-api` module or `portal-kernel`, a `bnd.bnd` with an `Export-Package`, or a `packageinfo`. The bnd baseline task diffs the exported API against the last release and fails on a missing or excessive `Bundle-Version`/`packageinfo` bump — which no drift check sees, since the `bnd.bnd` carrying the bump never changes.
 
 ## Match
 
-`^modules/.+-api/.+\.java$|(^|/)bnd\.bnd$|(^|/)packageinfo$`
+`^modules/.+-api/.+\.java$|^portal-kernel/src/.+\.java$|(^|/)bnd\.bnd$|(^|/)packageinfo$`
 
 ## Selection
 
-Run only on modules whose `bnd.bnd` declares `Export-Package` (the task no-ops otherwise) and whose `Bundle-Version` is above `1.0.0` (baseline is skipped below that). `portal-kernel` is Ant-built, not a Gradle module, so it is out of scope here.
+The Nexus baseline task runs only on modules whose `bnd.bnd` declares `Export-Package` (the task does nothing otherwise) and whose `Bundle-Version` is above `1.0.0` (baseline is skipped below that). `portal-kernel` is Ant built, not a Gradle module, so it is out of scope for that task — but the local version check below does cover it.
 
 ## Command
 
-Per selected module, with its directory converted to a Gradle project path:
+Run the Nexus baseline task per selected module, with its directory converted to a Gradle project path:
 
 ```bash
 ("${REPO_ROOT}/gradlew" \
@@ -24,6 +24,12 @@ Per selected module, with its directory converted to a Gradle project path:
 ```
 
 A nonempty `modules/<module>/build/reports/baseline/baseline.log` is a FAIL; empty is a PASS. The task builds the module jar and resolves the last released artifact from Nexus, so it requires network access.
+
+### Local Version Check
+
+This needs no network and reports an advisory note, never a PASS or FAIL.
+
+Look at each changed `.java` under an `*-api` module's `src/main/java` or under `portal-kernel/src`. When its diff adds or removes a `public` or `protected` line, the exported API changed, so the version should be bumped too. The bump shows up in the diff as a changed `packageinfo`, or a changed `bnd.bnd` `Bundle-Version` for an `*-api` module. If neither changed, flag the package: the API changed but the version did not. Network access is the only thing the Nexus task above adds.
 
 ## Checklist
 

--- a/.claude/skills/pr-check/validations/javascript-unit-test.md
+++ b/.claude/skills/pr-check/validations/javascript-unit-test.md
@@ -24,6 +24,8 @@ Locate the counterpart spec by parallel name: `Foo.tsx` → `Foo.test.tsx` or `F
 
 **Lockfile changes.** When `package-lock.json` or `yarn.lock` is in the diff, run the module's full Jest suite regardless of size — parallel-name lookup yields nothing for a lockfile, and a transitive-dependency pin can affect any code path that touches the runtime, so the blast radius is the whole module.
 
+**Test directory changes.** When any file under a module's `test`, `tests`, or `__tests__` directory changes — not only `*.test.*` or `*.spec.*` files — run the full Jest suite, since a stray fixture caught by the `jest.testMatch` glob fails the run on its own.
+
 **Deletion handling.** A deleted JS or TS file has no parallel-name counterpart to run, but its consumers can still break. Two layered checks:
 
 1. **Consumer search.** For each deleted file, grep the surrounding module for `import` statements that reference the deleted basename or relative path. For every consumer found, queue the consumer's parallel-name spec (and the consumer's spec itself when it is the consumer). This catches direct-import breakage where a surviving spec imports a now-deleted source.

--- a/.claude/skills/pr-check/validations/portlet-title.md
+++ b/.claude/skills/pr-check/validations/portlet-title.md
@@ -1,0 +1,25 @@
+# Portlet Title
+
+## Trigger
+
+A new portlet is registered through an added `jakarta.portlet.name=` property in a `@Component`. Each portlet needs a matching `jakarta.portlet.title.<portlet name>` key, in the global `portal-language-lang` `Language.properties` or in the module's own `content/Language.properties`. A missing key fails `PortletTitleTest`, which lives in a separate test module the PR never touches, so nothing else here catches it.
+
+## Match
+
+`(^|/)[^/]+Portlet\.java$`
+
+## Command
+
+This check is static and needs no build. List the added `jakarta.portlet.name=` lines:
+
+```bash
+git diff "$(git merge-base HEAD master)...HEAD" -- '*.java'
+```
+
+For each line, work out the portlet name from a string literal or from the value of a referenced `*PortletKeys` constant, reading that constant and joining its string fragments when needed. Then confirm that a `jakarta.portlet.title.<name>=` line exists in the global `portal-language-lang` `Language.properties` or in the module's own `content/Language.properties`, and report any missing key as a FAIL.
+
+Like `PortletTitleTest`, skip `ObjectDefinitionsPortlet` names, whose title comes from the object definition rather than a key.
+
+## Time Estimate
+
+~10-30 sec (static; no build).


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7729

Adds three `pr-check` validations beyond the G1–G7 set from LRCI-7643, each surfaced by the upstream master failure analysis.

- **Portlet Title** (new): flags a new `jakarta.portlet.name=` registration whose `jakarta.portlet.title.<rootPortletId>` key is missing from `portal-language-lang` or the module's own `content/Language.properties` — the static equivalent of `PortletTitleTest`. Evidence: LPD-94560.
- **JavaScript Unit Tests** (refined): runs the full Jest suite on any change under `test`/`tests`/`__tests__`, not only `*.test.*`/`*.spec.*`, catching a non spec fixture swept up by the jest glob. Evidence: LPD-92661.
- **Baseline** (strengthened): a Nexus free heuristic that flags an exported signature change in an `*-api` module or `portal-kernel` with no `packageinfo`/`Bundle-Version` bump, reported as an advisory note. Evidence: kernel version increase on CountryLocalService/RegionLocalService.

Each validation was reproduced locally.