### PR TITLE
LRCI-7844 Run js-unit module tests in parallel within an axis

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -8498,7 +8498,7 @@ information. Make sure to commit in all format-javadoc results.
 			<test-action>
 				<property name="js.unit.failure.count" value="0" />
 
-				<for delimiter=" " list="${modules.test.class.group}" param="modules.test.class" trim="true">
+				<for delimiter=" " list="${modules.test.class.group}" parallel="true" param="modules.test.class" threadCount="3" trim="true">
 					<sequential>
 						<echo>Executing Gradle tasks: @{modules.test.class}.</echo>
 


### PR DESCRIPTION
## Purpose

Test branch to measure the effect of parallelizing js-unit module execution within a single axis. Not for merge as-is.

## Change

The `js-unit` target in `build-test-batch.xml` runs its modules through a sequential ant-contrib `<for>` loop, one `gradle-execute` per module. In CI every module forks a fresh `--no-daemon` Gradle JVM, so a large share of each axis's ~22 min wall time is per-module startup paid one module at a time (measured: ~14s startup vs ~13s actual jest for a sample module). This flips the loop to `parallel="true" threadCount="3"` so several modules run concurrently.

## What to look for in the run

- js-unit axis wall time vs baseline (~22-26 min/axis on the stable suite).
- RAM/CPU headroom on the slave (floor is `test.batch.minimum.slave.ram[js-unit]=24`); jest already spawns its own workers, so watch for CPU oversubscription.

## Known caveat (do not read a green as full validation)

`js.unit.failure.count` is incremented inside the per-module catch and checked by a `<fail>` after the loop. Under `parallel="true"` those `<math>` increments can race and undercount, so a module-level execution failure could be masked. Individual test failures still surface via the per-module `TEST-frontend-js.xml` files (race-free). Making the count thread-safe is the follow-up before this could ship.