### PR TITLE
LRCI-7755 Rebase on the latest master before running pr-check

### DIFF
--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -12,11 +12,17 @@ Run premerge checks against the current branch. The skill iterates through the v
 
 ## Preconditions
 
-- **Branch rebased on local `master`.** Compare `git merge-base HEAD master` to `git rev-parse master`; when they differ, abort and tell the developer to rebase (`git rebase master`). The `format-source-current-branch` validation diffs against the local `master` tip to decide which files to format — when the branch's merge-base lags behind that tip, SF picks up reverse-direction diffs from the master commits the branch has not absorbed and the `<TICKET> SF` autocommit captures unrelated rewrites.
+- **Working tree clean.** `git status --porcelain` must return empty. When dirty, abort and ask the developer to commit first.
 
-- **Working tree clean.** `git status --porcelain` must return empty. When dirty, abort and ask the developer to commit first — the autocommit steps inside drift validations would otherwise capture their uncommitted edits.
+- **Rebased on the latest `master`.** Resolve the master remote. Use the one the developer names, otherwise `upstream`, otherwise `origin`. When none resolves, compare `git merge-base HEAD master` to `git rev-parse master`. Abort and tell the developer to rebase when the two differ, and warn that the branch was not checked against a remote. Otherwise run these steps.
 
-- **Diff baseline is local `master`.** The skill never fetches from a remote and does not compare against an `upstream/master` ref. Whether local `master` is up to date is the developer's call.
+	1. `git fetch <remote> master`.
+
+	1. Fast forward local `master` to the fetched tip. When local `master` has diverged, warn and stop.
+
+	1. `git rebase <remote>/master`. On a clean rebase, continue against the rebased branch. On conflict, list the unmerged files (`git diff --diff-filter=U --name-only`) and ask the developer who should resolve the conflicts. When the developer chooses to, run `git rebase --abort` and FAIL. When the developer asks you to, fix the conflicts, `git add` the files, and run `git rebase --continue`. When the conflicts cannot be resolved, run `git rebase --abort` and FAIL.
+
+- **Diff baseline is local `master`.** After the rebase, the three-dot diff against local `master` is the baseline.
 
 - **Diff is nonempty.** When the three-dot diff produces no files, exit with a one-line message — no validation produces useful signal on a clean branch.
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7755

## What Is Being Fixed

pr-check checked the branch only against local master and never fetched a remote, so when local master was stale a branch that conflicts with the latest master could pass pr-check and then be rejected on GitHub with rebase conflicts.

## How It Is Being Fixed

The Preconditions now include a rebased on master step that runs before any validation. It resolves the master remote, preferring the one the developer names, then upstream, then origin, fetches it, fast forwards local master, and rebases the branch. On a conflict it lists the unmerged files and asks the developer who should resolve them, aborting the rebase and failing when the developer takes it or when the conflicts cannot be resolved. When no remote resolves it falls back to the previous local only comparison and warns that the branch was not checked against a remote.

## Why Are There No Tests?

This is a documentation only change to the pr-check skill and adds no portal code, so there is nothing to unit test.

## PR Check

**pr-check: PASS** — tested on `074c929938c505611afc6dcd206b565687773f9f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "074c929938c505611afc6dcd206b565687773f9f"} -->
