### PR TITLE
LRCI-7844 Run js-unit modules in one shared-pool Jest per axis

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -8496,31 +8496,28 @@ information. Make sure to commit in all format-javadoc results.
 	<target name="js-unit">
 		<run-batch-test>
 			<test-action>
-				<property name="js.unit.failure.count" value="0" />
+				<echo
+					file="${project.dir}/modules/TEMP_js_unit_batch_tasks.txt"
+					message="${modules.test.class.group}"
+				/>
 
-				<for delimiter=" " list="${modules.test.class.group}" param="modules.test.class" trim="true">
-					<sequential>
-						<echo>Executing Gradle tasks: @{modules.test.class}.</echo>
+				<propertyregex
+					input="${modules.test.class.group}"
+					property="js.unit.driver.task"
+					regexp="(\S+)"
+					select="\1"
+				/>
 
-						<trycatch property="gradle.failure">
-							<try>
-								<gradle-execute dir="modules" task="@{modules.test.class}">
-									<arg value="--continue" />
-								</gradle-execute>
-							</try>
-							<catch>
-								<echo>${gradle.failure}</echo>
-
-								<math
-									operand1="${js.unit.failure.count}"
-									operand2="1"
-									operation="+"
-									result="js.unit.failure.count"
-								/>
-							</catch>
-						</trycatch>
-					</sequential>
-				</for>
+				<trycatch>
+					<try>
+						<gradle-execute dir="modules" task="${js.unit.driver.task}">
+							<arg value="--rerun-tasks" />
+						</gradle-execute>
+					</try>
+					<finally>
+						<delete file="${project.dir}/modules/TEMP_js_unit_batch_tasks.txt" />
+					</finally>
+				</trycatch>
 
 				<replace
 					dir="modules"
@@ -8535,15 +8532,6 @@ information. Make sure to commit in all format-javadoc results.
 						<replacevalue><![CDATA[]]></replacevalue>
 					</replacefilter>
 				</replace>
-
-				<if>
-					<not>
-						<equals arg1="${js.unit.failure.count}" arg2="0" />
-					</not>
-					<then>
-						<fail message="${js.unit.failure.count} JS unit tests failed." />
-					</then>
-				</if>
 			</test-action>
 
 			<test-set-up>

--- a/modules/frontend-sdk/node-scripts/bin.js
+++ b/modules/frontend-sdk/node-scripts/bin.js
@@ -171,6 +171,17 @@ const COMMANDS = {
 		parameters: '[--sync]',
 		script: './test/index.mjs',
 	},
+	'test:batch': {
+		description: `
+		Runs the js-unit modules of one test batch axis through a single
+		shared-pool Jest process instead of one Jest per module.
+
+		Arguments starting with ':' are Gradle task paths (as listed in
+		'modules.test.class.group'); the rest are forwarded to Jest.
+`,
+		parameters: '<:module:task> [<:module:task> ...]',
+		script: './test/batch.mjs',
+	},
 };
 
 const command = process.argv[2];

--- a/modules/frontend-sdk/node-scripts/test/batch.mjs
+++ b/modules/frontend-sdk/node-scripts/test/batch.mjs
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import runJsUnitBatch from '../util/jest/runJsUnitBatch.mjs';
+
+/**
+ * Runs the js-unit modules of one test batch axis through a single shared-pool
+ * Jest process. Arguments starting with ':' are Gradle task paths (as listed
+ * in 'modules.test.class.group'); the rest are forwarded to Jest.
+ */
+export default async function () {
+	const args = process.argv.slice(3);
+
+	const failed = await runJsUnitBatch({
+		cliFlags: args.filter((arg) => !arg.startsWith(':')),
+		moduleTasks: args.filter((arg) => arg.startsWith(':')),
+	});
+
+	if (failed) {
+		throw new Error('One or more js-unit projects failed.');
+	}
+}

