### PR TITLE
LRCI-7742 Add an injectable UrlReader read seam

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -52,9 +52,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
@@ -99,9 +96,6 @@ import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
-
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -5108,352 +5102,9 @@ public class JenkinsResultsParserUtil {
 			int retryPeriod, int timeout, HTTPAuthorization httpAuthorization)
 		throws IOException {
 
-		if (url.contains("/userContent/") && (timeout == 0)) {
-			timeout = 5000;
-		}
-
-		if (httpRequestMethod == null) {
-			if (postContent != null) {
-				httpRequestMethod = HttpRequestMethod.POST;
-			}
-			else {
-				httpRequestMethod = HttpRequestMethod.GET;
-			}
-		}
-
-		url = fixURL(url);
-
-		if (url.startsWith("file:")) {
-			url = fixFileURL(url);
-		}
-		else {
-			if (checkCache) {
-				if (debug) {
-					System.out.println("Loading " + url);
-				}
-
-				File cachedFile = getCacheFile(
-					generateToStringCacheKey(url, postContent));
-
-				if ((cachedFile != null) && cachedFile.exists()) {
-					return new FileInputStream(cachedFile);
-				}
-			}
-		}
-
-		boolean gitHubAPICall = false;
-		int retryCount = 0;
-
-		while (true) {
-			URLConnection urlConnection = null;
-
-			try {
-				if (debug) {
-					System.out.println("Downloading " + url);
-				}
-
-				Matcher matcher = _gitHubAPIURLPattern.matcher(url);
-
-				if (matcher.matches()) {
-					gitHubAPICall = true;
-
-					if (_updatingHttpRequestMethods.contains(
-							httpRequestMethod)) {
-
-						Properties buildProperties = getBuildProperties();
-
-						url =
-							buildProperties.getProperty("github.api.proxy") +
-								matcher.group(1);
-					}
-				}
-
-				if ((httpAuthorization == null) &&
-					(gitHubAPICall ||
-					 url.startsWith(
-						 "https://raw.githubusercontent.com/liferay/"))) {
-
-					Properties buildProperties = getBuildProperties();
-
-					httpAuthorization = new TokenHTTPAuthorization(
-						buildProperties.getProperty("github.access.token"));
-				}
-
-				if ((httpAuthorization == null) &&
-					url.startsWith("https://release.liferay.com")) {
-
-					httpAuthorization = getJenkinsHTTPAuthorization();
-				}
-
-				if ((httpAuthorization == null) &&
-					url.matches(
-						"https?:\\/\\/test-[135]-\\d+(?:\\.liferay\\.com)?.*?" +
-							"|http:\\/\\/localhost:8081.*?")) {
-
-					if (isCINode()) {
-						url = getLocalURL(url);
-					}
-					else {
-						url = getRemoteURL(url);
-					}
-
-					httpAuthorization = getJenkinsHTTPAuthorization();
-				}
-
-				boolean testray1Request = false;
-
-				if (url.matches("https://testray-old.liferay.com/?.+")) {
-					testray1Request = true;
-				}
-
-				if ((httpAuthorization == null) && testray1Request) {
-					Properties buildProperties = getBuildProperties();
-
-					httpAuthorization = new BasicHTTPAuthorization(
-						getProperty(
-							buildProperties, "testray.admin.user.password"),
-						getProperty(
-							buildProperties, "testray.admin.user.name"));
-				}
-
-				Matcher testray2URLMatcher = _testray2URLPattern.matcher(url);
-
-				if ((httpAuthorization == null) && testray2URLMatcher.find() &&
-					!url.contains("/o/oauth2/token")) {
-
-					Properties buildProperties = getBuildProperties();
-
-					URL tokenURL = new URL(
-						testray2URLMatcher.group("baseURL") +
-							"/o/oauth2/token");
-
-					String lxcEnvironment = testray2URLMatcher.group(
-						"lxcEnvironment");
-
-					String clientId = getProperty(
-						buildProperties, "testray.oauth2.client.id",
-						lxcEnvironment);
-					String clientSecret = getProperty(
-						buildProperties, "testray.oauth2.client.secret",
-						lxcEnvironment);
-
-					httpAuthorization = new ClientCredentialsHTTPAuthorization(
-						clientId, clientSecret, tokenURL);
-				}
-
-				URL urlObject = new URL(url);
-
-				urlConnection = urlObject.openConnection();
-
-				if (urlConnection instanceof HttpURLConnection) {
-					HttpURLConnection httpURLConnection =
-						(HttpURLConnection)urlConnection;
-
-					if (httpRequestMethod == HttpRequestMethod.PATCH) {
-						httpURLConnection.setRequestMethod("POST");
-
-						httpURLConnection.setRequestProperty(
-							"X-HTTP-Method-Override", "PATCH");
-					}
-					else {
-						httpURLConnection.setRequestMethod(
-							httpRequestMethod.name());
-					}
-
-					if (gitHubAPICall &&
-						(httpURLConnection instanceof HttpsURLConnection)) {
-
-						SSLContext sslContext = null;
-
-						try {
-							if (getJavaVersionNumber() < 1.8F) {
-								sslContext = SSLContext.getInstance("TLSv1.2");
-
-								sslContext.init(null, null, null);
-
-								HttpsURLConnection httpsURLConnection =
-									(HttpsURLConnection)httpURLConnection;
-
-								httpsURLConnection.setSSLSocketFactory(
-									sslContext.getSocketFactory());
-							}
-						}
-						catch (KeyManagementException | NoSuchAlgorithmException
-									exception) {
-
-							throw new RuntimeException(
-								"Unable to set SSL context to TLS v1.2",
-								exception);
-						}
-					}
-
-					if (httpAuthorization != null) {
-						httpURLConnection.setRequestProperty(
-							"accept", "application/json");
-						httpURLConnection.setRequestProperty(
-							"Authorization", httpAuthorization.toString());
-
-						if (!testray1Request) {
-							httpURLConnection.setRequestProperty(
-								"Content-Type", "application/json");
-						}
-					}
-
-					if (url.contains("/oauth2/")) {
-						httpURLConnection.setRequestProperty(
-							"accept", "application/json");
-						httpURLConnection.setRequestProperty(
-							"Content-Type",
-							"application/x-www-form-urlencoded");
-					}
-
-					if (url.startsWith("https://releases-cdn.liferay.com")) {
-						httpURLConnection.setRequestProperty("User-Agent", "");
-					}
-
-					if (postContent != null) {
-						if (httpRequestMethod == null) {
-							httpURLConnection.setRequestMethod("POST");
-						}
-
-						httpURLConnection.setDoOutput(true);
-
-						try (OutputStream outputStream =
-								httpURLConnection.getOutputStream()) {
-
-							outputStream.write(postContent.getBytes("UTF-8"));
-
-							outputStream.flush();
-						}
-					}
-				}
-
-				if (timeout != 0) {
-					urlConnection.setConnectTimeout(timeout);
-					urlConnection.setReadTimeout(timeout);
-				}
-
-				urlConnection.connect();
-
-				if (gitHubAPICall) {
-					try {
-						int limit = Integer.parseInt(
-							urlConnection.getHeaderField("X-RateLimit-Limit"));
-						int remaining = Integer.parseInt(
-							urlConnection.getHeaderField(
-								"X-RateLimit-Remaining"));
-						long reset = Long.parseLong(
-							urlConnection.getHeaderField("X-RateLimit-Reset"));
-
-						System.out.println(
-							combine(
-								getGitHubAPIRateLimitStatusMessage(
-									limit, remaining, reset),
-								"\n    ", url));
-					}
-					catch (Exception exception) {
-						System.out.println(
-							combine(
-								"Unable to parse GitHub API rate limit headers",
-								"\nURL:\n    ", url));
-
-						exception.printStackTrace();
-					}
-				}
-
-				return urlConnection.getInputStream();
-			}
-			catch (IOException ioException) {
-				if (ioException instanceof FileNotFoundException) {
-					throw ioException;
-				}
-
-				if ((ioException instanceof UnknownHostException) &&
-					url.matches("http://test-\\d+-\\d+/.*")) {
-
-					return toInputStream(
-						url.replaceAll(
-							"http://(test-\\d+-\\d+)(/.*)",
-							"https://$1.liferay.com$2"),
-						checkCache, maxRetries, httpRequestMethod, postContent,
-						retryPeriod, timeout, httpAuthorization);
-				}
-
-				String exceptionMessage = ioException.getMessage();
-
-				if (exceptionMessage.matches(
-						".*HTTP response code\\: 422 .*") &&
-					(urlConnection != null)) {
-
-					StringBuilder sb = new StringBuilder();
-
-					sb.append(exceptionMessage);
-					sb.append("\n");
-
-					if (!isNullOrEmpty(postContent)) {
-						sb.append("Post content:\n");
-						sb.append(postContent);
-					}
-
-					System.out.println(sb.toString());
-
-					throw new RuntimeException(exceptionMessage, ioException);
-				}
-
-				Integer retryPeriodOverride = null;
-
-				if (exceptionMessage.matches(
-						".*HTTP response code\\: 403 .*") &&
-					(urlConnection != null)) {
-
-					try {
-						retryPeriodOverride = Integer.parseInt(
-							urlConnection.getHeaderField("retry-after"));
-					}
-					catch (NumberFormatException numberFormatException) {
-						retryPeriodOverride = null;
-					}
-
-					if ((retryPeriodOverride == null) ||
-						(retryPeriodOverride == 0)) {
-
-						retryPeriodOverride = retryPeriod;
-
-						for (int i = 0; i < retryCount; i++) {
-							retryPeriodOverride *= retryPeriodOverride;
-						}
-					}
-
-					if (((maxRetries >= 0) && (retryCount >= maxRetries)) ||
-						(retryPeriodOverride > _SECONDS_RETRY_PERIOD_MAX)) {
-
-						throw new GitHubSecondaryRateLimitRuntimeException(
-							url, retryPeriodOverride, ioException);
-					}
-				}
-
-				long retryPeriodMillis = 1000 * retryPeriod;
-
-				if ((retryPeriodOverride != null) &&
-					(retryPeriodOverride > 0)) {
-
-					retryPeriodMillis = 1000 * retryPeriodOverride;
-				}
-
-				if ((maxRetries >= 0) && (retryCount >= maxRetries)) {
-					throw ioException;
-				}
-
-				System.out.println(
-					combine(
-						"Retrying ", url, " in ",
-						toDurationString(retryPeriodMillis)));
-
-				retryCount++;
-
-				sleep(retryPeriodMillis);
-			}
-		}
+		return UrlReader.doRead(
+			url, checkCache, maxRetries, httpRequestMethod, postContent,
+			retryPeriod, timeout, httpAuthorization);
 	}
 
 	public static JSONArray toJSONArray(String url) throws IOException {
@@ -7247,8 +6898,6 @@ public class JenkinsResultsParserUtil {
 
 	private static final int _SECONDS_RETRY_PERIOD_DEFAULT = 5;
 
-	private static final int _SECONDS_RETRY_PERIOD_MAX = 60 * 30;
-
 	private static final String _UPSTREAM_USER_NAME_DEFAULT = "liferay";
 
 	private static final String _URL_CACHE_MIRROR_DEFAULT =
@@ -7292,8 +6941,6 @@ public class JenkinsResultsParserUtil {
 	private static final List<String> _forbiddenRedactTokens = Arrays.asList(
 		"admin", "liferay", "test");
 	private static JSONArray _gitDirectoriesJSONArray;
-	private static final Pattern _gitHubAPIURLPattern = Pattern.compile(
-		"https\\:\\/\\/api\\.github\\.com(.*)");
 	private static final DateFormat _gitHubDateFormat;
 	private static final Pattern _gitSHAPattern = Pattern.compile(
 		"^([0-9a-fA-F]{6}|[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$");
@@ -7347,15 +6994,8 @@ public class JenkinsResultsParserUtil {
 
 	private static final Pattern _test1MasterNamePattern = Pattern.compile(
 		"test-1-(\\d+)");
-	private static final Pattern _testray2URLPattern = Pattern.compile(
-		"(?<baseURL>https://webserver-testray2(-(?<lxcEnvironment>.+))?" +
-			"\\.lfr\\.cloud|https://testray\\.liferay\\.com).*");
 	private static final Set<String> _timeStamps = new HashSet<>();
 	private static Set<String> _topLevelJobNames;
-	private static final List<HttpRequestMethod> _updatingHttpRequestMethods =
-		Arrays.asList(
-			HttpRequestMethod.POST, HttpRequestMethod.PATCH,
-			HttpRequestMethod.PUT, HttpRequestMethod.DELETE);
 	private static final Pattern _urlQueryStringPattern = Pattern.compile(
 		"\\&??(\\w++)=([^\\&]*)");
 	private static final File _userHomeDir = new File(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5102,7 +5102,7 @@ public class JenkinsResultsParserUtil {
 			int retryPeriod, int timeout, HTTPAuthorization httpAuthorization)
 		throws IOException {
 
-		return UrlReader.doRead(
+		return UrlReader.read(
 			checkCache, httpAuthorization, httpRequestMethod, maxRetries,
 			postContent, retryPeriod, timeout, url);
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5103,8 +5103,8 @@ public class JenkinsResultsParserUtil {
 		throws IOException {
 
 		return UrlReader.doRead(
-			url, checkCache, maxRetries, httpRequestMethod, postContent,
-			retryPeriod, timeout, httpAuthorization);
+			checkCache, httpAuthorization, httpRequestMethod, maxRetries,
+			postContent, retryPeriod, timeout, url);
 	}
 
 	public static JSONArray toJSONArray(String url) throws IOException {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -650,8 +650,7 @@ public class JenkinsResultsParserUtil {
 			httpURLConnection.setDoOutput(true);
 			httpURLConnection.setRequestMethod("POST");
 
-			HTTPAuthorization httpAuthorization =
-				_getJenkinsHTTPAuthorization();
+			HTTPAuthorization httpAuthorization = getJenkinsHTTPAuthorization();
 
 			httpURLConnection.setRequestProperty(
 				"Authorization", httpAuthorization.toString());
@@ -712,8 +711,7 @@ public class JenkinsResultsParserUtil {
 
 			httpURLConnection.setRequestMethod("HEAD");
 
-			HTTPAuthorization httpAuthorization =
-				_getJenkinsHTTPAuthorization();
+			HTTPAuthorization httpAuthorization = getJenkinsHTTPAuthorization();
 
 			httpURLConnection.setRequestProperty(
 				"Authorization", httpAuthorization.toString());
@@ -995,6 +993,20 @@ public class JenkinsResultsParserUtil {
 		}
 
 		return flattenedBuilds;
+	}
+
+	public static String generateToStringCacheKey(
+		String urlString, String postContent) {
+
+		String key = fixURL(urlString);
+
+		key.replace("//", "/");
+
+		if (!isNullOrEmpty(postContent)) {
+			key += postContent;
+		}
+
+		return key;
 	}
 
 	public static String getActualResult(String buildURL) throws IOException {
@@ -1939,7 +1951,7 @@ public class JenkinsResultsParserUtil {
 
 			jsonObject = jsonObject.getJSONObject("rate");
 
-			return _getGitHubAPIRateLimitStatusMessage(
+			return getGitHubAPIRateLimitStatusMessage(
 				jsonObject.getInt("limit"), jsonObject.getInt("remaining"),
 				jsonObject.getLong("reset"));
 		}
@@ -1948,6 +1960,21 @@ public class JenkinsResultsParserUtil {
 		}
 
 		return "";
+	}
+
+	public static String getGitHubAPIRateLimitStatusMessage(
+		int limit, int remaining, long reset) {
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(remaining);
+		sb.append(" GitHub API calls out of ");
+		sb.append(limit);
+		sb.append(" remain. GitHub API call limit will reset in ");
+		sb.append(toDurationString((1000 * reset) - getCurrentTimeMillis()));
+		sb.append(".");
+
+		return sb.toString();
 	}
 
 	public static String getGitHubApiSearchUrl(List<String> filters) {
@@ -2317,6 +2344,14 @@ public class JenkinsResultsParserUtil {
 		}
 
 		return _URL_JENKINS_GITHUB_DEFAULT;
+	}
+
+	public static HTTPAuthorization getJenkinsHTTPAuthorization()
+		throws IOException {
+
+		return new BasicHTTPAuthorization(
+			getBuildProperty("jenkins.admin.user.token"),
+			getBuildProperty("jenkins.admin.user.name"));
 	}
 
 	public static String getJenkinsLoadBalancerURL() {
@@ -3637,8 +3672,7 @@ public class JenkinsResultsParserUtil {
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();
 
-			HTTPAuthorization httpAuthorization =
-				_getJenkinsHTTPAuthorization();
+			HTTPAuthorization httpAuthorization = getJenkinsHTTPAuthorization();
 
 			httpURLConnection.setRequestProperty(
 				"Authorization", httpAuthorization.toString());
@@ -5099,7 +5133,7 @@ public class JenkinsResultsParserUtil {
 				}
 
 				File cachedFile = getCacheFile(
-					_generateToStringCacheKey(url, postContent));
+					generateToStringCacheKey(url, postContent));
 
 				if ((cachedFile != null) && cachedFile.exists()) {
 					return new FileInputStream(cachedFile);
@@ -5148,7 +5182,7 @@ public class JenkinsResultsParserUtil {
 				if ((httpAuthorization == null) &&
 					url.startsWith("https://release.liferay.com")) {
 
-					httpAuthorization = _getJenkinsHTTPAuthorization();
+					httpAuthorization = getJenkinsHTTPAuthorization();
 				}
 
 				if ((httpAuthorization == null) &&
@@ -5163,7 +5197,7 @@ public class JenkinsResultsParserUtil {
 						url = getRemoteURL(url);
 					}
 
-					httpAuthorization = _getJenkinsHTTPAuthorization();
+					httpAuthorization = getJenkinsHTTPAuthorization();
 				}
 
 				boolean testray1Request = false;
@@ -5313,7 +5347,7 @@ public class JenkinsResultsParserUtil {
 
 						System.out.println(
 							combine(
-								_getGitHubAPIRateLimitStatusMessage(
+								getGitHubAPIRateLimitStatusMessage(
 									limit, remaining, reset),
 								"\n    ", url));
 					}
@@ -5803,7 +5837,7 @@ public class JenkinsResultsParserUtil {
 
 					if (checkCache && !url.startsWith("file:")) {
 						saveToCacheFile(
-							_generateToStringCacheKey(url, postContent),
+							generateToStringCacheKey(url, postContent),
 							content);
 					}
 
@@ -6574,20 +6608,6 @@ public class JenkinsResultsParserUtil {
 		return sb.toString();
 	}
 
-	private static String _generateToStringCacheKey(
-		String urlString, String postContent) {
-
-		String key = fixURL(urlString);
-
-		key.replace("//", "/");
-
-		if (!isNullOrEmpty(postContent)) {
-			key += postContent;
-		}
-
-		return key;
-	}
-
 	private static synchronized String _getCacheURL() {
 		if (_cacheURL != null) {
 			return _cacheURL;
@@ -6817,21 +6837,6 @@ public class JenkinsResultsParserUtil {
 		return null;
 	}
 
-	private static String _getGitHubAPIRateLimitStatusMessage(
-		int limit, int remaining, long reset) {
-
-		StringBuilder sb = new StringBuilder();
-
-		sb.append(remaining);
-		sb.append(" GitHub API calls out of ");
-		sb.append(limit);
-		sb.append(" remain. GitHub API call limit will reset in ");
-		sb.append(toDurationString((1000 * reset) - getCurrentTimeMillis()));
-		sb.append(".");
-
-		return sb.toString();
-	}
-
 	private static synchronized JSONArray _getGitWorkingDirectoriesJSONArray() {
 		if (_gitWorkingDirectoriesJSONArray != null) {
 			return _gitWorkingDirectoriesJSONArray;
@@ -6863,14 +6868,6 @@ public class JenkinsResultsParserUtil {
 		}
 
 		return _gitWorkingDirectoriesJSONArray;
-	}
-
-	private static HTTPAuthorization _getJenkinsHTTPAuthorization()
-		throws IOException {
-
-		return new BasicHTTPAuthorization(
-			getBuildProperty("jenkins.admin.user.token"),
-			getBuildProperty("jenkins.admin.user.name"));
 	}
 
 	private static String _getJenkinsRepositoryURL() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+/**
+ * @author Kenji Heigel
+ */
+public class UrlReader {
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -40,7 +40,22 @@ import javax.net.ssl.SSLContext;
  */
 public class UrlReader {
 
-	public static InputStream doRead(
+	public static InputStream read(
+			boolean checkCache, HTTPAuthorization httpAuthorization,
+			HttpRequestMethod httpRequestMethod, int maxRetries,
+			String postContent, int retryPeriod, int timeout, String url)
+		throws IOException {
+
+		return _urlReader.doRead(
+			checkCache, httpAuthorization, httpRequestMethod, maxRetries,
+			postContent, retryPeriod, timeout, url);
+	}
+
+	public static void setInstance(UrlReader urlReader) {
+		_urlReader = urlReader;
+	}
+
+	protected InputStream doRead(
 			boolean checkCache, HTTPAuthorization httpAuthorization,
 			HttpRequestMethod httpRequestMethod, int maxRetries,
 			String postContent, int retryPeriod, int timeout, String url)
@@ -417,5 +432,6 @@ public class UrlReader {
 		Arrays.asList(
 			HttpRequestMethod.POST, HttpRequestMethod.PATCH,
 			HttpRequestMethod.PUT, HttpRequestMethod.DELETE);
+	private static volatile UrlReader _urlReader = new UrlReader();
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -5,8 +5,417 @@
 
 package com.liferay.jenkins.results.parser;
 
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.BasicHTTPAuthorization;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HTTPAuthorization;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HttpRequestMethod;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.TokenHTTPAuthorization;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.UnknownHostException;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+
 /**
  * @author Kenji Heigel
  */
 public class UrlReader {
+
+	public static InputStream doRead(
+			String url, boolean checkCache, int maxRetries,
+			HttpRequestMethod httpRequestMethod, String postContent,
+			int retryPeriod, int timeout, HTTPAuthorization httpAuthorization)
+		throws IOException {
+
+		if (url.contains("/userContent/") && (timeout == 0)) {
+			timeout = 5000;
+		}
+
+		if (httpRequestMethod == null) {
+			if (postContent != null) {
+				httpRequestMethod = HttpRequestMethod.POST;
+			}
+			else {
+				httpRequestMethod = HttpRequestMethod.GET;
+			}
+		}
+
+		url = JenkinsResultsParserUtil.fixURL(url);
+
+		if (url.startsWith("file:")) {
+			url = JenkinsResultsParserUtil.fixFileURL(url);
+		}
+		else {
+			if (checkCache) {
+				if (JenkinsResultsParserUtil.debug) {
+					System.out.println("Loading " + url);
+				}
+
+				File cachedFile = JenkinsResultsParserUtil.getCacheFile(
+					JenkinsResultsParserUtil.generateToStringCacheKey(
+						url, postContent));
+
+				if ((cachedFile != null) && cachedFile.exists()) {
+					return new FileInputStream(cachedFile);
+				}
+			}
+		}
+
+		boolean gitHubAPICall = false;
+		int retryCount = 0;
+
+		while (true) {
+			URLConnection urlConnection = null;
+
+			try {
+				if (JenkinsResultsParserUtil.debug) {
+					System.out.println("Downloading " + url);
+				}
+
+				Matcher matcher = _gitHubAPIURLPattern.matcher(url);
+
+				if (matcher.matches()) {
+					gitHubAPICall = true;
+
+					if (_updatingHttpRequestMethods.contains(
+							httpRequestMethod)) {
+
+						Properties buildProperties =
+							JenkinsResultsParserUtil.getBuildProperties();
+
+						url =
+							buildProperties.getProperty("github.api.proxy") +
+								matcher.group(1);
+					}
+				}
+
+				if ((httpAuthorization == null) &&
+					(gitHubAPICall ||
+					 url.startsWith(
+						 "https://raw.githubusercontent.com/liferay/"))) {
+
+					Properties buildProperties =
+						JenkinsResultsParserUtil.getBuildProperties();
+
+					httpAuthorization = new TokenHTTPAuthorization(
+						buildProperties.getProperty("github.access.token"));
+				}
+
+				if ((httpAuthorization == null) &&
+					url.startsWith("https://release.liferay.com")) {
+
+					httpAuthorization =
+						JenkinsResultsParserUtil.getJenkinsHTTPAuthorization();
+				}
+
+				if ((httpAuthorization == null) &&
+					url.matches(
+						"https?:\\/\\/test-[135]-\\d+(?:\\.liferay\\.com)?.*?" +
+							"|http:\\/\\/localhost:8081.*?")) {
+
+					if (JenkinsResultsParserUtil.isCINode()) {
+						url = JenkinsResultsParserUtil.getLocalURL(url);
+					}
+					else {
+						url = JenkinsResultsParserUtil.getRemoteURL(url);
+					}
+
+					httpAuthorization =
+						JenkinsResultsParserUtil.getJenkinsHTTPAuthorization();
+				}
+
+				boolean testray1Request = false;
+
+				if (url.matches("https://testray-old.liferay.com/?.+")) {
+					testray1Request = true;
+				}
+
+				if ((httpAuthorization == null) && testray1Request) {
+					Properties buildProperties =
+						JenkinsResultsParserUtil.getBuildProperties();
+
+					httpAuthorization = new BasicHTTPAuthorization(
+						JenkinsResultsParserUtil.getProperty(
+							buildProperties, "testray.admin.user.password"),
+						JenkinsResultsParserUtil.getProperty(
+							buildProperties, "testray.admin.user.name"));
+				}
+
+				Matcher testray2URLMatcher = _testray2URLPattern.matcher(url);
+
+				if ((httpAuthorization == null) && testray2URLMatcher.find() &&
+					!url.contains("/o/oauth2/token")) {
+
+					Properties buildProperties =
+						JenkinsResultsParserUtil.getBuildProperties();
+
+					URL tokenURL = new URL(
+						testray2URLMatcher.group("baseURL") +
+							"/o/oauth2/token");
+
+					String lxcEnvironment = testray2URLMatcher.group(
+						"lxcEnvironment");
+
+					String clientId = JenkinsResultsParserUtil.getProperty(
+						buildProperties, "testray.oauth2.client.id",
+						lxcEnvironment);
+					String clientSecret = JenkinsResultsParserUtil.getProperty(
+						buildProperties, "testray.oauth2.client.secret",
+						lxcEnvironment);
+
+					httpAuthorization = new ClientCredentialsHTTPAuthorization(
+						clientId, clientSecret, tokenURL);
+				}
+
+				URL urlObject = new URL(url);
+
+				urlConnection = urlObject.openConnection();
+
+				if (urlConnection instanceof HttpURLConnection) {
+					HttpURLConnection httpURLConnection =
+						(HttpURLConnection)urlConnection;
+
+					if (httpRequestMethod == HttpRequestMethod.PATCH) {
+						httpURLConnection.setRequestMethod("POST");
+
+						httpURLConnection.setRequestProperty(
+							"X-HTTP-Method-Override", "PATCH");
+					}
+					else {
+						httpURLConnection.setRequestMethod(
+							httpRequestMethod.name());
+					}
+
+					if (gitHubAPICall &&
+						(httpURLConnection instanceof HttpsURLConnection)) {
+
+						SSLContext sslContext = null;
+
+						float javaVersionNumber =
+							JenkinsResultsParserUtil.getJavaVersionNumber();
+
+						try {
+							if (javaVersionNumber < 1.8F) {
+								sslContext = SSLContext.getInstance("TLSv1.2");
+
+								sslContext.init(null, null, null);
+
+								HttpsURLConnection httpsURLConnection =
+									(HttpsURLConnection)httpURLConnection;
+
+								httpsURLConnection.setSSLSocketFactory(
+									sslContext.getSocketFactory());
+							}
+						}
+						catch (KeyManagementException | NoSuchAlgorithmException
+									exception) {
+
+							throw new RuntimeException(
+								"Unable to set SSL context to TLS v1.2",
+								exception);
+						}
+					}
+
+					if (httpAuthorization != null) {
+						httpURLConnection.setRequestProperty(
+							"accept", "application/json");
+						httpURLConnection.setRequestProperty(
+							"Authorization", httpAuthorization.toString());
+
+						if (!testray1Request) {
+							httpURLConnection.setRequestProperty(
+								"Content-Type", "application/json");
+						}
+					}
+
+					if (url.contains("/oauth2/")) {
+						httpURLConnection.setRequestProperty(
+							"accept", "application/json");
+						httpURLConnection.setRequestProperty(
+							"Content-Type",
+							"application/x-www-form-urlencoded");
+					}
+
+					if (url.startsWith("https://releases-cdn.liferay.com")) {
+						httpURLConnection.setRequestProperty("User-Agent", "");
+					}
+
+					if (postContent != null) {
+						if (httpRequestMethod == null) {
+							httpURLConnection.setRequestMethod("POST");
+						}
+
+						httpURLConnection.setDoOutput(true);
+
+						try (OutputStream outputStream =
+								httpURLConnection.getOutputStream()) {
+
+							outputStream.write(postContent.getBytes("UTF-8"));
+
+							outputStream.flush();
+						}
+					}
+				}
+
+				if (timeout != 0) {
+					urlConnection.setConnectTimeout(timeout);
+					urlConnection.setReadTimeout(timeout);
+				}
+
+				urlConnection.connect();
+
+				if (gitHubAPICall) {
+					try {
+						int limit = Integer.parseInt(
+							urlConnection.getHeaderField("X-RateLimit-Limit"));
+						int remaining = Integer.parseInt(
+							urlConnection.getHeaderField(
+								"X-RateLimit-Remaining"));
+						long reset = Long.parseLong(
+							urlConnection.getHeaderField("X-RateLimit-Reset"));
+
+						System.out.println(
+							JenkinsResultsParserUtil.combine(
+								JenkinsResultsParserUtil.
+									getGitHubAPIRateLimitStatusMessage(
+										limit, remaining, reset),
+								"\n    ", url));
+					}
+					catch (Exception exception) {
+						System.out.println(
+							JenkinsResultsParserUtil.combine(
+								"Unable to parse GitHub API rate limit headers",
+								"\nURL:\n    ", url));
+
+						exception.printStackTrace();
+					}
+				}
+
+				return urlConnection.getInputStream();
+			}
+			catch (IOException ioException) {
+				if (ioException instanceof FileNotFoundException) {
+					throw ioException;
+				}
+
+				if ((ioException instanceof UnknownHostException) &&
+					url.matches("http://test-\\d+-\\d+/.*")) {
+
+					return doRead(
+						url.replaceAll(
+							"http://(test-\\d+-\\d+)(/.*)",
+							"https://$1.liferay.com$2"),
+						checkCache, maxRetries, httpRequestMethod, postContent,
+						retryPeriod, timeout, httpAuthorization);
+				}
+
+				String exceptionMessage = ioException.getMessage();
+
+				if (exceptionMessage.matches(
+						".*HTTP response code\\: 422 .*") &&
+					(urlConnection != null)) {
+
+					StringBuilder sb = new StringBuilder();
+
+					sb.append(exceptionMessage);
+					sb.append("\n");
+
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(postContent)) {
+						sb.append("Post content:\n");
+						sb.append(postContent);
+					}
+
+					System.out.println(sb.toString());
+
+					throw new RuntimeException(exceptionMessage, ioException);
+				}
+
+				Integer retryPeriodOverride = null;
+
+				if (exceptionMessage.matches(
+						".*HTTP response code\\: 403 .*") &&
+					(urlConnection != null)) {
+
+					try {
+						retryPeriodOverride = Integer.parseInt(
+							urlConnection.getHeaderField("retry-after"));
+					}
+					catch (NumberFormatException numberFormatException) {
+						retryPeriodOverride = null;
+					}
+
+					if ((retryPeriodOverride == null) ||
+						(retryPeriodOverride == 0)) {
+
+						retryPeriodOverride = retryPeriod;
+
+						for (int i = 0; i < retryCount; i++) {
+							retryPeriodOverride *= retryPeriodOverride;
+						}
+					}
+
+					if (((maxRetries >= 0) && (retryCount >= maxRetries)) ||
+						(retryPeriodOverride > _SECONDS_RETRY_PERIOD_MAX)) {
+
+						throw new GitHubSecondaryRateLimitRuntimeException(
+							url, retryPeriodOverride, ioException);
+					}
+				}
+
+				long retryPeriodMillis = 1000 * retryPeriod;
+
+				if ((retryPeriodOverride != null) &&
+					(retryPeriodOverride > 0)) {
+
+					retryPeriodMillis = 1000 * retryPeriodOverride;
+				}
+
+				if ((maxRetries >= 0) && (retryCount >= maxRetries)) {
+					throw ioException;
+				}
+
+				System.out.println(
+					JenkinsResultsParserUtil.combine(
+						"Retrying ", url, " in ",
+						JenkinsResultsParserUtil.toDurationString(
+							retryPeriodMillis)));
+
+				retryCount++;
+
+				JenkinsResultsParserUtil.sleep(retryPeriodMillis);
+			}
+		}
+	}
+
+	private static final int _SECONDS_RETRY_PERIOD_MAX = 60 * 30;
+
+	private static final Pattern _gitHubAPIURLPattern = Pattern.compile(
+		"https\\:\\/\\/api\\.github\\.com(.*)");
+	private static final Pattern _testray2URLPattern = Pattern.compile(
+		"(?<baseURL>https://webserver-testray2(-(?<lxcEnvironment>.+))?" +
+			"\\.lfr\\.cloud|https://testray\\.liferay\\.com).*");
+	private static final List<HttpRequestMethod> _updatingHttpRequestMethods =
+		Arrays.asList(
+			HttpRequestMethod.POST, HttpRequestMethod.PATCH,
+			HttpRequestMethod.PUT, HttpRequestMethod.DELETE);
+
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -41,9 +41,9 @@ import javax.net.ssl.SSLContext;
 public class UrlReader {
 
 	public static InputStream doRead(
-			String url, boolean checkCache, int maxRetries,
-			HttpRequestMethod httpRequestMethod, String postContent,
-			int retryPeriod, int timeout, HTTPAuthorization httpAuthorization)
+			boolean checkCache, HTTPAuthorization httpAuthorization,
+			HttpRequestMethod httpRequestMethod, int maxRetries,
+			String postContent, int retryPeriod, int timeout, String url)
 		throws IOException {
 
 		if (url.contains("/userContent/") && (timeout == 0)) {
@@ -321,11 +321,11 @@ public class UrlReader {
 					url.matches("http://test-\\d+-\\d+/.*")) {
 
 					return doRead(
+						checkCache, httpAuthorization, httpRequestMethod,
+						maxRetries, postContent, retryPeriod, timeout,
 						url.replaceAll(
 							"http://(test-\\d+-\\d+)(/.*)",
-							"https://$1.liferay.com$2"),
-						checkCache, maxRetries, httpRequestMethod, postContent,
-						retryPeriod, timeout, httpAuthorization);
+							"https://$1.liferay.com$2"));
 				}
 
 				String exceptionMessage = ioException.getMessage();

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -5,6 +5,7 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
@@ -47,6 +48,8 @@ public class Test {
 		Environment.setInstance(new Environment());
 
 		Shell.setInstance(new Shell());
+
+		UrlReader.setInstance(new UrlReader());
 	}
 
 	@Rule
@@ -316,6 +319,20 @@ public class Test {
 		return shell;
 	}
 
+	protected UrlReader mockUrlReader() {
+		UrlReader urlReader = Mockito.mock(
+			UrlReader.class,
+			invocation -> {
+				String url = invocation.getArgument(7);
+
+				throw new AssertionError("No output set for URL: " + url);
+			});
+
+		UrlReader.setInstance(urlReader);
+
+		return urlReader;
+	}
+
 	protected String read(File file) throws IOException {
 		return new String(Files.readAllBytes(Paths.get(file.toURI())));
 	}
@@ -343,6 +360,22 @@ public class Test {
 		).doExecute(
 			Mockito.argThat(
 				executionRequest -> _hasCommand(command, executionRequest))
+		);
+	}
+
+	protected void setUrlReaderOutput(
+			String standardOut, String url, UrlReader urlReader)
+		throws Exception {
+
+		Mockito.doAnswer(
+			invocation -> new ByteArrayInputStream(standardOut.getBytes())
+		).when(
+			urlReader
+		).doRead(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
+			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
+			Mockito.argThat(
+				readURL -> (readURL != null) && readURL.contains(url))
 		);
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.InputStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Kenji Heigel
+ */
+public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testToInputStream() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(_STANDARD_OUT, _URL, urlReader);
+
+		try (InputStream inputStream = JenkinsResultsParserUtil.toInputStream(
+				_URL, false)) {
+
+			Assert.assertEquals(
+				_STANDARD_OUT,
+				JenkinsResultsParserUtil.readInputStream(inputStream));
+		}
+	}
+
+	@Test
+	public void testToString() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(_STANDARD_OUT, _URL, urlReader);
+
+		Assert.assertEquals(
+			_STANDARD_OUT, JenkinsResultsParserUtil.toString(_URL, false));
+	}
+
+	private static final String _STANDARD_OUT = "Hello, World!\n";
+
+	private static final String _URL = "http://test.liferay.com";
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7742

**What is being fixed:** jenkins-results-parser cannot unit test code paths that read URLs, because URL reading goes straight to the network with no seam to intercept.

**How it is being fixed:** Add an injectable UrlReader seam at toInputStream, the floor under toString, toBufferedReader, toFile, and the toJSON helpers, so tests stub URL responses without real network calls. It mirrors the merged Shell seam from LRCI-7520. Three private JenkinsResultsParserUtil helpers become public because the relocated body references them and the source formatter does not allow package-private members.
