### PR TITLE
LRCI-7597 Add initial unit tests using the new wrappers

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -204,6 +204,9 @@ public class JenkinsResultsParserUtil {
 	}
 
 	public static void clearCache() {
+		_cacheURL = null;
+		_ciNode = null;
+
 		File cacheDirectory = new File(
 			System.getProperty("java.io.tmpdir"), "jenkins-cached-files");
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildDatabaseTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildDatabaseTestUtil.java
@@ -79,6 +79,12 @@ public class BuildDatabaseTestUtil {
 							"login", "test-owner-" + index
 						)
 					)
+				).put(
+					"user",
+					new JSONObject(
+					).put(
+						"login", "test-owner-" + index
+					)
 				)
 			).put(
 				"html_url", htmlURL

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -1,0 +1,163 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.File;
+
+import java.util.Collections;
+import java.util.Properties;
+
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Kenji Heigel
+ */
+public class PortalWorkspaceGitRepositoryTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testSetUp() throws Exception {
+		File workingDirectory = File.createTempFile("portal-workspace-", null);
+
+		workingDirectory.delete();
+
+		workingDirectory.mkdir();
+
+		File gitDirectory = new File(workingDirectory, ".git");
+
+		gitDirectory.mkdir();
+
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"binaries.cache.s3.path",
+			"s3://liferayci-file-propagator/binaries-cache/master.tar.gz");
+		buildProperties.setProperty("git.archive.enabled", "true");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		BuildDatabaseUtil.setBuildDatabase(
+			BuildDatabaseTestUtil.newBuildDatabaseWithPullRequest());
+
+		Shell shell = mockShell();
+
+		Mockito.doReturn(
+			new Shell.ExecutionResult(0, "", "")
+		).when(
+			shell
+		).doExecute(
+			Mockito.any(Shell.ExecutionRequest.class)
+		);
+
+		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
+
+		Mockito.doReturn(
+			"1234567890123456789012345678901234567890"
+		).when(
+			localGitBranch
+		).getSHA();
+
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			Mockito.mock(PortalWorkspaceGitRepository.class);
+
+		Mockito.doReturn(
+			workingDirectory
+		).when(
+			portalWorkspaceGitRepository
+		).getDirectory();
+
+		Mockito.doReturn(
+			"liferay-portal"
+		).when(
+			portalWorkspaceGitRepository
+		).getDirectoryName();
+
+		Mockito.doReturn(
+			gitWorkingDirectory
+		).when(
+			portalWorkspaceGitRepository
+		).getGitWorkingDirectory();
+
+		Mockito.doReturn(
+			localGitBranch
+		).when(
+			portalWorkspaceGitRepository
+		).getLocalGitBranch();
+
+		Mockito.doReturn(
+			"master"
+		).when(
+			portalWorkspaceGitRepository
+		).getUpstreamBranchName();
+
+		Mockito.doReturn(
+			true
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).prepareGitWorkingDirectory();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUp();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
+		portalWorkspaceGitRepository.setUp();
+
+		Mockito.verify(
+			shell
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _isCommand(
+					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
+		);
+
+		Mockito.verify(
+			shell
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _isCommand(
+					executionRequest, "tar --directory=",
+					"binaries-cache.tar.gz"))
+		);
+	}
+
+	private boolean _isCommand(
+		Shell.ExecutionRequest executionRequest, String... substrings) {
+
+		if (executionRequest == null) {
+			return false;
+		}
+
+		String command = executionRequest.getCommands()[0];
+
+		for (String substring : substrings) {
+			if (!command.contains(substring)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PullRequestTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PullRequestTest.java
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import org.json.JSONObject;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Kenji Heigel
+ */
+public class PullRequestTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetFileNames() throws Exception {
+		PullRequest pullRequest = _newPullRequest();
+
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			JenkinsResultsParserUtil.combine(
+				"[{\"filename\": \"modules/apps/foo/Foo.java\"}, ",
+				"{\"filename\": \"portal-impl/Bar.java\"}]"),
+			"/files", urlReader);
+
+		Assert.assertEquals(
+			Arrays.asList("modules/apps/foo/Foo.java", "portal-impl/Bar.java"),
+			pullRequest.getFileNames());
+	}
+
+	private PullRequest _newPullRequest() {
+		BuildDatabase buildDatabase =
+			BuildDatabaseTestUtil.newBuildDatabaseWithPullRequest();
+
+		BuildDatabaseUtil.setBuildDatabase(buildDatabase);
+
+		JSONObject jsonObject = buildDatabase.getJSONObject();
+
+		JSONObject pullRequestsJSONObject = jsonObject.getJSONObject(
+			"pull_requests");
+
+		Iterator<String> iterator = pullRequestsJSONObject.keys();
+
+		return PullRequestFactory.newPullRequest(iterator.next(), null);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PullRequestTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PullRequestTest.java
@@ -19,6 +19,23 @@ import org.junit.Test;
 public class PullRequestTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
+	public void testGetCIMergeSHA() throws Exception {
+		PullRequest pullRequest = _newPullRequest();
+
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			JenkinsResultsParserUtil.combine(
+				"[{\"filename\": \"test/ci-merge\", ",
+				"\"patch\": \"+abcdef0123456789abcdef0123456789abcdef01\"}]"),
+			"/files", urlReader);
+
+		Assert.assertEquals(
+			"abcdef0123456789abcdef0123456789abcdef01",
+			pullRequest.getCIMergeSHA());
+	}
+
+	@Test
 	public void testGetFileNames() throws Exception {
 		PullRequest pullRequest = _newPullRequest();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -45,6 +45,8 @@ public class Test {
 
 	@After
 	public void tearDown() {
+		BuildDatabaseUtil.clearBuildDatabases();
+
 		Environment.setInstance(new Environment());
 
 		Shell.setInstance(new Shell());
@@ -300,6 +302,30 @@ public class Test {
 		}
 
 		return _simpleClassNames;
+	}
+
+	protected Environment mockEnvironment(
+		Map<String, String> environmentValues) {
+
+		Environment environment = Mockito.mock(Environment.class);
+
+		Mockito.doAnswer(
+			invocation -> environmentValues.get(invocation.getArgument(0))
+		).when(
+			environment
+		).doGet(
+			Mockito.anyString()
+		);
+
+		Mockito.doReturn(
+			environmentValues
+		).when(
+			environment
+		).doGetAll();
+
+		Environment.setInstance(environment);
+
+		return environment;
 	}
 
 	protected Shell mockShell() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7597

## What Is Being Fixed

jenkins-results-parser had near-zero unit coverage on the classes most
entangled with the environment, shelled-out processes, the network, and
the cross-JVM build database. Phase 1 of LRCI-6664 introduced four
wrappers — Environment, Shell, UrlReader, and BuildDatabase — around those
dependencies, but nothing yet exercised them, so there was no worked
example proving the wrappers make that code reachable in a unit test.

## How It Is Being Fixed

Adds an initial unit test suite that drives previously untestable code
through the wrappers, with no real environment, process, network, or disk.
Each test composes more than one wrapper, matching how the production code
actually runs.

PortalWorkspaceGitRepositoryTest drives the real setUp flow down the
non-snapshot path and asserts the binaries-cache restore is reached,
through the Environment, Shell, and BuildDatabase wrappers. PullRequestTest
sources a pull request from the BuildDatabase wrapper, then reads its
changed files and its ci-merge SHA from the GitHub API through the
UrlReader wrapper.

Supporting changes add a mockEnvironment helper to the base Test class,
reset the cached CI-node and cache-URL state in clearCache so the
Environment wrapper is honored when tests share a JVM, and add a base user
to the shared pull request test fixture.

## What Each Test Catches

| Test | Wrappers | Regression it catches |
| --- | --- | --- |
| `testSetUp` | Environment, Shell, BuildDatabase | `setUp()` failing to reach `setUpAdditionalCaches()` on the non-snapshot path, silently skipping the binaries-cache restore (the LRCI-7506 class; mutation-verified by dropping the call). |
| `testGetFileNames` | BuildDatabase, UrlReader | modified-file detection breaking — a wrong GitHub `/files` URL or a broken parse, which feeds wrong inputs to `ci:test:relevant` selection. |
| `testGetCIMergeSHA` | BuildDatabase, UrlReader | the `ci-merge` SHA extraction breaking, which `ci:forward` relies on to forward the right merge commit. |

## PR Check

**pr-check: PASS** — tested on `2fd65dc481b6c08f9c5908ff9943817c62ac64d8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2fd65dc481b6c08f9c5908ff9943817c62ac64d8"} -->
