### PR TITLE
LRCI-7755 Rebase on the latest master before running pr-check

### DIFF
--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -16,7 +16,7 @@ Run premerge checks against the current branch. The skill iterates through the v
 
 - **Working tree clean.** `git status --porcelain` must return empty. When dirty, abort and ask the developer to commit first.
 
-- **Rebased on the latest `master`.** Resolve the master remote. Use the one the developer names, otherwise `upstream`, otherwise `origin`. When none resolves, compare `git merge-base HEAD master` to `git rev-parse master`. Abort and tell the developer to rebase when the two differ, and warn that the branch was not checked against a remote. Otherwise run these steps.
+- **Rebased on the latest `master`.** Resolve the master remote. Prefer `upstream`, otherwise the remote whose URL points at `liferay/liferay-portal` (check `git remote --verbose`). When none resolves, compare `git merge-base HEAD master` to `git rev-parse master`. Abort and tell the developer to rebase when the two differ, and warn that the branch was not checked against a remote. Otherwise run these steps.
 
 	1. `git fetch <remote> master`.
 

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -20,9 +20,9 @@ Run premerge checks against the current branch. The skill iterates through the v
 
 	1. `git fetch <remote> master`.
 
-	1. Fast forward local `master` to the fetched tip. When `master` is checked out in another worktree, fast forward it there with `git -C <worktree> merge --ff-only <remote>/master`. Otherwise update it in place with `git fetch <remote> master:master`. Both forms are fast forward only, so a diverged `master` makes the command fail. Warn and stop rather than rewriting it.
+	1. Fast forward local `master` to the fetched tip. When `master` is checked out in another worktree, fast forward it there with `git -C <worktree> merge --ff-only <remote>/master`. Otherwise update it in place with `git fetch <remote> master:master`, which also creates `master` when it does not exist. Both are fast forward only. When the command fails, because `master` has diverged or its worktree is not clean, warn the developer and stop the run.
 
-	1. `git rebase <remote>/master`. On a clean rebase, continue against the rebased branch. On conflict, list the unmerged files (`git diff --diff-filter=U --name-only`) and ask the developer who should resolve the conflicts. When the developer chooses to resolve them, run `git rebase --abort` and FAIL. When the developer asks you to resolve them, fix the conflicts, `git add` the files, and run `git rebase --continue`. When the conflicts cannot be resolved, run `git rebase --abort` and FAIL.
+	1. `git rebase <remote>/master`. On a clean rebase, continue against the rebased branch. On conflict, list the unmerged files (`git diff --diff-filter=U --name-only`) and ask the developer who should resolve the conflicts. When the developer asks you to resolve them, fix the conflicts, `git add` the files, and run `git rebase --continue`. In every other case (the developer resolves them, the conflicts cannot be resolved, or the rebase fails otherwise) run `git rebase --abort` and stop the run.
 
 - **Diff baseline is local `master`.** After the rebase, the three-dot diff against local `master` is the baseline.
 

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -18,7 +18,7 @@ Run premerge checks against the current branch. The skill iterates through the v
 
 	1. `git fetch <remote> master`.
 
-	1. Fast forward local `master` to the fetched tip. When local `master` has diverged, warn and stop.
+	1. Fast forward local `master` to the fetched tip. When `master` is checked out in another worktree, fast forward it there with `git -C <worktree> merge --ff-only <remote>/master`. Otherwise update it in place with `git fetch <remote> master:master`. Both forms are fast forward only, so a diverged `master` makes the command fail. Warn and stop rather than rewriting it.
 
 	1. `git rebase <remote>/master`. On a clean rebase, continue against the rebased branch. On conflict, list the unmerged files (`git diff --diff-filter=U --name-only`) and ask the developer who should resolve the conflicts. When the developer chooses to resolve them, run `git rebase --abort` and FAIL. When the developer asks you to resolve them, fix the conflicts, `git add` the files, and run `git rebase --continue`. When the conflicts cannot be resolved, run `git rebase --abort` and FAIL.
 

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -20,7 +20,7 @@ Run premerge checks against the current branch. The skill iterates through the v
 
 	1. Fast forward local `master` to the fetched tip. When local `master` has diverged, warn and stop.
 
