### PR TITLE
LRCI-7844 Download the build database from S3 only once per path

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildDatabaseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildDatabaseUtil.java
@@ -357,8 +357,44 @@ public class BuildDatabaseUtil {
 
 		parentDir.mkdirs();
 
-		String buildDatabaseFilePath =
-			JenkinsResultsParserUtil.getCanonicalPath(buildDatabaseFile);
+		synchronized (_s3BuildDatabaseFiles) {
+			String buildDatabaseFilePath =
+				JenkinsResultsParserUtil.getCanonicalPath(buildDatabaseFile);
+
+			File downloadedBuildDatabaseFile = _s3BuildDatabaseFiles.get(path);
+
+			if ((downloadedBuildDatabaseFile != null) &&
+				downloadedBuildDatabaseFile.exists()) {
+
+				try {
+					Files.copy(
+						downloadedBuildDatabaseFile.toPath(),
+						buildDatabaseFile.toPath(),
+						StandardCopyOption.REPLACE_EXISTING);
+
+					System.out.println(
+						JenkinsResultsParserUtil.combine(
+							"Copied ",
+							JenkinsResultsParserUtil.getCanonicalPath(
+								downloadedBuildDatabaseFile),
+							" to ", buildDatabaseFilePath));
+
+					return;
+				}
+				catch (IOException ioException) {
+					throw new RuntimeException(ioException);
+				}
+			}
+
+			_downloadBuildDatabaseFileFromS3Bucket(
+				buildDatabaseFile, buildDatabaseFilePath, path);
+
+			_s3BuildDatabaseFiles.put(path, buildDatabaseFile);
+		}
+	}
+
+	private static void _downloadBuildDatabaseFileFromS3Bucket(
+		File buildDatabaseFile, String buildDatabaseFilePath, String path) {
 
 		Retryable<Object> retryable = new Retryable<Object>(true, 3, 5, true) {
 
@@ -602,6 +638,8 @@ public class BuildDatabaseUtil {
 	}
 
 	private static final Map<File, BuildDatabase> _buildDatabases =
+		new HashMap<>();
+	private static final Map<String, File> _s3BuildDatabaseFiles =
 		new HashMap<>();
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7844

## Download the build database from S3 only once per path

`BuildDatabaseUtil`'s stop-phase download re-fetched the same `build-database.json` from S3 once per build processed — up to ~54 identical downloads of a single path in the upstream testsuite stop phase, where the batch-aggregation / reporting loop calls `getBuildDatabase` per downstream build.

This caches the downloaded file by its S3 path: the first request downloads from S3, and subsequent requests for the same path copy the already-downloaded file locally instead of re-fetching.

Split out of the consolidated PR #2146 so the parser change reviews on its own (ships via the Nexus jar cycle).

## Testing
Exercised by the upstream testsuite stop phase; download count expected to drop from ~54 to ~1 per path.
