### PR TITLE
LRCI-7525 Add unit tests for batch generation and JS unit test names

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JSUnitJUnitTestResultTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JSUnitJUnitTestResultTest.java
@@ -43,11 +43,11 @@ public class JSUnitJUnitTestResultTest
 			).put(
 				"className", className
 			).put(
-				"duration", 0.5
+				"duration", RandomTestUtil.randomDouble()
 			).put(
-				"name", "renders the component"
+				"name", RandomTestUtil.randomString()
 			).put(
-				"status", "PASSED"
+				"status", RandomTestUtil.randomString()
 			));
 
 		return jsUnitJUnitTestResult.getTestTaskName();

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JSUnitJUnitTestResultTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JSUnitJUnitTestResultTest.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import org.json.JSONObject;
+
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Kenji Heigel
+ */
+public class JSUnitJUnitTestResultTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetTestTaskName() {
+		testEquals(
+			":apps:frontend-js:frontend-js-clay-web:packageRunTest",
+			_getTestTaskName(
+				"liferay-portal.modules.apps.frontend-js.frontend-js-clay-" +
+					"web.clay.clay-button.src.__tests__.index"));
+		testEquals(
+			":apps:frontend-js:frontend-js-web:packageRunTest",
+			_getTestTaskName(
+				"liferay-portal.modules.apps.frontend-js.frontend-js-web.src." +
+					"__tests__.index"));
+		testEquals(
+			":apps:portal-search:portal-search-web:packageRunTest",
+			_getTestTaskName(
+				"liferay-portal.modules.apps.portal-search.portal-search-" +
+					"web.test.js.index"));
+	}
+
+	private String _getTestTaskName(String className) {
+		JSUnitJUnitTestResult jsUnitJUnitTestResult = new JSUnitJUnitTestResult(
+			Mockito.mock(Build.class),
+			new JSONObject(
+			).put(
+				"className", className
+			).put(
+				"duration", 0.5
+			).put(
+				"name", "renders the component"
+			).put(
+				"status", "PASSED"
+			));
+
+		return jsUnitJUnitTestResult.getTestTaskName();
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JSUnitTestReportTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JSUnitTestReportTest.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import org.json.JSONObject;
+
+import org.junit.Test;
+
+/**
+ * @author Kenji Heigel
+ */
+public class JSUnitTestReportTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetTestTaskName() {
+		testEquals(
+			":apps:frontend-js:frontend-js-clay-web:packageRunTest",
+			_getTestTaskName(
+				"liferay-portal.modules.apps.frontend-js.frontend-js-clay-" +
+					"web.clay.clay-button.src.__tests__.index"));
+		testEquals(
+			":apps:frontend-js:frontend-js-web:packageRunTest",
+			_getTestTaskName(
+				"liferay-portal.modules.apps.frontend-js.frontend-js-web.src." +
+					"__tests__.index"));
+		testEquals(
+			":apps:portal-search:portal-search-web:packageRunTest",
+			_getTestTaskName(
+				"liferay-portal.modules.apps.portal-search.portal-search-" +
+					"web.test.js.index"));
+	}
+
+	private String _getTestTaskName(String testName) {
+		JSUnitTestReport jsUnitTestReport = new JSUnitTestReport(
+			null,
+			new JSONObject(
+			).put(
+				"name", testName
+			));
+
+		return jsUnitTestReport.getTestTaskName();
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RandomTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RandomTestUtil.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * @author Kenji Heigel
+ */
+public class RandomTestUtil {
+
+	public static double randomDouble() {
+		return _random.nextDouble();
+	}
+
+	public static String randomString() {
+		UUID uuid = UUID.randomUUID();
+
+		return uuid.toString();
+	}
+
+	private static final Random _random = new Random();
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroupTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroupTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.jenkins.results.parser.test.clazz.group;
 
+import com.liferay.jenkins.results.parser.RandomTestUtil;
 import com.liferay.jenkins.results.parser.test.clazz.TestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClassFactory;
 
@@ -35,7 +36,7 @@ public class BatchTestClassGroupTest
 			batchTestClassGroup.addTestClass(
 				TestClassFactory.newTestClass(
 					batchTestClassGroup,
-					new File("test-class-" + i)));
+					new File(RandomTestUtil.randomString())));
 		}
 
 		batchTestClassGroup.setAxisTestClassGroups();

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroupTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroupTest.java
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.test.clazz.group;
+
+import com.liferay.jenkins.results.parser.test.clazz.TestClass;
+import com.liferay.jenkins.results.parser.test.clazz.TestClassFactory;
+
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Kenji Heigel
+ */
+public class BatchTestClassGroupTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetAxisTestClassGroups() {
+		BatchTestClassGroup batchTestClassGroup = new BatchTestClassGroup(
+			"default", BatchTestClassGroupTestUtil.getPortalTestClassJob()) {
+		};
+
+		int axisMaxSize = batchTestClassGroup.getAxisMaxSize();
+
+		for (int i = 0; i < (axisMaxSize + 2); i++) {
+			batchTestClassGroup.addTestClass(
+				TestClassFactory.newTestClass(
+					batchTestClassGroup,
+					new File("test-class-" + i)));
+		}
+
+		batchTestClassGroup.setAxisTestClassGroups();
+
+		List<TestClass> testClasses = batchTestClassGroup.getTestClasses();
+
+		List<AxisTestClassGroup> axisTestClassGroups =
+			batchTestClassGroup.getAxisTestClassGroups();
+
+		Assert.assertEquals(
+			axisTestClassGroups.toString(),
+			(int)Math.ceil((double)testClasses.size() / axisMaxSize),
+			axisTestClassGroups.size());
+
+		List<TestClass> axisTestClasses = new ArrayList<>();
+
+		for (AxisTestClassGroup axisTestClassGroup : axisTestClassGroups) {
+			axisTestClasses.addAll(axisTestClassGroup.getTestClasses());
+		}
+
+		Collections.sort(axisTestClasses);
+
+		Assert.assertEquals(testClasses, axisTestClasses);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroupTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroupTestUtil.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.test.clazz.group;
+
+import com.liferay.jenkins.results.parser.GitWorkingDirectoryFactory;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.Job;
+import com.liferay.jenkins.results.parser.JobFactory;
+import com.liferay.jenkins.results.parser.PortalGitWorkingDirectory;
+import com.liferay.jenkins.results.parser.PortalTestClassJob;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Kenji Heigel
+ */
+public class BatchTestClassGroupTestUtil {
+
+	public static PortalTestClassJob getPortalTestClassJob() {
+		if (_portalTestClassJob != null) {
+			return _portalTestClassJob;
+		}
+
+		String repositoryName = "liferay-portal";
+		String upstreamBranchName = "master";
+
+		PortalGitWorkingDirectory portalGitWorkingDirectory = Mockito.spy(
+			(PortalGitWorkingDirectory)
+				GitWorkingDirectoryFactory.newGitWorkingDirectory(
+					upstreamBranchName,
+					JenkinsResultsParserUtil.getGitWorkingDir(new File(".")),
+					repositoryName));
+
+		try {
+			Mockito.doReturn(
+				Collections.emptyList()
+			).when(
+				portalGitWorkingDirectory
+			).getModifiedModuleDirsList(
+				Mockito.anyList(), Mockito.anyList()
+			);
+
+			Mockito.doReturn(
+				Collections.emptyList()
+			).when(
+				portalGitWorkingDirectory
+			).getModifiedNonposhiModules();
+
+			Mockito.doReturn(
+				Collections.emptyList()
+			).when(
+				portalGitWorkingDirectory
+			).getModifiedPoshiModules();
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+
+		_portalTestClassJob = (PortalTestClassJob)JobFactory.newJob(
+			Job.BuildProfile.DXP, "test-portal-acceptance-pullrequest(master)",
+			null, portalGitWorkingDirectory, upstreamBranchName, null,
+			repositoryName, "relevant", upstreamBranchName);
+
+		List<File> jobPropertiesFiles =
+			_portalTestClassJob.getJobPropertiesFiles();
+
+		jobPropertiesFiles.clear();
+
+		jobPropertiesFiles.add(
+			new File(
+				"src/test/resources/dependencies/test/clazz/group" +
+					"/BatchTestClassGroupTestUtil/test.properties"));
+
+		return _portalTestClassJob;
+	}
+
+	public static ServiceBuilderModulesBatchTestClassGroup
+		newServiceBuilderModulesBatchTestClassGroup(
+			String... modifiedFilePaths) {
+
+		PortalTestClassJob portalTestClassJob = getPortalTestClassJob();
+
+		PortalGitWorkingDirectory portalGitWorkingDirectory =
+			portalTestClassJob.getPortalGitWorkingDirectory();
+
+		List<File> modifiedFiles = new ArrayList<>();
+
+		File workingDirectory = portalGitWorkingDirectory.getWorkingDirectory();
+
+		for (String modifiedFilePath : modifiedFilePaths) {
+			modifiedFiles.add(new File(workingDirectory, modifiedFilePath));
+		}
+
+		Mockito.doReturn(
+			modifiedFiles
+		).when(
+			portalGitWorkingDirectory
+		).getModifiedFilesList();
+
+		return new ServiceBuilderModulesBatchTestClassGroup(
+			"service-builder-modules", portalTestClassJob);
+	}
+
+	private static PortalTestClassJob _portalTestClassJob;
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroupTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroupTest.java
@@ -24,6 +24,24 @@ public class ServiceBuilderModulesBatchTestClassGroupTest
 	@Test
 	public void testGetBuildType() {
 		_testGetBuildType(
+			ServiceBuilderModulesBatchTestClassGroup.BuildType.CORE,
+			"portal-impl/src/com/liferay/portal/service/impl" +
+				"/UserLocalServiceImpl.java");
+		_testGetBuildType(
+			ServiceBuilderModulesBatchTestClassGroup.BuildType.CORE,
+			"portal-kernel/src/com/liferay/portal/kernel/service" +
+				"/UserLocalService.java");
+		_testGetBuildType(
+			ServiceBuilderModulesBatchTestClassGroup.BuildType.FULL,
+			"modules/util/portal-tools-service-builder/src/main/java/com" +
+				"/liferay/portal/tools/service/builder/ServiceBuilder.java");
+		_testGetBuildType(
+			ServiceBuilderModulesBatchTestClassGroup.BuildType.FULL,
+			"modules/util/portal-tools-service-builder/src/main/java/com" +
+				"/liferay/portal/tools/service/builder/ServiceBuilder.java",
+			"portal-impl/src/com/liferay/portal/service/impl" +
+				"/UserLocalServiceImpl.java");
+		_testGetBuildType(
 			null,
 			"modules/apps/blogs/blogs-web/src/main/resources/META-INF" +
 				"/resources/view.jsp");

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroupTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroupTest.java
@@ -6,6 +6,7 @@
 package com.liferay.jenkins.results.parser.test.clazz.group;
 
 import com.liferay.jenkins.results.parser.PortalGitWorkingDirectory;
+import com.liferay.jenkins.results.parser.RandomTestUtil;
 
 import java.io.File;
 
@@ -25,27 +26,22 @@ public class ServiceBuilderModulesBatchTestClassGroupTest
 	public void testGetBuildType() {
 		_testGetBuildType(
 			ServiceBuilderModulesBatchTestClassGroup.BuildType.CORE,
-			"portal-impl/src/com/liferay/portal/service/impl" +
-				"/UserLocalServiceImpl.java");
+			"portal-impl/" + RandomTestUtil.randomString());
 		_testGetBuildType(
 			ServiceBuilderModulesBatchTestClassGroup.BuildType.CORE,
-			"portal-kernel/src/com/liferay/portal/kernel/service" +
-				"/UserLocalService.java");
+			"portal-kernel/" + RandomTestUtil.randomString());
 		_testGetBuildType(
 			ServiceBuilderModulesBatchTestClassGroup.BuildType.FULL,
-			"modules/util/portal-tools-service-builder/src/main/java/com" +
-				"/liferay/portal/tools/service/builder/ServiceBuilder.java");
+			"modules/util/portal-tools-service-builder/" +
+				RandomTestUtil.randomString());
 		_testGetBuildType(
 			ServiceBuilderModulesBatchTestClassGroup.BuildType.FULL,
-			"modules/util/portal-tools-service-builder/src/main/java/com" +
-				"/liferay/portal/tools/service/builder/ServiceBuilder.java",
-			"portal-impl/src/com/liferay/portal/service/impl" +
-				"/UserLocalServiceImpl.java");
+			"modules/util/portal-tools-service-builder/" +
+				RandomTestUtil.randomString(),
+			"portal-impl/" + RandomTestUtil.randomString());
 		_testGetBuildType(null);
 		_testGetBuildType(
-			null,
-			"modules/apps/blogs/blogs-web/src/main/resources/META-INF" +
-				"/resources/view.jsp");
+			null, "modules/apps/" + RandomTestUtil.randomString());
 	}
 
 	private void _testGetBuildType(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroupTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroupTest.java
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.test.clazz.group;
+
+import com.liferay.jenkins.results.parser.PortalGitWorkingDirectory;
+
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Kenji Heigel
+ */
+public class ServiceBuilderModulesBatchTestClassGroupTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetBuildType() {
+		_testGetBuildType(
+			null,
+			"modules/apps/blogs/blogs-web/src/main/resources/META-INF" +
+				"/resources/view.jsp");
+	}
+
+	private void _testGetBuildType(
+		ServiceBuilderModulesBatchTestClassGroup.BuildType expectedBuildType,
+		String... modifiedFilePaths) {
+
+		ServiceBuilderModulesBatchTestClassGroup
+			serviceBuilderModulesBatchTestClassGroup =
+				BatchTestClassGroupTestUtil.
+					newServiceBuilderModulesBatchTestClassGroup(
+						modifiedFilePaths);
+
+		Assert.assertEquals(
+			expectedBuildType,
+			serviceBuilderModulesBatchTestClassGroup.getBuildType());
+
+		List<File> expectedTestClassFiles = new ArrayList<>();
+
+		if (expectedBuildType != null) {
+			PortalGitWorkingDirectory portalGitWorkingDirectory =
+				serviceBuilderModulesBatchTestClassGroup.
+					getPortalGitWorkingDirectory();
+
+			expectedTestClassFiles.add(
+				new File(
+					portalGitWorkingDirectory.getWorkingDirectory(),
+					"portal-impl/build.xml"));
+		}
+
+		Assert.assertEquals(
+			expectedTestClassFiles,
+			serviceBuilderModulesBatchTestClassGroup.getTestClassFiles());
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroupTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroupTest.java
@@ -41,6 +41,7 @@ public class ServiceBuilderModulesBatchTestClassGroupTest
 				"/liferay/portal/tools/service/builder/ServiceBuilder.java",
 			"portal-impl/src/com/liferay/portal/service/impl" +
 				"/UserLocalServiceImpl.java");
+		_testGetBuildType(null);
 		_testGetBuildType(
 			null,
 			"modules/apps/blogs/blogs-web/src/main/resources/META-INF" +

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/test/clazz/group/BatchTestClassGroupTestUtil/test.properties
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/test/clazz/group/BatchTestClassGroupTestUtil/test.properties
@@ -1,0 +1,3 @@
+test.batch.axis.max.size=5
+test.batch.unified.builder.supported=false
+test.relevant.changes=true


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7525

## Why

The batch generator (`BatchTestClassGroup` and its ServiceBuilder subclass) and the JS-unit test-name parsing had no unit coverage, so the regressions below only surfaced in production CI. This adds targeted tests, each mapped to a real bug and validated red-before-green — revert the fix (or mutate the invariant), confirm the test fails, restore, confirm it passes.

## Bug 1 — Clay JS-unit results reported "Unable to run" (LRCI-7172, fix `a756f517`)

**What broke:** `JSUnitTestReport.getTestTaskName` and `JSUnitJUnitTestResult.getTestTaskName` derive a Gradle task name from a JS-unit test name by truncating at a layout delimiter. The recognized delimiters were `.src.` and `.test.`, but Clay components use `.clay.`, so a Clay test name was never truncated, produced a malformed task name, and Testray reported the result as "Unable to run" even though the test had run.

**Test:** `JSUnitTestReportTest` and `JSUnitJUnitTestResultTest` each feed `getTestTaskName` three real-shaped names — a `.clay.` layout (which also contains `.src.`, so delimiter precedence matters), a `.src.` layout, and a `.test.` layout — and assert the derived task name. Reverting `a756f517` drops the `.clay.` branch, the Clay name truncates at `.src.` instead, and the Clay assertion fails.

## Bug 2 — phantom portal-impl test class in irrelevant service-builder batches (LRCI-7172, fix `abe15732`)

**What broke:** `ServiceBuilderModulesBatchTestClassGroup.setTestClasses` added `portal-impl/build.xml` as a test class unconditionally. When a pull request changed none of the service-builder tools, portal-impl, or portal-kernel, the build type stayed `null` but the portal-impl core build was still added — a phantom test class running in batches with no reason to build portal-impl. The same fix also restructured FULL/CORE detection into a strict if/else cascade so a service-builder-tools change no longer short-circuits the portal-impl/portal-kernel checks.

**Test:** `ServiceBuilderModulesBatchTestClassGroupTest.testGetBuildType` drives `setTestClasses` through `BatchTestClassGroupTestUtil` with an injected modified-files list and asserts, per input, the resolved build type and the resulting test-class files:
- service-builder-tools change -> FULL
- service-builder-tools + portal-impl change -> FULL (tools takes precedence)
- portal-impl change -> CORE
- portal-kernel change -> CORE
- an irrelevant change, and an empty diff -> `null` build type and zero test classes (no phantom `portal-impl/build.xml`)

Removing the `_buildType != null` gate makes the two null cases add the phantom class and fail; breaking the else cascade makes the tools+portal-impl case resolve CORE instead of FULL and fail.

## Bug 3 — axis partition (LRCI-7362)

**What broke:** the generator splits a batch's test classes across axes of at most `test.batch.axis.max.size` each; a partition-math regression could drop, duplicate, or misdistribute classes.

**Test:** `BatchTestClassGroupTest.testGetAxisTestClassGroups` adds `axis.max.size + 2` test classes, runs the split, asserts the axis count is `ceil(classes / max size)`, and flattens every axis to confirm the multiset equals the original test classes (none dropped, duplicated, or phantom). A floor-instead-of-ceil mutation produces too few axes and fails.

## Test harness

- `BatchTestClassGroupTestUtil` builds a real `PortalAcceptancePullRequestJob` whose `PortalGitWorkingDirectory` is a Mockito spy — the four git-shelling methods are overridden to inject a controlled diff, while the real `getWorkingDirectory` and job property resolution are kept. Job properties come from a committed `test.properties` fixture. This mirrors the existing `RelevantRuleEngineTest`.
- `RandomTestUtil` supplies random values for inputs the tests do not assert on.

Each regression is committed separately, one test per commit.