### PR TITLE
LRCI-7574 Validate PQL in liferay-portal

### DIFF
--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -66,6 +66,8 @@ The procedure runs in two passes over the validations, in the order below. The o
 
 1. [Java Unit Tests](validations/java-unit-test.md)
 
+1. [PQL Validation](validations/pql-validation.md)
+
 1. [JavaScript Unit Tests](validations/javascript-unit-test.md)
 
 Process each validation in a subagent.

--- a/.claude/skills/pr-check/validations/pql-validation.md
+++ b/.claude/skills/pr-check/validations/pql-validation.md
@@ -1,0 +1,21 @@
+# PQL Validation
+
+## Trigger
+
+A `test.properties` file changed. These files contain PQL expressions in `test.batch.run.property.query` properties; a malformed one is otherwise caught only when the batch runs after merging.
+
+## Match
+
+`(^|/)test\.properties$`
+
+## Command
+
+```bash
+(cd "${REPO_ROOT}/modules/test/jenkins-results-parser" && ../../../gradlew test --tests com.liferay.jenkins.results.parser.test.properties.TestPropertiesPQLValidationTest)
+```
+
+`TestPropertiesPQLValidationTest` validates every `test.properties` file in the repository, not only the changed file.
+
+## Time Estimate
+
+~30 sec.

--- a/.claude/skills/pr-check/validations/pql-validation.md
+++ b/.claude/skills/pr-check/validations/pql-validation.md
@@ -11,7 +11,7 @@ A `test.properties` file changed. These files contain PQL expressions in `test.b
 ## Command
 
 ```bash
