### PR TITLE
LRCI-7842 Run format-source-current-branch in pr-check

### DIFF
--- a/.claude/skills/pr-check/validations/source-format.md
+++ b/.claude/skills/pr-check/validations/source-format.md
@@ -10,17 +10,16 @@ Always.
 
 ## Command
 
-Run the SDK setup, then invoke the `format-source` skill:
+Run the SDK setup, then run the source formatter in `current-branch` mode:
 
 ```bash
 (cd "${REPO_ROOT}" && ant setup-sdk)
+(cd "${REPO_ROOT}/portal-impl" && ANT_OPTS="-Xmx2560m" ant format-source-current-branch)
 ```
-
-The skill runs the dual-mode formatter (automatically applies fixable violations and lists unfixable ones) and then applies the manual rules. Unfixable violations fail pr-check so the developer fixes them manually.
 
 ## Autocommit
 
-The formatter is dual-mode: it automatically applies fixable violations and lists unfixable ones as errors. When `git status --porcelain` is nonempty after the formatter (fixable subset applied), stage all changes (`git add --all`) and create a commit titled `<TICKET> SF`.
+When `git status --porcelain` is nonempty after the formatter (fixable subset applied to the working tree), stage all changes (`git add --all`) and create a commit titled `<TICKET> SF`.
 
 When the commit fails, record the failure and continue to the next validation.
 
@@ -32,4 +31,4 @@ Run **after** all drift validations so the formatter sees the regenerated tree.
 
 ## Time Estimate
 
-~1-2 min.
+~2-4 min, scaling with the number of changed files.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7842

## What Is Being Fixed

pr-check's Source Format validation ran the module-scoped `gradlew formatSource`, which leaves `format.current.branch` false. That skips every current-branch-only source-formatter check CI runs through `ant format-source-current-branch`, including the copyright-year check on newly added files. A branch could pass pr-check locally and then fail CI on a formatting error pr-check never looked for.

## How It Is Being Fixed

The Source Format validation now runs `ant format-source-current-branch`, the same target CI runs. It is a strict superset of the old module-scoped call — the same checks plus the current-branch-only ones — so the `gradlew formatSource` invocation is dropped. The manual style rules previously applied through the `format-source` skill are dropped from this step as well, leaving it a faithful mirror of CI's source-format gate.

## Why Are There No Tests?

The change touches only a pr-check skill Markdown file. There is no code to test.

## PR Check

**pr-check: PASS** — tested on `f792ae0aa2822b827a9c3bc43dbd6e1607b5c263`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "f792ae0aa2822b827a9c3bc43dbd6e1607b5c263"} -->
