### PR TITLE
LRCI-7790 Optimize the modules-compile and playwright-compile batches

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -8764,6 +8764,12 @@ information. Make sure to commit in all format-javadoc results.
 				<gradle-execute dir="modules" task="${modules.compile.tasks}">
 					<arg value="--continue" />
 					<arg value="--parallel" />
+					<arg value="--exclude-task" />
+					<arg value="javadoc" />
+					<arg value="--exclude-task" />
+					<arg value="jarJavadoc" />
+					<arg value="--exclude-task" />
+					<arg value="jarSources" />
 				</gradle-execute>
 			</test-action>
 

--- a/test.properties
+++ b/test.properties
@@ -1426,7 +1426,7 @@
 
     test.batch.aspectj.enabled=false
 
-    test.batch.axis.count[modules-compile]=6
+    test.batch.axis.count[modules-compile]=3
     test.batch.axis.count[modules-integration-analytics-cloud]=1
     test.batch.axis.count[playwright-compile]=1
     test.batch.axis.count[playwright-js-smoke*]=1

--- a/test.properties
+++ b/test.properties
@@ -1666,6 +1666,7 @@
         javadoc-test,\
         js-unit,\
         modules-semantic-versioning,\
+        playwright-compile,\
         portal-frontend-js-lint,\
         poshi-validation,\
         rest-builder,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7790

Part of @ealonso's stable test suite work in https://github.com/ealonso/liferay-portal/pull/3514, carrying only the compile-batch changes. The stable integration test consolidation is handled separately.

## What Is Being Fixed

The modules-compile batch assembled javadoc and source jars that do not validate compilation, playwright compilation ran inside another batch rather than on its own, and modules-compile fanned out across six axes even though the work fits comfortably in fewer.

## How It Is Being Fixed

The modules-compile batch stops assembling javadoc and source jars by excluding jarJavadoc and jarSources from :assemble while keeping :jar and bnd, so the OSGi checks are unchanged. Playwright compilation moves into its own standalone batch so it no longer competes for slots inside an unrelated batch. And the modules-compile axis count drops from six to three.

## Compute Saved Per Build

| Change | Estimated | Measured |
| --- | --- | --- |
| Skip javadoc and source jars in modules-compile | ~15 min | ~15 min |
| Reduce modules-compile axes from six to three | n/a | ~20 min |
| Total | ~15 min | ~35 min |

The modules-compile batch dropped from about 76 minutes of slave time across six axes to about 40 minutes across three.

## Why Are There No Tests?

The change set covers CI batch composition rather than product code, so it adds no new automated tests.