-(cd "${REPO_ROOT}/modules/test/jenkins-results-parser" && ../../../gradlew test --tests com.liferay.jenkins.results.parser.test.properties.TestPropertiesPQLValidationTest)
+(cd "${REPO_ROOT}/modules/test/jenkins-results-parser" && ../../../gradlew test --tests com.liferay.jenkins.results.parser.TestPropertiesPQLValidationTest)
 ```
 
 `TestPropertiesPQLValidationTest` validates every `test.properties` file in the repository, not only the changed file.

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/test.properties
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/test.properties
@@ -1,4 +1,4 @@
 test.batch.run.property.query[functional-tomcat-mysql*-jdk*][test-portal-hotfix-release]=\
-    (testray.component.names ~ "Walkthrough") AND ((portal.acceptance == true) AND (portal.upstream == true)) AND ((app.server.types == null) OR (app.server.types ~ "tomcat")) AND ((database.types == null) OR (database.types ~ "mysql")
+    (testray.component.names ~ "Walkthrough") AND ((portal.acceptance == true) AND (portal.upstream == true)) AND ((app.server.types == null) OR (app.server.types ~ "tomcat")) AND ((database.types == null) OR (database.types ~ "mysql"))
 
 testray.main.component.name=Frontend JS

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/test.properties
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/test.properties
@@ -1,4 +1,16 @@
 test.batch.run.property.query[functional-tomcat-mysql*-jdk*][test-portal-hotfix-release]=\
-    (testray.component.names ~ "Walkthrough") AND ((portal.acceptance == true) AND (portal.upstream == true)) AND ((app.server.types == null) OR (app.server.types ~ "tomcat")) AND ((database.types == null) OR (database.types ~ "mysql"))
+    (testray.component.names ~ "Walkthrough") AND \
+    (\
+        (portal.acceptance == true) AND \
+        (portal.upstream == true)\
+    ) AND \
+    (\
+        (app.server.types == null) OR \
+        (app.server.types ~ "tomcat")\
+    ) AND \
+    (\
+        (database.types == null) OR \
+        (database.types ~ "mysql")\
+    )
 
 testray.main.component.name=Frontend JS

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/TestPropertiesPQLValidationTest.java
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.jenkins.results.parser.test.properties;
-
-import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/TestPropertiesPQLValidationTest.java
@@ -116,8 +116,9 @@ public class TestPropertiesPQLValidationTest {
 						}
 						catch (RuntimeException runtimeException) {
 							errorMessages.add(
-								"Invalid PQL in property " + propertyName +
-									": " + runtimeException.getMessage());
+								JenkinsResultsParserUtil.combine(
+									"Invalid PQL in property ", propertyName,
+									": ", runtimeException.getMessage()));
 						}
 					}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -1,0 +1,180 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.test.properties;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Charlotte Wong
+ */
+public class TestPropertiesPQLValidationTest {
+
+	@Test
+	public void testValidatePQL() throws Exception {
+		List<File> testPropertiesFiles = _findTestPropertiesFiles(
+			_getPortalDir());
+
+		List<String> errors = Collections.synchronizedList(new ArrayList<>());
+		List<Future<?>> futures = new ArrayList<>();
+
+		ThreadPoolExecutor threadPoolExecutor =
+			JenkinsResultsParserUtil.getNewThreadPoolExecutor(
+				Runtime.getRuntime(
+				).availableProcessors(),
+				true);
+
+		for (File testPropertiesFile : testPropertiesFiles) {
+			Properties properties = new Properties();
+
+			try (InputStream inputStream = new FileInputStream(
+					testPropertiesFile)) {
+
+				properties.load(inputStream);
+			}
+
+			for (String propertyName : properties.stringPropertyNames()) {
+				if (!propertyName.startsWith(
+						"test.batch.run.property.query")) {
+
+					continue;
+				}
+
+				String value = properties.getProperty(
+					propertyName
+				).trim();
+
+				if (value.contains("${")) {
+					continue;
+				}
+
+				futures.add(
+					threadPoolExecutor.submit(
+						() -> {
+							try {
+								JenkinsResultsParserUtil.validatePQL(
+									value, testPropertiesFile);
+							}
+							catch (RuntimeException runtimeException) {
+								errors.add(
+									"Invalid PQL in property `" +
+										propertyName + "` in " +
+											testPropertiesFile + ": " +
+												runtimeException.getMessage());
+							}
+						}));
+			}
+		}
+
+		threadPoolExecutor.shutdown();
+
+		System.out.println(
+			"Validating " + futures.size() +
+				" test.batch.run.property.query PQL values across " +
+					testPropertiesFiles.size() + " test.properties files");
+
+		for (Future<?> future : futures) {
+			future.get();
+		}
+
+		Assert.assertTrue(
+			"Found invalid PQL:\n" + String.join("\n", errors),
+			errors.isEmpty());
+	}
+
+	private List<File> _findTestPropertiesFiles(File portalDir)
+		throws IOException {
+
+		List<File> testPropertiesFiles = new ArrayList<>();
+
+		Files.walkFileTree(
+			portalDir.toPath(),
+			new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult preVisitDirectory(
+					Path dir, BasicFileAttributes basicFileAttributes) {
+
+					String dirName = dir.getFileName(
+					).toString();
+
+					if (dirName.equals("build") ||
+						dirName.equals("bundles") ||
+						dirName.equals("classes") ||
+						dirName.equals("node_modules") ||
+						dirName.equals("src") ||
+						dirName.equals("test-classes") ||
+						dirName.startsWith(".")) {
+
+						return FileVisitResult.SKIP_SUBTREE;
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFile(
+					Path file, BasicFileAttributes basicFileAttributes) {
+
+					if (Objects.equals(
+							file.getFileName(
+							).toString(),
+							"test.properties")) {
+
+						testPropertiesFiles.add(file.toFile());
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFileFailed(
+					Path file, IOException ioException) {
+
+					return FileVisitResult.CONTINUE;
+				}
+
+			});
+
+		return testPropertiesFiles;
+	}
+
+	private File _getPortalDir() {
+		File dir = JenkinsResultsParserUtil.getCanonicalFile(new File("."));
+
+		while (dir != null) {
+			if (Objects.equals(dir.getName(), "liferay-portal")) {
+				return dir;
+			}
+
+			dir = dir.getParentFile();
+		}
+
+		throw new RuntimeException("Unable to find portal directory");
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -163,9 +163,9 @@ public class TestPropertiesPQLValidationTest {
 		File dir = JenkinsResultsParserUtil.getCanonicalFile(new File("."));
 
 		while (dir != null) {
-			File releasePropertiesFile = new File(dir, "release.properties");
+			File buildTestXMLFile = new File(dir, "build-test.xml");
 
-			if (releasePropertiesFile.exists()) {
+			if (buildTestXMLFile.exists()) {
 				return dir;
 			}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -110,9 +110,8 @@ public class TestPropertiesPQLValidationTest {
 
 						String pql = propertyValue.trim();
 
-						if (pql.contains("${")) {
-							continue;
-						}
+						pql = pql.replaceAll(
+							"\\$\\{[^}]+\\}", "(portal.acceptance == true)");
 
 						try {
 							JenkinsResultsParserUtil.validatePQL(pql, file);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -42,11 +42,11 @@ public class TestPropertiesPQLValidationTest {
 		List<String> errors = Collections.synchronizedList(new ArrayList<>());
 		List<Future<?>> futures = new ArrayList<>();
 
+		Runtime runtime = Runtime.getRuntime();
+
 		ThreadPoolExecutor threadPoolExecutor =
 			JenkinsResultsParserUtil.getNewThreadPoolExecutor(
-				Runtime.getRuntime(
-				).availableProcessors(),
-				true);
+				runtime.availableProcessors(), true);
 
 		for (File testPropertiesFile : testPropertiesFiles) {
 			Properties properties = new Properties();
@@ -62,11 +62,11 @@ public class TestPropertiesPQLValidationTest {
 					continue;
 				}
 
-				String value = properties.getProperty(
-					propertyName
-				).trim();
+				String propertyValue = properties.getProperty(propertyName);
 
-				if (value.contains("${")) {
+				String pql = propertyValue.trim();
+
+				if (pql.contains("${")) {
 					continue;
 				}
 
@@ -75,13 +75,12 @@ public class TestPropertiesPQLValidationTest {
 						() -> {
 							try {
 								JenkinsResultsParserUtil.validatePQL(
-									value, testPropertiesFile);
+									pql, testPropertiesFile);
 							}
 							catch (RuntimeException runtimeException) {
 								errors.add(
-									"Invalid PQL in property `" + propertyName +
-										"` in " + testPropertiesFile + ": " +
-											runtimeException.getMessage());
+									"Invalid PQL in property " + propertyName +
+										": " + runtimeException.getMessage());
 							}
 						}));
 			}
@@ -89,18 +88,19 @@ public class TestPropertiesPQLValidationTest {
 
 		threadPoolExecutor.shutdown();
 
-		System.out.println(
-			"Validating " + futures.size() +
-				" test.batch.run.property.query PQL values across " +
-					testPropertiesFiles.size() + " test.properties files");
+		System.out.println("Validating " + futures.size() + " PQL values");
 
 		for (Future<?> future : futures) {
 			future.get();
 		}
 
-		Assert.assertTrue(
-			"Found invalid PQL:\n" + String.join("\n", errors),
-			errors.isEmpty());
+		Collections.sort(errors);
+
+		for (String error : errors) {
+			System.out.println(error);
+		}
+
+		Assert.assertTrue(errors.isEmpty());
 	}
 
 	private List<File> _findTestPropertiesFiles(File portalDir)
@@ -116,8 +116,9 @@ public class TestPropertiesPQLValidationTest {
 				public FileVisitResult preVisitDirectory(
 					Path dir, BasicFileAttributes basicFileAttributes) {
 
-					String dirName = dir.getFileName(
-					).toString();
+					File dirFile = dir.toFile();
+
+					String dirName = dirFile.getName();
 
 					if (dirName.equals("build") || dirName.equals("bundles") ||
 						dirName.equals("classes") ||
@@ -136,11 +137,11 @@ public class TestPropertiesPQLValidationTest {
 				public FileVisitResult visitFile(
 					Path file, BasicFileAttributes basicFileAttributes) {
 
-					if (Objects.equals(
-							file.getFileName(
-							).toString(),
-							"test.properties")) {
+					File visitedFile = file.toFile();
 
+					String fileName = visitedFile.getName();
+
+					if (Objects.equals(fileName, "test.properties")) {
 						testPropertiesFiles.add(file.toFile());
 					}
 
@@ -163,7 +164,9 @@ public class TestPropertiesPQLValidationTest {
 		File dir = JenkinsResultsParserUtil.getCanonicalFile(new File("."));
 
 		while (dir != null) {
-			if (Objects.equals(dir.getName(), "liferay-portal")) {
+			File releasePropertiesFile = new File(dir, "release.properties");
+
+			if (releasePropertiesFile.exists()) {
 				return dir;
 			}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -110,8 +110,7 @@ public class TestPropertiesPQLValidationTest {
 
 						String pql = propertyValue.trim();
 
-						pql = pql.replaceAll(
-							"\\$\\{[^}]+\\}", "(portal.acceptance == true)");
+						pql = pql.replaceAll("\\$\\{[^}]+\\}", "(1 == 1)");
 
 						try {
 							JenkinsResultsParserUtil.validatePQL(pql, file);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -58,9 +58,7 @@ public class TestPropertiesPQLValidationTest {
 			}
 
 			for (String propertyName : properties.stringPropertyNames()) {
-				if (!propertyName.startsWith(
-						"test.batch.run.property.query")) {
-
+				if (!propertyName.startsWith("test.batch.run.property.query")) {
 					continue;
 				}
 
@@ -81,10 +79,9 @@ public class TestPropertiesPQLValidationTest {
 							}
 							catch (RuntimeException runtimeException) {
 								errors.add(
-									"Invalid PQL in property `" +
-										propertyName + "` in " +
-											testPropertiesFile + ": " +
-												runtimeException.getMessage());
+									"Invalid PQL in property `" + propertyName +
+										"` in " + testPropertiesFile + ": " +
+											runtimeException.getMessage());
 							}
 						}));
 			}
@@ -107,7 +104,7 @@ public class TestPropertiesPQLValidationTest {
 	}
 
 	private List<File> _findTestPropertiesFiles(File portalDir)
-		throws IOException {
+		throws Exception {
 
 		List<File> testPropertiesFiles = new ArrayList<>();
 
@@ -122,8 +119,7 @@ public class TestPropertiesPQLValidationTest {
 					String dirName = dir.getFileName(
 					).toString();
 
-					if (dirName.equals("build") ||
-						dirName.equals("bundles") ||
+					if (dirName.equals("build") || dirName.equals("bundles") ||
 						dirName.equals("classes") ||
 						dirName.equals("node_modules") ||
 						dirName.equals("src") ||

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -105,8 +105,9 @@ public class TestPropertiesPQLValidationTest {
 							continue;
 						}
 
-						String propertyValue = properties.getProperty(
-							propertyName);
+						String propertyValue =
+							JenkinsResultsParserUtil.getProperty(
+								properties, propertyName);
 
 						String pql = propertyValue.trim();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -50,7 +50,7 @@ public class TestPropertiesPQLValidationTest {
 			throw new RuntimeException("Unable to find portal directory");
 		}
 
-		List<String> errors = new ArrayList<>();
+		List<String> errorMessages = new ArrayList<>();
 
 		Files.walkFileTree(
 			portalDir.toPath(),
@@ -118,7 +118,7 @@ public class TestPropertiesPQLValidationTest {
 							JenkinsResultsParserUtil.validatePQL(pql, file);
 						}
 						catch (RuntimeException runtimeException) {
-							errors.add(
+							errorMessages.add(
 								"Invalid PQL in property " + propertyName +
 									": " + runtimeException.getMessage());
 						}
@@ -136,13 +136,13 @@ public class TestPropertiesPQLValidationTest {
 
 			});
 
-		Collections.sort(errors);
+		Collections.sort(errorMessages);
 
-		for (String error : errors) {
-			System.out.println(error);
+		for (String errorMessage : errorMessages) {
+			System.out.println(errorMessage);
 		}
 
-		Assert.assertTrue(errors.isEmpty());
+		Assert.assertTrue(errorMessages.isEmpty());
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -22,8 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,77 +33,24 @@ public class TestPropertiesPQLValidationTest {
 
 	@Test
 	public void testValidatePQL() throws Exception {
-		List<File> testPropertiesFiles = _findTestPropertiesFiles(
-			_getPortalDir());
+		File portalDir = JenkinsResultsParserUtil.getCanonicalFile(
+			new File("."));
 
-		List<String> errors = Collections.synchronizedList(new ArrayList<>());
-		List<Future<?>> futures = new ArrayList<>();
+		while (portalDir != null) {
+			File buildTestXMLFile = new File(portalDir, "build-test.xml");
 
-		Runtime runtime = Runtime.getRuntime();
-
-		ThreadPoolExecutor threadPoolExecutor =
-			JenkinsResultsParserUtil.getNewThreadPoolExecutor(
-				runtime.availableProcessors(), true);
-
-		for (File testPropertiesFile : testPropertiesFiles) {
-			Properties properties = new Properties();
-
-			try (InputStream inputStream = new FileInputStream(
-					testPropertiesFile)) {
-
-				properties.load(inputStream);
+			if (buildTestXMLFile.exists()) {
+				break;
 			}
 
-			for (String propertyName : properties.stringPropertyNames()) {
-				if (!propertyName.startsWith("test.batch.run.property.query")) {
-					continue;
-				}
-
-				String propertyValue = properties.getProperty(propertyName);
-
-				String pql = propertyValue.trim();
-
-				if (pql.contains("${")) {
-					continue;
-				}
-
-				futures.add(
-					threadPoolExecutor.submit(
-						() -> {
-							try {
-								JenkinsResultsParserUtil.validatePQL(
-									pql, testPropertiesFile);
-							}
-							catch (RuntimeException runtimeException) {
-								errors.add(
-									"Invalid PQL in property " + propertyName +
-										": " + runtimeException.getMessage());
-							}
-						}));
-			}
+			portalDir = portalDir.getParentFile();
 		}
 
-		threadPoolExecutor.shutdown();
-
-		System.out.println("Validating " + futures.size() + " PQL values");
-
-		for (Future<?> future : futures) {
-			future.get();
+		if (portalDir == null) {
+			throw new RuntimeException("Unable to find portal directory");
 		}
 
-		Collections.sort(errors);
-
-		for (String error : errors) {
-			System.out.println(error);
-		}
-
-		Assert.assertTrue(errors.isEmpty());
-	}
-
-	private List<File> _findTestPropertiesFiles(File portalDir)
-		throws Exception {
-
-		List<File> testPropertiesFiles = new ArrayList<>();
+		List<String> errors = new ArrayList<>();
 
 		Files.walkFileTree(
 			portalDir.toPath(),
@@ -113,11 +58,11 @@ public class TestPropertiesPQLValidationTest {
 
 				@Override
 				public FileVisitResult preVisitDirectory(
-					Path dir, BasicFileAttributes basicFileAttributes) {
+					Path path, BasicFileAttributes basicFileAttributes) {
 
-					File dirFile = dir.toFile();
+					File dir = path.toFile();
 
-					String dirName = dirFile.getName();
+					String dirName = dir.getName();
 
 					if (dirName.equals("build") || dirName.equals("bundles") ||
 						dirName.equals("classes") ||
@@ -134,14 +79,49 @@ public class TestPropertiesPQLValidationTest {
 
 				@Override
 				public FileVisitResult visitFile(
-					Path file, BasicFileAttributes basicFileAttributes) {
+						Path path, BasicFileAttributes basicFileAttributes)
+					throws IOException {
 
-					File visitedFile = file.toFile();
+					File file = path.toFile();
 
-					String fileName = visitedFile.getName();
+					String fileName = file.getName();
 
-					if (fileName.equals("test.properties")) {
-						testPropertiesFiles.add(file.toFile());
+					if (!fileName.equals("test.properties")) {
+						return FileVisitResult.CONTINUE;
+					}
+
+					Properties properties = new Properties();
+
+					try (InputStream inputStream = new FileInputStream(file)) {
+						properties.load(inputStream);
+					}
+
+					for (String propertyName :
+							properties.stringPropertyNames()) {
+
+						if (!propertyName.startsWith(
+								"test.batch.run.property.query")) {
+
+							continue;
+						}
+
+						String propertyValue = properties.getProperty(
+							propertyName);
+
+						String pql = propertyValue.trim();
+
+						if (pql.contains("${")) {
+							continue;
+						}
+
+						try {
+							JenkinsResultsParserUtil.validatePQL(pql, file);
+						}
+						catch (RuntimeException runtimeException) {
+							errors.add(
+								"Invalid PQL in property " + propertyName +
+									": " + runtimeException.getMessage());
+						}
 					}
 
 					return FileVisitResult.CONTINUE;
@@ -149,30 +129,20 @@ public class TestPropertiesPQLValidationTest {
 
 				@Override
 				public FileVisitResult visitFileFailed(
-					Path file, IOException ioException) {
+					Path path, IOException ioException) {
 
 					return FileVisitResult.CONTINUE;
 				}
 
 			});
 
-		return testPropertiesFiles;
-	}
+		Collections.sort(errors);
 
-	private File _getPortalDir() {
-		File dir = JenkinsResultsParserUtil.getCanonicalFile(new File("."));
-
-		while (dir != null) {
-			File buildTestXMLFile = new File(dir, "build-test.xml");
-
-			if (buildTestXMLFile.exists()) {
-				return dir;
-			}
-
-			dir = dir.getParentFile();
+		for (String error : errors) {
+			System.out.println(error);
 		}
 
-		throw new RuntimeException("Unable to find portal directory");
+		Assert.assertTrue(errors.isEmpty());
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -21,7 +21,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -141,7 +140,7 @@ public class TestPropertiesPQLValidationTest {
 
 					String fileName = visitedFile.getName();
 
-					if (Objects.equals(fileName, "test.properties")) {
+					if (fileName.equals("test.properties")) {
 						testPropertiesFiles.add(file.toFile());
 					}
 

--- a/test.properties
+++ b/test.properties
@@ -1551,6 +1551,7 @@
     test.batch.class.names.includes[modules-unit-project-templates-jdk21_zulu]=**/project-templates/**/src/test/**/*Test.java
 
     test.batch.class.names.includes[modules-unit_stable]=\
+        **/jenkins-results-parser/**/TestPropertiesPQLValidationTest.java,\
         **/portal-tools-sample-sql-builder/**/SampleSQLBuilderTest.java,\
         portal-impl/**/Log4jConfigUtilTest.java
 


### PR DESCRIPTION
Adds a unit test that validates every `test.batch.run.property.query` PQL expression across all `test.properties` files in the repository, so a malformed query is caught at PR time rather than when the batch runs after merging. PQL is validated via `JenkinsResultsParserUtil.validatePQL`, property references are resolved before validation, and the check is wired into the pr-check coverage.

Supersedes the closed #2096 and incorporates the bchan-bot review feedback:

- Moved `TestPropertiesPQLValidationTest` into `com.liferay.jenkins.results.parser` (alongside the class it tests and its peer tests), dropping the now same-package import and updating the pr-check `--tests` argument.
- Built the invalid-PQL error message with `JenkinsResultsParserUtil.combine` (the module's idiom) to satisfy rule 306, rather than `StringBundler` which this module does not use.

Verified with `gradlew formatSource` (no violations) and the test passing.