-	1. `git rebase <remote>/master`. On a clean rebase, continue against the rebased branch. On conflict, list the unmerged files (`git diff --diff-filter=U --name-only`) and ask the developer who should resolve the conflicts. When the developer chooses to, run `git rebase --abort` and FAIL. When the developer asks you to, fix the conflicts, `git add` the files, and run `git rebase --continue`. When the conflicts cannot be resolved, run `git rebase --abort` and FAIL.
+	1. `git rebase <remote>/master`. On a clean rebase, continue against the rebased branch. On conflict, list the unmerged files (`git diff --diff-filter=U --name-only`) and ask the developer who should resolve the conflicts. When the developer chooses to resolve them, run `git rebase --abort` and FAIL. When the developer asks you to resolve them, fix the conflicts, `git add` the files, and run `git rebase --continue`. When the conflicts cannot be resolved, run `git rebase --abort` and FAIL.
 
 - **Diff baseline is local `master`.** After the rebase, the three-dot diff against local `master` is the baseline.
 

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -12,6 +12,8 @@ Run premerge checks against the current branch. The skill iterates through the v
 
 ## Preconditions
 
+- **On a feature branch.** When `HEAD` is `master` or detached, exit with a one-line message.
+
 - **Working tree clean.** `git status --porcelain` must return empty. When dirty, abort and ask the developer to commit first.
 
 - **Rebased on the latest `master`.** Resolve the master remote. Use the one the developer names, otherwise `upstream`, otherwise `origin`. When none resolves, compare `git merge-base HEAD master` to `git rev-parse master`. Abort and tell the developer to rebase when the two differ, and warn that the branch was not checked against a remote. Otherwise run these steps.

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -12,11 +12,17 @@ Run premerge checks against the current branch. The skill iterates through the v
 
 ## Preconditions
 
-- **Branch rebased on local `master`.** Compare `git merge-base HEAD master` to `git rev-parse master`; when they differ, abort and tell the developer to rebase (`git rebase master`). The `format-source-current-branch` validation diffs against the local `master` tip to decide which files to format — when the branch's merge-base lags behind that tip, SF picks up reverse-direction diffs from the master commits the branch has not absorbed and the `<TICKET> SF` autocommit captures unrelated rewrites.
+- **Working tree clean.** `git status --porcelain` must return empty. When dirty, abort and ask the developer to commit first.
 
-- **Working tree clean.** `git status --porcelain` must return empty. When dirty, abort and ask the developer to commit first — the autocommit steps inside drift validations would otherwise capture their uncommitted edits.
+- **Rebased on the latest `master`.** Resolve the master remote. Use the one the developer names, otherwise `upstream`, otherwise `origin`. When none resolves, compare `git merge-base HEAD master` to `git rev-parse master`. Abort and tell the developer to rebase when the two differ, and warn that the branch was not checked against a remote. Otherwise run these steps.
 
-- **Diff baseline is local `master`.** The skill never fetches from a remote and does not compare against an `upstream/master` ref. Whether local `master` is up to date is the developer's call.
+	1. `git fetch <remote> master`.
+
+	1. Fast forward local `master` to the fetched tip. When local `master` has diverged, warn and stop.
+
+	1. `git rebase <remote>/master`. On a clean rebase, continue against the rebased branch. On conflict, list the unmerged files (`git diff --diff-filter=U --name-only`) and ask the developer who should resolve the conflicts. When the developer chooses to, run `git rebase --abort` and FAIL. When the developer asks you to, fix the conflicts, `git add` the files, and run `git rebase --continue`. When the conflicts cannot be resolved, run `git rebase --abort` and FAIL.
+
+- **Diff baseline is local `master`.** After the rebase, the three-dot diff against local `master` is the baseline.
 
 - **Diff is nonempty.** When the three-dot diff produces no files, exit with a one-line message — no validation produces useful signal on a clean branch.
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7755

## What Is Being Fixed

pr-check compared the branch only against local `master` and never fetched a remote, so a stale local `master` let a branch that conflicts with the latest `master` pass pr-check and then get rejected on GitHub. This catches those rebase conflicts locally, before the PR is sent.

## How It Is Being Fixed

pr-check now rebases the branch onto the latest `master` before any validation runs. It resolves the canonical remote (prefer `upstream`, otherwise the remote whose URL is `liferay/liferay-portal`), fetches it, fast forwards local `master`, and rebases. It runs only on a feature branch with a clean tree.

## Addressing the Review Feedback

Responding to the AI review on the forwarded PR https://github.com/brianchandotcom/liferay-portal/pull/177646:

- Mutating the repo is intentional. A clean rebase rewrites the branch onto the current tree so the run reflects how it will merge, and a conflict aborts the rebase and stops the run with no result, so nothing is left half done.

- The conflict step names who acts. It asks the developer who should resolve the conflicts and resolves them only when asked.

- The fast forward is explicit. Step 2 gives the command and fast forwards `master` in its own worktree when it is checked out elsewhere, which a plain `git fetch master:master` cannot.

## Why Are There No Tests?

A documentation only change to the pr-check skill, with no portal code to test.

## PR Check

**pr-check: PASS** — tested on `5eab7d7ce356584be75d715ca7ea1012c7b29c3d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "5eab7d7ce356584be75d715ca7ea1012c7b29c3d"} -->
