### PR TITLE
LRCI-7844 Scale osb-faro-web jest workers to the axis machine

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
@@ -171,7 +171,7 @@
 		"format": "eslint --fix \"src/main/js/**/*.+(js|ts)?(x)\"",
 		"lint": "eslint \"src/main/js/**/*.+(js|ts)?(x)\"",
 		"start": "cross-env FARO_ENVIRONMENT_NAME=local webpack-dev-server --config webpack.dev.js",
-		"test": "cross-env LC_ALL=en_US.UTF-8 TZ=Etc/GMT jest --coverage=false --maxWorkers=4",
+		"test": "cross-env LC_ALL=en_US.UTF-8 TZ=Etc/GMT jest --coverage=false --maxWorkers=100%",
 		"webpack": "webpack --config webpack.prod.js",
 		"webpack:dev": "webpack --config webpack.dev.js"
 	},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7844

## What

Change osb-faro-web's jest `--maxWorkers` from a hardcoded `4` to `100%` so it scales to the vCPU count of whatever axis machine it lands on.

## Why

`osb-faro-web` is the long pole of the stable js-unit batch — it runs alone on its axis (3286 tests / 659 suites, ~12 min of jest). The memory fleet those axes run on is heterogeneous: mostly 2-vCPU (r5a.large) with some 4-vCPU (r7g.xlarge) and larger. A fixed worker count of 4 oversubscribes the 2-vCPU nodes and is fine on the 4-vCPU nodes; any other fixed number is wrong for one class. A percentage lets jest match the cores actually present on each run — no oversubscription on small boxes, no idle cores on large ones.

## Testing

Measuring via `ci:test:stable`. Because the fleet is heterogeneous, the axis timing depends on which instance type faro lands on; the node type will be recorded alongside the result.