--- a/modules/frontend-sdk/node-scripts/test/index.mjs
+++ b/modules/frontend-sdk/node-scripts/test/index.mjs
@@ -9,9 +9,12 @@ import path from 'path';
 import getNamedArguments from '../util/getNamedArguments.mjs';
 import getYarnWorkspaceProjects from '../util/getYarnWorkspaceProjects.mjs';
 import runJest from '../util/jest/runJest.mjs';
+import runJsUnitBatch from '../util/jest/runJsUnitBatch.mjs';
 import {PORTAL_DIR} from '../util/locations.mjs';
 import print from '../util/print.mjs';
 import runConcurrentTasks from '../util/runConcurrentTasks.mjs';
+
+const BATCH_TASKS_FILE_NAME = 'TEMP_js_unit_batch_tasks.txt';
 
 export default async function () {
 	const {sync} = getNamedArguments({
@@ -23,6 +26,43 @@ export default async function () {
 	process.env.NODE_ENV = 'test';
 
 	const args = process.argv.slice(3);
+
+	/**
+	 * When a batch tasks file is present, one Jest run covers every module of
+	 * the test batch axis through a shared worker pool (see `runJsUnitBatch`),
+	 * rather than one Jest per module. The CI js-unit target writes the file so
+	 * a single Gradle-driven invocation, which already has Node set up, runs
+	 * the whole axis.
+	 */
+	const batchTasksFile = path.join(
+		PORTAL_DIR,
+		'modules',
+		BATCH_TASKS_FILE_NAME
+	);
+
+	let batchTasks = null;
+
+	try {
+		batchTasks = await fs.readFile(batchTasksFile, 'utf8');
+	}
+	catch (error) {
+		batchTasks = null;
+	}
+
+	if (batchTasks) {
+		const failed = await runJsUnitBatch({
+			cliFlags: args.filter((arg) => !arg.startsWith(':')),
+			moduleTasks: batchTasks.trim().split(/\s+/),
+		});
+
+		process.env.NODE_ENV = originalNodeEnv;
+
+		if (failed) {
+			throw new Error('One or more js-unit projects failed.');
+		}
+
+		return;
+	}
 
 	/**
 	 * When using 'yarn run ...' it sets the cwd to the nearest package.json

--- a/modules/frontend-sdk/node-scripts/util/jest/getMergedJestConfig.mjs
+++ b/modules/frontend-sdk/node-scripts/util/jest/getMergedJestConfig.mjs
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import merge from 'deepmerge';
+
+import getJestConfig from './getJestConfig.js';
+import getJestModuleNameMapper from './getJestModuleNameMapper.mjs';
+import getUserConfig from './getUserConfig.mjs';
+
+/**
+ * Builds the fully merged Jest configuration for a single project, resolving
+ * `<rootDir>` to the project path. This is the same configuration `runJest`
+ * writes per project, factored out so a single Jest run can list several
+ * projects at once and share one worker pool.
+ */
+export default async function getMergedJestConfig(projectPath) {
+	let userConfig = await getUserConfig('jest', {cwd: projectPath});
+
+	userConfig = JSON.parse(
+		JSON.stringify(userConfig).replace('<rootDir>', projectPath)
+	);
+
+	return merge.all([
+		getJestConfig({rootDir: projectPath}),
+		{
+			moduleNameMapper: await getJestModuleNameMapper({
+				cwd: projectPath,
+			}),
+		},
+		userConfig,
+	]);
+}

--- a/modules/frontend-sdk/node-scripts/util/jest/runJest.mjs
+++ b/modules/frontend-sdk/node-scripts/util/jest/runJest.mjs
@@ -3,16 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import merge from 'deepmerge';
 import {$} from 'execa';
 import fs from 'fs/promises';
 import path from 'path';
 
 import fileExists from '../fileExists.mjs';
 import onExit from '../onExit.mjs';
-import getJestConfig from './getJestConfig.js';
-import getJestModuleNameMapper from './getJestModuleNameMapper.mjs';
-import getUserConfig from './getUserConfig.mjs';
+import getMergedJestConfig from './getMergedJestConfig.mjs';
 
 const CONFIG_NAME = 'TEMP_jest.config.json';
 const FORCE_DEBUG_FLAG = '--force-debug';
@@ -47,27 +44,9 @@ export default async function runJest({
 			...execaConfig,
 		};
 
-		let userConfig = await getUserConfig('jest', {cwd: projectPath});
-
-		userConfig = JSON.parse(
-			JSON.stringify(userConfig).replace('<rootDir>', projectPath)
-		);
-
 		await fs.writeFile(
 			CONFIG_PATH,
-			JSON.stringify(
-				merge.all([
-					getJestConfig({rootDir: projectPath}),
-					{
-						moduleNameMapper: await getJestModuleNameMapper({
-							cwd: projectPath,
-						}),
-					},
-					userConfig,
-				]),
-				null,
-				4
-			)
+			JSON.stringify(await getMergedJestConfig(projectPath), null, 4)
 		);
 
 		onExit(() => fs.unlink(CONFIG_PATH));

--- a/modules/frontend-sdk/node-scripts/util/jest/runJestSharedPool.mjs
+++ b/modules/frontend-sdk/node-scripts/util/jest/runJestSharedPool.mjs
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {$} from 'execa';
+import fs from 'fs/promises';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+import fileExists from '../fileExists.mjs';
+import onExit from '../onExit.mjs';
+import getMergedJestConfig from './getMergedJestConfig.mjs';
+
+const ROOT_CONFIG_NAME = 'TEMP_jest.projects.config.json';
+
+const TEST_RESULTS_PROCESSOR = fileURLToPath(
+	new URL('./writePerModuleJUnitResults.js', import.meta.url)
+);
+
+/**
+ * Runs a single Jest process over several projects at once through Jest's
+ * `projects` option, so every project's test files share one worker pool
+ * instead of each project spinning up its own Jest with its own pool. Startup
+ * is paid once and the pool stays fully utilized across the whole set.
+ *
+ * `getMergedJestConfig` reads `process.env.USE_REACT_16` when it builds a
+ * project's `moduleNameMapper`, so the caller must set that variable to match
+ * this group before invoking this function.
+ */
+export default async function runJestSharedPool({
+	cliFlags = [],
+	execaConfig = {},
+	projectPaths = [],
+	rootDir,
+}) {
+	const CONFIG_PATH = path.join(rootDir, ROOT_CONFIG_NAME);
+
+	let result = false;
+
+	try {
+		const projects = [];
+
+		for (const projectPath of projectPaths) {
+			const projectConfig = await getMergedJestConfig(projectPath);
+
+			// A single-module run gets its root directory from the Jest
+			// '--projects <path>' argument. Here each project is an inline
+			// config object, so its root directory must be set explicitly.
+
+			projectConfig.rootDir = projectPath;
+
+			// The per-project result processor is a global Jest option that is
+			// ignored inside a project config and would only write one combined
+			// file anyway. It is replaced by the root-level processor below,
+			// which writes per-module output.
+
+			delete projectConfig.testResultsProcessor;
+
+			projects.push(projectConfig);
+		}
+
+		await fs.writeFile(
+			CONFIG_PATH,
+			JSON.stringify(
+				{projects, testResultsProcessor: TEST_RESULTS_PROCESSOR},
+				null,
+				4
+			)
+		);
+
+		onExit(() => fs.unlink(CONFIG_PATH));
+
+		const config = {
+			cwd: rootDir,
+			env: {
+				...process.env,
+				...execaConfig.env,
+				NODE_ENV: 'test',
+			},
+			...execaConfig,
+		};
+
+		result = await $(
+			config
+		)`jest --passWithNoTests --config ${CONFIG_PATH} ${cliFlags}`;
+	}
+	catch (error) {
+		result = {
+			all: error.toString(),
+			failed: true,
+		};
+	}
+	finally {
+		if (await fileExists(CONFIG_PATH)) {
+			await fs.unlink(CONFIG_PATH);
+		}
+	}
+
+	return result;
+}

--- a/modules/frontend-sdk/node-scripts/util/jest/runJsUnitBatch.mjs
+++ b/modules/frontend-sdk/node-scripts/util/jest/runJsUnitBatch.mjs
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+
+import {PORTAL_DIR} from '../locations.mjs';
+import runJestSharedPool from './runJestSharedPool.mjs';
+
+/**
+ * Runs the js-unit modules assigned to one test batch axis through a single
+ * shared-pool Jest process instead of one Jest per module.
+ *
+ * `moduleTasks` are Gradle task paths as listed in `modules.test.class.group`
+ * (for example ':apps:foo:foo-web:packageRunTest'), each mapped to its module
+ * directory under `modules`. Modules are grouped by their React version,
+ * because a module opts into React 16 through the `USE_REACT_16` environment
+ * variable, which is read while the Jest config is built and while tests run,
+ * so each group needs its own Jest process with that variable set accordingly.
+ *
+ * Returns `true` when any group failed.
+ */
+export default async function runJsUnitBatch({cliFlags = [], moduleTasks = []}) {
+	const modulesDir = path.join(PORTAL_DIR, 'modules');
+
+	const react16Paths = [];
+	const react18Paths = [];
+
+	for (const moduleTask of moduleTasks) {
+		const projectPath = path.join(
+			modulesDir,
+			moduleTask
+				.replace(/^:/, '')
+				.replace(/:[^:]+$/, '')
+				.split(':')
+				.join(path.sep)
+		);
+
+		const packageJson = JSON.parse(
+			await fs.readFile(path.join(projectPath, 'package.json'), 'utf8')
+		);
+
+		if (packageJson.scripts.test.includes('USE_REACT_16=true')) {
+			react16Paths.push(projectPath);
+		}
+		else {
+			react18Paths.push(projectPath);
+		}
+	}
+
+	let failed = false;
+
+	const groups = [
+		{projectPaths: react18Paths, useReact16: false},
+		{projectPaths: react16Paths, useReact16: true},
+	];
+
+	for (const {projectPaths, useReact16} of groups) {
+		if (!projectPaths.length) {
+			continue;
+		}
+
+		if (useReact16) {
+			process.env.USE_REACT_16 = 'true';
+		}
+		else {
+			delete process.env.USE_REACT_16;
+		}
+
+		const result = await runJestSharedPool({
+			cliFlags,
+			execaConfig: {
+				env: useReact16 ? {USE_REACT_16: 'true'} : {},
+				stdio: 'inherit',
+			},
+			projectPaths,
+			rootDir: modulesDir,
+		});
+
+		if (result.failed) {
+			failed = true;
+		}
+	}
+
+	return failed;
+}

--- a/modules/frontend-sdk/node-scripts/util/jest/writePerModuleJUnitResults.js
+++ b/modules/frontend-sdk/node-scripts/util/jest/writePerModuleJUnitResults.js
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const junitReporter = require('@liferay/jest-junit-reporter');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * A Jest `testResultsProcessor` for shared-pool runs (see `runJestSharedPool`).
+ * The `@liferay/jest-junit-reporter` writes one `TEST-frontend-js.xml` in the
+ * current working directory, which is correct when Jest runs one module at a
+ * time but collapses every module into a single file when several modules run
+ * in one process. This groups the results by their owning module and delegates
+ * to that same reporter once per module, with the working directory set to the
+ * module, so the per-module `TEST-frontend-js.xml` layout the CI collects is
+ * preserved.
+ */
+
+const moduleRootCache = new Map();
+
+function findModuleRoot(filePath) {
+	let dir = path.dirname(filePath);
+
+	while (true) {
+		if (moduleRootCache.has(dir)) {
+			return moduleRootCache.get(dir);
+		}
+
+		if (fs.existsSync(path.join(dir, 'package.json'))) {
+			moduleRootCache.set(dir, dir);
+
+			return dir;
+		}
+
+		const parent = path.dirname(dir);
+
+		if (parent === dir) {
+			return null;
+		}
+
+		dir = parent;
+	}
+}
+
+module.exports = (report) => {
+	const suitesByModuleRoot = new Map();
+
+	for (const suite of report.testResults) {
+		const moduleRoot = findModuleRoot(suite.testFilePath);
+
+		if (!moduleRoot) {
+			continue;
+		}
+
+		if (!suitesByModuleRoot.has(moduleRoot)) {
+			suitesByModuleRoot.set(moduleRoot, []);
+		}
+
+		suitesByModuleRoot.get(moduleRoot).push(suite);
+	}
+
+	const originalCwd = process.cwd();
+
+	try {
+		for (const [moduleRoot, suites] of suitesByModuleRoot) {
+			const numFailedTests = suites.reduce(
+				(total, suite) => total + suite.numFailingTests,
+				0
+			);
+			const numTotalTests = suites.reduce(
+				(total, suite) =>
+					total +
+					suite.numFailingTests +
+					suite.numPassingTests +
+					suite.numPendingTests,
+				0
+			);
+
+			process.chdir(moduleRoot);
+
+			junitReporter({
+				...report,
+				numFailedTests,
+				numTotalTests,
+				testResults: suites,
+			});
+		}
+	}
+	finally {
+		process.chdir(originalCwd);
+	}
+
+	return report;
+};


### PR DESCRIPTION
## Purpose

Test branch to measure the **shared worker pool** approach for js-unit, the counterpart to #2141 (which parallelizes the per-module Gradle calls). Not for merge as-is.

## The problem

Each js-unit axis runs ~26 modules through a sequential ant-contrib loop, each forking its own `--no-daemon` Gradle invocation and its own Jest. Measured on a warm stable build: a sample module took 28s of which only ~13.6s was jest — the rest is per-module Gradle/node startup, paid one module at a time. Jest already parallelizes test files within a module (default `cores-1` workers, no `--runInBand`), so intra-module parallelism is already maxed; the waste is 26 sequential startups and each small module underusing its pool.

## The change

Run the whole axis in **one** Jest through Jest's `projects` option, so every module's test files share one worker pool and startup is paid once. No oversubscription (one `cores-1` pool total), unlike running N concurrent jests.

- `getMergedJestConfig` — extracted from `runJest` so the per-module config is built identically.
- `runJestSharedPool` — writes one root config `{projects: [...]}` and runs a single `jest --config`.
- `test:batch` command + `runJsUnitBatch` — maps the axis's `modules.test.class.group` tasks to module dirs, groups by React version (env-selected, so one Jest per group, run sequentially), and runs each group shared-pool.
- `writePerModuleJUnitResults` — `@liferay/jest-junit-reporter` writes a single cwd-relative `TEST-frontend-js.xml`; under one Jest that would collapse all modules into one file, so this delegates to that same reporter once per module (cwd set to the module) to preserve the per-module layout the CI collects.
- `build-test-batch.xml` `js-unit` — writes the axis task list to a file and runs one Gradle-driven `packageRunTest` (which sets up Node); `node-scripts test` detects the file and runs the batch.

## What to look for

- js-unit axis wall time vs baseline (~22-26 min/axis) and vs #2141.
- Per-module `TEST-frontend-js.xml` still produced and collected correctly (the main risk — result attribution).
- React 16 modules pass in their own group.

## Known limitations (test branch)

- Could not be run locally (workspace `node_modules` not installed here); node-scripts files pass `node --check` and the XML is well-formed, but behavior is CI-validated only.
- The Gradle-driver + task-file handoff is the pragmatic way to invoke one Jest with Node set up without a cross-module Gradle task; open to a cleaner invocation if this proves out.
- Source formatter (eslint/prettier for the JS) not run locally.