### PR TITLE
LRCI-7868 Bump report frontends from Chart.js 2.x to 4.x

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/css/main.css
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/css/main.css
@@ -1,3 +1,7 @@
+.chart-container {
+	height: 800px;
+}
+
 .col-1 {
 	left: 1px;
 	max-width: 198px;

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/js/main.js
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/js/main.js
@@ -3,24 +3,24 @@ function createBuildCountLineChart(timelineData, elementID) {
 
 	let lineChart = getLineChart('Build Count', datasets, elementID, 'Builds');
 
-	lineChart.options.title = {
+	lineChart.options.plugins.title = {
 		display: false
 	};
 
-	lineChart.options.tooltips = {
+	lineChart.options.plugins.tooltip = {
 		callbacks: {
-		    label: function(tooltipItem, data) {
-		        let label = data.datasets[tooltipItem.datasetIndex].label || '';
+		    label: function(context) {
+		        let label = context.dataset.label || '';
 
 		        if (label) {
 		            label += ': ';
 		        }
 
-		        label += tooltipItem.yLabel;
+		        label += context.parsed.y;
 
 		        label += ' (';
 
-		        label += Math.round(tooltipItem.yLabel * 10000 / (maxWeeklyServerDurationMillis || MAX_WEEKLY_SERVER_DURATION_MILLIS)) / 100;
+		        label += Math.round(context.parsed.y * 10000 / (maxWeeklyServerDurationMillis || MAX_WEEKLY_SERVER_DURATION_MILLIS)) / 100;
 
 		        label += '%)'
 
@@ -29,28 +29,29 @@ function createBuildCountLineChart(timelineData, elementID) {
 		},
 		mode: 'index'
 	};
+
+	lineChart.update();
 }
 
 function createDurationLineChart(chartTitle, datasets, elementID) {
 	let lineChart = getLineChart(chartTitle, datasets, elementID, 'Duration (mins)');
 
-	lineChart.options.scales.yAxes[0].ticks = {
-		beginAtZero: true,
+	lineChart.options.scales.y.ticks = {
 		callback: function(value) {
 			return Math.round(value / 60000);
 		}
 	};
 
-	lineChart.options.tooltips = {
+	lineChart.options.plugins.tooltip = {
 		callbacks: {
-			label: function(tooltipItem, data) {
-			    let label = data.datasets[tooltipItem.datasetIndex].label || '';
+			label: function(context) {
+			    let label = context.dataset.label || '';
 
 			    if (label) {
 			        label += ': ';
 			    }
 
-			    label += Math.round(tooltipItem.yLabel / 60000);
+			    label += Math.round(context.parsed.y / 60000);
 
 			    label += ' mins';
 
@@ -59,6 +60,8 @@ function createDurationLineChart(chartTitle, datasets, elementID) {
 		},
 		mode: 'index'
 	};
+
+	lineChart.update();
 }
 
 function createBuildDurationLineChart(timelineData, elementID) {
@@ -122,40 +125,39 @@ function getLineChart(chartTitle, datasets, elementID, yLabel) {
 					radius: 0
 				}
 			},
-			hover: {
-			    animationDuration: 0
-			},
 			maintainAspectRatio: false,
+			plugins: {
+				title: {
+					display: true,
+					font: {
+						size: 14
+					},
+					text: chartTitle
+				}
+			},
 			responsive: true,
 			scales: {
-				xAxes: [{
-					autoSkipPadding: 50,
-					type: 'time',
+				x: {
 					ticks: {
+						autoSkipPadding: 50,
 						sampleSize: 100
 					},
 					time: {
 					    displayFormats: {
-					        hour: 'ddd MMM DD hA'
+					        hour: 'EEE MMM dd ha'
 					    },
 					    unit: 'hour'
-					}
-				}],
-				yAxes: [{
-					scaleLabel: {
-						display: true,
-						labelString: yLabel
 					},
+					type: 'time'
+				},
+				y: {
+					beginAtZero: true,
 					stacked: true,
-					ticks: {
-						beginAtZero: true
+					title: {
+						display: true,
+						text: yLabel
 					}
-				}]
-			},
-			title: {
-				display: true,
-				fontSize: 14,
-				text: chartTitle
+				}
 			}
 		},
 		type: 'line'

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/css/report.css
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/css/report.css
@@ -67,6 +67,11 @@ th.col-1, th.col-2 {
 	content: "\2796";
 }
 
+.chart-container {
+	height: 600px;
+	position: relative;
+}
+
 .date p {
 	font-size: 12px;
 	font-style: italic;

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js
@@ -162,10 +162,10 @@ function createBarChartFromTable(chartTitle, dataSuffix, elementID, metricName, 
 		datasets.push(dataset);
 	});
 
-	let yAxesMax = 100;
+	let yMax = 100;
 
 	if (testSuiteReport) {
-		yAxesMax = getDynamicMax(datasets);
+		yMax = getDynamicMax(datasets);
 	}
 
 	let barChart = new Chart(document.getElementById(elementID), {
@@ -175,54 +175,58 @@ function createBarChartFromTable(chartTitle, dataSuffix, elementID, metricName, 
 		},
 		options: {
 			maintainAspectRatio: false,
+			plugins: {
+				title: {
+					display: true,
+					font: {
+						size: 14
+					},
+					text: chartTitle
+				},
+				tooltip: {
+					callbacks: {
+						label: function(context) {
+					        let label = context.dataset.label;
+					        let dataDenomination = context.dataset.data[context.dataIndex];
+					        let totaldataDenomination = 0;
+
+					        for (let i = 0; i < context.chart.data.datasets.length; i++) {
+					            totaldataDenomination += parseFloat(context.chart.data.datasets[i].data[context.dataIndex]);
+					        }
+
+					        if (context.datasetIndex != 0) {
+					            return label + ' : ' + dataDenomination + dataSuffix;
+					        }
+					        else {
+					            return [label + ' : ' + dataDenomination + dataSuffix, "Total : " + totaldataDenomination.toFixed(2) + dataSuffix];
+					        }
+						}
+					},
+					itemSort: function(a, b) {
+						return b.datasetIndex - a.datasetIndex;
+					},
+					mode: 'index'
+				}
+			},
 			responsive: true,
 			scales: {
-				xAxes: [{
-					stacked: true,
-				}],
-				yAxes: [{
-					scaleLabel: {
-						display: true,
-						labelString: dataSuffix
-					},
+				x: {
+					stacked: true
+				},
+				y: {
+					beginAtZero: true,
+					max: yMax,
 					stacked: true,
 					ticks: {
-						beginAtZero: true,
 						callback: function(value) {
 							return value + dataSuffix;
-						},
-						max: yAxesMax
+						}
+					},
+					title: {
+						display: true,
+						text: dataSuffix
 					}
-				}]
-			},
-			title: {
-				display: true,
-				fontSize: 14,
-				text: chartTitle
-			},
-			tooltips: {
-				callbacks: {
-					label: function(tooltipItem, data) {
-				        let label = data.datasets[tooltipItem.datasetIndex].label;
-				        let dataDenomination = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index];
-				        let totaldataDenomination = 0;
-
-				        for (let i = 0; i < data.datasets.length; i++) {
-				            totaldataDenomination += parseFloat(data.datasets[i].data[tooltipItem.index]);
-				        }
-
-				        if (tooltipItem.datasetIndex != 0) {
-				            return label + ' : ' + dataDenomination + dataSuffix;
-				        }
-				        else {
-				            return [label + ' : ' + dataDenomination + dataSuffix, "Total : " + totaldataDenomination.toFixed(2) + dataSuffix];
-				        }
-					}
-				},
-				itemSort: function(a, b) {
-					return b.datasetIndex - a.datasetIndex;
-				},
-				mode: 'index'
+				}
 			}
 		},
 		type: 'bar'


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7868

## What Is Being Fixed

The report frontends generated through BuildHistoryReport pin Chart.js 2.x (2.9.4 on the build history report, 2.5.0 on the test suite and utilization reports), two major versions behind.

## How It Is Being Fixed

This is the first of two steps, following the usual rollout for these files: the js and css merge first, then a follow-up updates the report HTML to load Chart.js 4.x from the CDN and bumps the pinned jsdelivr revisions to this change. The chart configs move to the 4.x API (scales.x/y, plugins.title, plugins.tooltip, the new tooltip callback signature, and date-fns format tokens on the build history time axis), and the stylesheets gain a chart-container rule because responsive charts in 4.x no longer honor the canvas height attribute. Nothing changes for the deployed reports until the follow-up: they keep loading the currently pinned revisions with Chart.js 2.x. All five report pages were rendered headless with the migrated files against Chart.js 4.5.0 and the production data synced from test-1-0, with zero console errors and matching tooltip, legend, and search behavior.

## Why Are There No Tests?

The changes are report frontend files (JS/CSS) with no test harness in the module; verification was rendering all five reports headless against production data and exercising the chart tooltips, accordion, table search, and column sorting with zero console errors.

## PR Check

**pr-check: PASS** — tested on `1c4bf99d78296ff65244db71cc7a273c0630051a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "1c4bf99d78296ff65244db71cc7a273c0630051a"} -->
