### PR TITLE
LRCI-7523 Add unit tests for per-job cache and archive behavior

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -388,6 +388,39 @@ public class JenkinsResultsParserUtilTest
 	}
 
 	@Test
+	public void testIsBuildCachingEnabledCloudCINode() {
+		Environment environment = mockEnvironment();
+
+		JenkinsResultsParserUtil.clearCache();
+
+		Mockito.when(
+			environment.doGet("BUILD_CACHING_ENABLED")
+		).thenReturn(
+			"true"
+		);
+
+		Mockito.when(
+			environment.doGet("MASTER_NETWORK_NAME")
+		).thenReturn(
+			"aws-network"
+		);
+
+		Assert.assertTrue(
+			JenkinsResultsParserUtil.isBuildCachingEnabled(
+				"test-portal-release", "default"));
+
+		Mockito.when(
+			environment.doGet("BUILD_CACHING_ENABLED")
+		).thenReturn(
+			"false"
+		);
+
+		Assert.assertFalse(
+			JenkinsResultsParserUtil.isBuildCachingEnabled(
+				"test-portal-release", "default"));
+	}
+
+	@Test
 	public void testIsBuildCachingEnabledNonCINode() {
 		Environment environment = mockEnvironment();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -282,6 +282,31 @@ public class JenkinsResultsParserUtilTest
 	}
 
 	@Test
+	public void testGetPropertyNameWithWildcards() {
+		Properties properties = new Properties();
+
+		properties.setProperty("build.caching.enabled", "false");
+		properties.setProperty(
+			"build.caching.enabled[test-portal-acceptance-pullrequest(*)]",
+			"true");
+		properties.setProperty(
+			"build.caching.enabled[test-portal-acceptance-pullrequest(master)]",
+			"false");
+
+		_testGetPropertyName(
+			"build.caching.enabled", "false", properties,
+			"build.caching.enabled", "test-portal-source-format");
+		_testGetPropertyName(
+			"build.caching.enabled[test-portal-acceptance-pullrequest(*)]",
+			"true", properties, "build.caching.enabled",
+			"test-portal-acceptance-pullrequest(ee-7.4.x)");
+		_testGetPropertyName(
+			"build.caching.enabled[test-portal-acceptance-pullrequest(master)]",
+			"false", properties, "build.caching.enabled",
+			"test-portal-acceptance-pullrequest(master)");
+	}
+
+	@Test
 	public void testGetRemoteURL() {
 		testEquals(
 			"https://test-1-20.liferay.com/ABC?123=456&xyz=abc",

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -19,6 +19,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -384,6 +385,23 @@ public class JenkinsResultsParserUtilTest
 								duration))));
 			}
 		}
+	}
+
+	@Test
+	public void testIsBuildCachingEnabledNonCINode() {
+		Environment environment = mockEnvironment();
+
+		JenkinsResultsParserUtil.clearCache();
+
+		Mockito.when(
+			environment.doGet("BUILD_CACHING_ENABLED")
+		).thenReturn(
+			"true"
+		);
+
+		Assert.assertFalse(
+			JenkinsResultsParserUtil.isBuildCachingEnabled(
+				"test-portal-release", "default"));
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -20,6 +20,7 @@ import org.json.JSONObject;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -305,6 +306,42 @@ public class JenkinsResultsParserUtilTest
 			"build.caching.enabled[test-portal-acceptance-pullrequest(master)]",
 			"false", properties, "build.caching.enabled",
 			"test-portal-acceptance-pullrequest(master)");
+	}
+
+	@Test
+	public void testGetPropertyWithBuildAwsProperties() {
+		Properties properties = _getBuildAwsProperties();
+
+		_testGetProperty(
+			"false", properties, "binaries.cache.enabled",
+			"forward-pullrequest");
+		_testGetProperty(
+			"true", properties, "binaries.cache.enabled",
+			"test-portal-release");
+		_testGetProperty(
+			"false", properties, "binaries.cache.enabled",
+			"test-portal-source-format");
+		_testGetProperty(
+			"false", properties, "build.caching.enabled",
+			"forward-pullrequest");
+		_testGetProperty(
+			"true", properties, "build.caching.enabled",
+			"test-portal-fixpack-release");
+		_testGetProperty(
+			"true", properties, "build.caching.enabled",
+			"test-portal-hotfix-release");
+		_testGetProperty(
+			"true", properties, "build.caching.enabled", "test-portal-release");
+		_testGetProperty(
+			"false", properties, "build.caching.enabled",
+			"test-portal-source-format");
+		_testGetProperty(
+			"false", properties, "git.archive.enabled", "forward-pullrequest");
+		_testGetProperty(
+			"true", properties, "git.archive.enabled", "test-portal-release");
+		_testGetProperty(
+			"false", properties, "git.archive.enabled",
+			"test-portal-source-format");
 	}
 
 	@Test
@@ -642,6 +679,21 @@ public class JenkinsResultsParserUtilTest
 		return JenkinsResultsParserUtil.fixURL(
 			JenkinsResultsParserUtil.fixURL(
 				JenkinsResultsParserUtil.fixURL(urlString)));
+	}
+
+	private Properties _getBuildAwsProperties() {
+		File jenkinsRepositoryDir =
+			JenkinsResultsParserUtil.getJenkinsRepositoryDir();
+
+		File buildAwsPropertiesFile = new File(
+			jenkinsRepositoryDir, "commands/build-aws.properties");
+
+		Assume.assumeTrue(
+			JenkinsResultsParserUtil.getCanonicalPath(buildAwsPropertiesFile) +
+				" does not exist",
+			buildAwsPropertiesFile.exists());
+
+		return JenkinsResultsParserUtil.getProperties(buildAwsPropertiesFile);
 	}
 
 	private void _testGetProperty(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7523

Resend of https://github.com/brianchandotcom/liferay-portal/pull/178087

**What is being fixed:** This adds regression coverage for how per-job build cache and git archive behavior is resolved. Three areas had no unit tests. The wildcard path in getPropertyName that the per-job caching config relies on was untested. The isCloudCINode gate and BUILD_CACHING_ENABLED override inside isBuildCachingEnabled were untested. And the per-job opt-in matrix in build-aws.properties had nothing pinning it, which is the exact gap that let LRCI-7411 drop the release jobs from the caching opt-in list and cause LRCI-7447.

**How it is being fixed:** The coverage lands in four commits and every test was validated red then green against the behavior it guards. The first pins wildcard property name resolution so an exact job entry beats a (*) wildcard which beats the base default. The second pins isBuildCachingEnabled staying false off a cloud CI node even when the environment override is set. The third pins the BUILD_CACHING_ENABLED environment override deciding the result on a cloud CI node. The fourth pins the resolved per-job values of build.caching.enabled, binaries.cache.enabled, and git.archive.enabled, with the release jobs as true and the opt-out jobs as false. The config pins read the live build-aws.properties and skip when the jenkins-ee checkout is absent. This supersedes closed PR #2137 and addresses the review feedback there, most recently collapsing the property pins into a single testGetProperty named for the method under test.