### PR TITLE
LRCI-7523 Add unit tests for per-job cache and archive behavior

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsBuildPropertiesTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsBuildPropertiesTest.java
@@ -19,6 +19,16 @@ public class JenkinsBuildPropertiesTest
 	extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
+	public void testBinariesCacheEnabledProperties() {
+		_testGetProperty(
+			"binaries.cache.enabled", "false", "forward-pullrequest");
+		_testGetProperty(
+			"binaries.cache.enabled", "false", "test-portal-source-format");
+		_testGetProperty(
+			"binaries.cache.enabled", "true", "test-portal-release");
+	}
+
+	@Test
 	public void testBuildCachingEnabledProperties() {
 		_testGetProperty(
 			"build.caching.enabled", "false", "forward-pullrequest");
@@ -30,6 +40,14 @@ public class JenkinsBuildPropertiesTest
 			"build.caching.enabled", "true", "test-portal-hotfix-release");
 		_testGetProperty(
 			"build.caching.enabled", "true", "test-portal-release");
+	}
+
+	@Test
+	public void testGitArchiveEnabledProperties() {
+		_testGetProperty("git.archive.enabled", "false", "forward-pullrequest");
+		_testGetProperty(
+			"git.archive.enabled", "false", "test-portal-source-format");
+		_testGetProperty("git.archive.enabled", "true", "test-portal-release");
 	}
 
 	private Properties _getBuildAwsProperties() {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsBuildPropertiesTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsBuildPropertiesTest.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.File;
+
+import java.util.Properties;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+/**
+ * @author Kenji Heigel
+ */
+public class JenkinsBuildPropertiesTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testBuildCachingEnabledProperties() {
+		_testGetProperty(
+			"build.caching.enabled", "false", "forward-pullrequest");
+		_testGetProperty(
+			"build.caching.enabled", "false", "test-portal-source-format");
+		_testGetProperty(
+			"build.caching.enabled", "true", "test-portal-fixpack-release");
+		_testGetProperty(
+			"build.caching.enabled", "true", "test-portal-hotfix-release");
+		_testGetProperty(
+			"build.caching.enabled", "true", "test-portal-release");
+	}
+
+	private Properties _getBuildAwsProperties() {
+		File jenkinsRepositoryDir =
+			JenkinsResultsParserUtil.getJenkinsRepositoryDir();
+
+		File buildAwsPropertiesFile = new File(
+			jenkinsRepositoryDir, "commands/build-aws.properties");
+
+		Assume.assumeTrue(
+			JenkinsResultsParserUtil.getCanonicalPath(buildAwsPropertiesFile) +
+				" does not exist",
+			buildAwsPropertiesFile.exists());
+
+		return JenkinsResultsParserUtil.getProperties(buildAwsPropertiesFile);
+	}
+
+	private void _testGetProperty(
+		String basePropertyName, String expectedValue, String jobName) {
+
+		testEquals(
+			expectedValue,
+			JenkinsResultsParserUtil.getProperty(
+				_getBuildAwsProperties(), basePropertyName, jobName));
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -324,6 +324,39 @@ public class JenkinsResultsParserUtilTest
 	}
 
 	@Test
+	public void testIsBuildCachingEnabledCloudCINode() {
+		Environment environment = mockEnvironment();
+
+		JenkinsResultsParserUtil.clearCache();
+
+		Mockito.when(
+			environment.doGet("BUILD_CACHING_ENABLED")
+		).thenReturn(
+			"true"
+		);
+
+		Mockito.when(
+			environment.doGet("MASTER_NETWORK_NAME")
+		).thenReturn(
+			"aws-network"
+		);
+
+		Assert.assertTrue(
+			JenkinsResultsParserUtil.isBuildCachingEnabled(
+				"test-portal-release", "default"));
+
+		Mockito.when(
+			environment.doGet("BUILD_CACHING_ENABLED")
+		).thenReturn(
+			"false"
+		);
+
+		Assert.assertFalse(
+			JenkinsResultsParserUtil.isBuildCachingEnabled(
+				"test-portal-release", "default"));
+	}
+
+	@Test
 	public void testIsBuildCachingEnabledNonCINode() {
 		Environment environment = mockEnvironment();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -16,6 +16,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -320,6 +321,23 @@ public class JenkinsResultsParserUtilTest
 			"https://releases.liferay.com/portal/",
 			JenkinsResultsParserUtil.getRemoteURL(
 				"https://releases.liferay.com/portal/"));
+	}
+
+	@Test
+	public void testIsBuildCachingEnabledNonCINode() {
+		Environment environment = mockEnvironment();
+
+		JenkinsResultsParserUtil.clearCache();
+
+		Mockito.when(
+			environment.doGet("BUILD_CACHING_ENABLED")
+		).thenReturn(
+			"true"
+		);
+
+		Assert.assertFalse(
+			JenkinsResultsParserUtil.isBuildCachingEnabled(
+				"test-portal-release", "default"));
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -254,6 +254,31 @@ public class JenkinsResultsParserUtilTest
 	}
 
 	@Test
+	public void testGetPropertyNameWithWildcards() {
+		Properties properties = new Properties();
+
+		properties.setProperty("build.caching.enabled", "false");
+		properties.setProperty(
+			"build.caching.enabled[test-portal-acceptance-pullrequest(*)]",
+			"true");
+		properties.setProperty(
+			"build.caching.enabled[test-portal-acceptance-pullrequest(master)]",
+			"false");
+
+		_testGetPropertyName(
+			"build.caching.enabled", "false", properties,
+			"build.caching.enabled", "test-portal-source-format");
+		_testGetPropertyName(
+			"build.caching.enabled[test-portal-acceptance-pullrequest(*)]",
+			"true", properties, "build.caching.enabled",
+			"test-portal-acceptance-pullrequest(ee-7.4.x)");
+		_testGetPropertyName(
+			"build.caching.enabled[test-portal-acceptance-pullrequest(master)]",
+			"false", properties, "build.caching.enabled",
+			"test-portal-acceptance-pullrequest(master)");
+	}
+
+	@Test
 	public void testGetRemoteURL() {
 		testEquals(
 			"https://test-1-20.liferay.com/ABC?123=456&xyz=abc",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7523

**What is being fixed:** This adds regression coverage for how per-job build cache and git archive behavior is resolved. Three areas had no unit tests. The wildcard path in getPropertyName that the per-job caching config relies on was untested. The isCloudCINode gate and BUILD_CACHING_ENABLED override inside isBuildCachingEnabled were untested. And the per-job opt-in matrix in build-aws.properties had nothing pinning it, which is the exact gap that let LRCI-7411 drop the release jobs from the caching opt-in list and cause LRCI-7447.

**How it is being fixed:** The coverage lands in five commits and every test was validated red then green against the behavior it guards. The first pins wildcard property name resolution so an exact job entry beats a (*) wildcard which beats the base default. The second pins isBuildCachingEnabled staying false off a cloud CI node even when the environment override is set. The third pins the BUILD_CACHING_ENABLED environment override deciding the result on a cloud CI node. The fourth pins the resolved build.caching.enabled value for the release jobs as true and for the opt-out jobs as false. The fifth pins the decoupled binaries.cache.enabled and git.archive.enabled values per job, one test per property. The config pins read the live build-aws.properties and skip when the jenkins-ee checkout is absent.