### PR TITLE
LRCI-7524 Add unit tests for past one-off CI regression fixes

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -3700,37 +3700,10 @@ public class JenkinsResultsParserUtil {
 			sb.append("token=");
 			sb.append(getBuildProperty("jenkins.authentication.token"));
 
-			URL urlObject = new URL(fixURL(sb.toString()));
-
-			HttpURLConnection httpURLConnection =
-				(HttpURLConnection)urlObject.openConnection();
-
-			if (timeout != 0) {
-				httpURLConnection.setConnectTimeout(timeout);
-				httpURLConnection.setReadTimeout(timeout);
-			}
-
-			HTTPAuthorization httpAuthorization = getJenkinsHTTPAuthorization();
-
-			httpURLConnection.setRequestProperty(
-				"Authorization", httpAuthorization.toString());
-
-			httpURLConnection.connect();
-
-			int responseCode = httpURLConnection.getResponseCode();
-
-			System.out.println(
-				combine(
-					"Response from ", urlObject.toString(), ": ",
-					String.valueOf(responseCode), " ",
-					httpURLConnection.getResponseMessage()));
-
-			if (responseCode >= 400) {
-				return 0;
-			}
-
 			return getJenkinsBuildQueueId(
-				httpURLConnection.getHeaderField("Location"));
+				UrlReader.getResponseHeader(
+					"Location", getJenkinsHTTPAuthorization(),
+					HttpRequestMethod.GET, null, timeout, sb.toString()));
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2303,6 +2303,21 @@ public class JenkinsResultsParserUtil {
 		}
 	}
 
+	public static long getJenkinsBuildQueueId(String location) {
+		if (isNullOrEmpty(location)) {
+			return 0L;
+		}
+
+		Matcher jenkinsBuildQueueURLMatcher =
+			_jenkinsBuildQueueURLPattern.matcher(location);
+
+		if (!jenkinsBuildQueueURLMatcher.find()) {
+			return 0L;
+		}
+
+		return Long.parseLong(jenkinsBuildQueueURLMatcher.group("queueId"));
+	}
+
 	public static String getJenkinsBuildResult(String buildURL) {
 		try {
 			JSONObject jsonObject = toJSONObject(
@@ -3714,20 +3729,8 @@ public class JenkinsResultsParserUtil {
 				return 0;
 			}
 
-			String location = httpURLConnection.getHeaderField("Location");
-
-			if (isNullOrEmpty(location)) {
-				return 0L;
-			}
-
-			Matcher jenkinsBuildQueueURLMatcher =
-				_jenkinsBuildQueueURLPattern.matcher(location);
-
-			if (!jenkinsBuildQueueURLMatcher.find()) {
-				return 0L;
-			}
-
-			return Long.parseLong(jenkinsBuildQueueURLMatcher.group("queueId"));
+			return getJenkinsBuildQueueId(
+				httpURLConnection.getHeaderField("Location"));
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -392,39 +392,7 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 		File workingDirectory = getWorkingDirectory();
 
 		try {
-			Map<String, String> filteredEnv = new HashMap<>();
-
-			Map<String, String> env = Environment.getAll();
-
-			for (Map.Entry<String, String> entry : env.entrySet()) {
-				String key = entry.getKey();
-
-				if (!key.startsWith("ANT_") && !key.startsWith("JAVA_") &&
-					!key.startsWith("JENKINS_HOME")) {
-
-					continue;
-				}
-
-				filteredEnv.put(key, entry.getValue());
-			}
-
-			String antOptsDefault = JenkinsResultsParserUtil.getBuildProperty(
-				"ant.opts.default", getUpstreamBranchName());
-
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(antOptsDefault)) {
-				filteredEnv.put("ANT_OPTS", antOptsDefault);
-				filteredEnv.put("JAVA_OPTS", antOptsDefault);
-			}
-
-			String javaJDKDefaultRuntime =
-				JenkinsResultsParserUtil.getBuildProperty(
-					"java.jdk.default.runtime", getUpstreamBranchName());
-
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(
-					javaJDKDefaultRuntime)) {
-
-				filteredEnv.put("JAVA_HOME", javaJDKDefaultRuntime);
-			}
+			Map<String, String> filteredEnv = getFilteredEnvironment();
 
 			Properties properties = new Properties();
 
@@ -570,6 +538,42 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 		throws IOException {
 
 		super(upstreamBranchName, workingDirectoryPath, gitRepositoryName);
+	}
+
+	protected Map<String, String> getFilteredEnvironment() throws IOException {
+		Map<String, String> filteredEnv = new HashMap<>();
+
+		Map<String, String> env = Environment.getAll();
+
+		for (Map.Entry<String, String> entry : env.entrySet()) {
+			String key = entry.getKey();
+
+			if (!key.startsWith("ANT_") && !key.startsWith("JAVA_") &&
+				!key.startsWith("JENKINS_HOME")) {
+
+				continue;
+			}
+
+			filteredEnv.put(key, entry.getValue());
+		}
+
+		String antOptsDefault = JenkinsResultsParserUtil.getBuildProperty(
+			"ant.opts.default", getUpstreamBranchName());
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(antOptsDefault)) {
+			filteredEnv.put("ANT_OPTS", antOptsDefault);
+			filteredEnv.put("JAVA_OPTS", antOptsDefault);
+		}
+
+		String javaJDKDefaultRuntime =
+			JenkinsResultsParserUtil.getBuildProperty(
+				"java.jdk.default.runtime", getUpstreamBranchName());
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(javaJDKDefaultRuntime)) {
+			filteredEnv.put("JAVA_HOME", javaJDKDefaultRuntime);
+		}
+
+		return filteredEnv;
 	}
 
 	private boolean _isNPMTestModuleDir(File moduleDir) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -40,6 +40,17 @@ import javax.net.ssl.SSLContext;
  */
 public class UrlReader {
 
+	public static String getResponseHeader(
+			String headerName, HTTPAuthorization httpAuthorization,
+			HttpRequestMethod httpRequestMethod, String postContent,
+			int timeout, String url)
+		throws IOException {
+
+		return _urlReader.doGetResponseHeader(
+			headerName, httpAuthorization, httpRequestMethod, postContent,
+			timeout, url);
+	}
+
 	public static InputStream read(
 			boolean checkCache, HTTPAuthorization httpAuthorization,
 			HttpRequestMethod httpRequestMethod, int maxRetries,
@@ -53,6 +64,59 @@ public class UrlReader {
 
 	public static void setInstance(UrlReader urlReader) {
 		_urlReader = urlReader;
+	}
+
+	protected String doGetResponseHeader(
+			String headerName, HTTPAuthorization httpAuthorization,
+			HttpRequestMethod httpRequestMethod, String postContent,
+			int timeout, String url)
+		throws IOException {
+
+		URL urlObject = new URL(JenkinsResultsParserUtil.fixURL(url));
+
+		HttpURLConnection httpURLConnection =
+			(HttpURLConnection)urlObject.openConnection();
+
+		if (httpRequestMethod != null) {
+			httpURLConnection.setRequestMethod(httpRequestMethod.name());
+		}
+
+		if (httpAuthorization != null) {
+			httpURLConnection.setRequestProperty(
+				"Authorization", httpAuthorization.toString());
+		}
+
+		if (timeout != 0) {
+			httpURLConnection.setConnectTimeout(timeout);
+			httpURLConnection.setReadTimeout(timeout);
+		}
+
+		if (postContent != null) {
+			httpURLConnection.setDoOutput(true);
+
+			try (OutputStream outputStream =
+					httpURLConnection.getOutputStream()) {
+
+				outputStream.write(postContent.getBytes("UTF-8"));
+
+				outputStream.flush();
+			}
+		}
+
+		httpURLConnection.connect();
+
+		int responseCode = httpURLConnection.getResponseCode();
+
+		System.out.println(
+			JenkinsResultsParserUtil.combine(
+				"Response from ", url, ": ", String.valueOf(responseCode), " ",
+				httpURLConnection.getResponseMessage()));
+
+		if (responseCode >= 400) {
+			return null;
+		}
+
+		return httpURLConnection.getHeaderField(headerName);
 	}
 
 	protected InputStream doRead(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -6,7 +6,6 @@
 package com.liferay.jenkins.results.parser;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.dom4j.Element;
 
@@ -54,18 +53,6 @@ public class BaseDownstreamBuildTest
 			baseDownstreamBuild.getDisplayName()
 		).thenReturn(
 			RandomTestUtil.randomString()
-		);
-
-		Mockito.when(
-			baseDownstreamBuild.getUniqueFailureTestResults()
-		).thenReturn(
-			Collections.<TestResult>emptyList()
-		);
-
-		Mockito.when(
-			baseDownstreamBuild.getUpstreamJobFailureTestResults()
-		).thenReturn(
-			Collections.<TestResult>emptyList()
 		);
 
 		Element uniqueFailureElement = Dom4JUtil.getNewElement(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -55,10 +55,13 @@ public class BaseDownstreamBuildTest
 			RandomTestUtil.randomString()
 		);
 
+		String uniqueFailureMarker = RandomTestUtil.randomString();
+		String upstreamJobFailureMarker = RandomTestUtil.randomString();
+
 		Element uniqueFailureElement = Dom4JUtil.getNewElement(
-			"code", null, _FAILURE_MARKER_UNIQUE);
+			"code", null, uniqueFailureMarker);
 		Element upstreamJobFailureElement = Dom4JUtil.getNewElement(
-			"code", null, _FAILURE_MARKER_UPSTREAM_JOB);
+			"code", null, upstreamJobFailureMarker);
 
 		Mockito.when(
 			baseDownstreamBuild.getTestResultGitHubElements(
@@ -89,9 +92,8 @@ public class BaseDownstreamBuildTest
 
 		String gitHubMessageXML = gitHubMessageElement.asXML();
 
-		Assert.assertFalse(
-			gitHubMessageXML.contains(_FAILURE_MARKER_UPSTREAM_JOB));
-		Assert.assertTrue(gitHubMessageXML.contains(_FAILURE_MARKER_UNIQUE));
+		Assert.assertFalse(gitHubMessageXML.contains(upstreamJobFailureMarker));
+		Assert.assertTrue(gitHubMessageXML.contains(uniqueFailureMarker));
 
 		Element gitHubMessageUpstreamJobFailureElement =
 			baseDownstreamBuild.getGitHubMessageUpstreamJobFailureElement();
@@ -100,17 +102,10 @@ public class BaseDownstreamBuildTest
 			gitHubMessageUpstreamJobFailureElement.asXML();
 
 		Assert.assertFalse(
-			gitHubMessageUpstreamJobFailureXML.contains(
-				_FAILURE_MARKER_UNIQUE));
+			gitHubMessageUpstreamJobFailureXML.contains(uniqueFailureMarker));
 		Assert.assertTrue(
 			gitHubMessageUpstreamJobFailureXML.contains(
-				_FAILURE_MARKER_UPSTREAM_JOB));
+				upstreamJobFailureMarker));
 	}
-
-	private static final String _FAILURE_MARKER_UNIQUE =
-		"FAILURE_MARKER_UNIQUE";
-
-	private static final String _FAILURE_MARKER_UPSTREAM_JOB =
-		"FAILURE_MARKER_UPSTREAM_JOB";
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -1,0 +1,129 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.dom4j.Element;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class BaseDownstreamBuildTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetGitHubMessageElement() {
+		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
+			BaseDownstreamBuild.class);
+
+		Mockito.when(
+			baseDownstreamBuild.getStatus()
+		).thenReturn(
+			"completed"
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getResult()
+		).thenReturn(
+			"UNSTABLE"
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getBatchName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getBuildURL()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getDisplayName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getUniqueFailureTestResults()
+		).thenReturn(
+			Collections.<TestResult>emptyList()
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getUpstreamJobFailureTestResults()
+		).thenReturn(
+			Collections.<TestResult>emptyList()
+		);
+
+		Element uniqueFailureElement = Dom4JUtil.getNewElement(
+			"code", null, _FAILURE_MARKER_UNIQUE);
+		Element upstreamJobFailureElement = Dom4JUtil.getNewElement(
+			"code", null, _FAILURE_MARKER_UPSTREAM_JOB);
+
+		Mockito.when(
+			baseDownstreamBuild.getTestResultGitHubElements(
+				Mockito.anyList(), Mockito.eq(true))
+		).thenReturn(
+			Arrays.asList(uniqueFailureElement)
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getTestResultGitHubElements(
+				Mockito.anyList(), Mockito.eq(false))
+		).thenReturn(
+			Arrays.asList(upstreamJobFailureElement)
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getGitHubMessageElement();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getGitHubMessageUpstreamJobFailureElement();
+
+		Element gitHubMessageElement =
+			baseDownstreamBuild.getGitHubMessageElement();
+
+		String gitHubMessageXML = gitHubMessageElement.asXML();
+
+		Assert.assertTrue(gitHubMessageXML.contains(_FAILURE_MARKER_UNIQUE));
+		Assert.assertFalse(
+			gitHubMessageXML.contains(_FAILURE_MARKER_UPSTREAM_JOB));
+
+		Element gitHubMessageUpstreamJobFailureElement =
+			baseDownstreamBuild.getGitHubMessageUpstreamJobFailureElement();
+
+		String gitHubMessageUpstreamJobFailureXML =
+			gitHubMessageUpstreamJobFailureElement.asXML();
+
+		Assert.assertTrue(
+			gitHubMessageUpstreamJobFailureXML.contains(
+				_FAILURE_MARKER_UPSTREAM_JOB));
+		Assert.assertFalse(
+			gitHubMessageUpstreamJobFailureXML.contains(
+				_FAILURE_MARKER_UNIQUE));
+	}
+
+	private static final String _FAILURE_MARKER_UNIQUE =
+		"FAILURE_MARKER_UNIQUE";
+
+	private static final String _FAILURE_MARKER_UPSTREAM_JOB =
+		"FAILURE_MARKER_UPSTREAM_JOB";
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -89,9 +89,9 @@ public class BaseDownstreamBuildTest
 
 		String gitHubMessageXML = gitHubMessageElement.asXML();
 
-		Assert.assertTrue(gitHubMessageXML.contains(_FAILURE_MARKER_UNIQUE));
 		Assert.assertFalse(
 			gitHubMessageXML.contains(_FAILURE_MARKER_UPSTREAM_JOB));
+		Assert.assertTrue(gitHubMessageXML.contains(_FAILURE_MARKER_UNIQUE));
 
 		Element gitHubMessageUpstreamJobFailureElement =
 			baseDownstreamBuild.getGitHubMessageUpstreamJobFailureElement();
@@ -99,12 +99,12 @@ public class BaseDownstreamBuildTest
 		String gitHubMessageUpstreamJobFailureXML =
 			gitHubMessageUpstreamJobFailureElement.asXML();
 
-		Assert.assertTrue(
-			gitHubMessageUpstreamJobFailureXML.contains(
-				_FAILURE_MARKER_UPSTREAM_JOB));
 		Assert.assertFalse(
 			gitHubMessageUpstreamJobFailureXML.contains(
 				_FAILURE_MARKER_UNIQUE));
+		Assert.assertTrue(
+			gitHubMessageUpstreamJobFailureXML.contains(
+				_FAILURE_MARKER_UPSTREAM_JOB));
 	}
 
 	private static final String _FAILURE_MARKER_UNIQUE =

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -411,6 +411,53 @@ public class JenkinsResultsParserUtilTest
 				"https://releases.liferay.com/portal/"));
 	}
 
+	@Test
+	public void testInvokeJenkinsBuild() throws Exception {
+		Environment environment = mockEnvironment();
+
+		Mockito.when(
+			environment.doGet("MASTER_NETWORK_NAME")
+		).thenReturn(
+			"aws-network"
+		);
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"jenkins.admin.user.name", RandomTestUtil.randomString());
+		buildProperties.setProperty(
+			"jenkins.admin.user.token", RandomTestUtil.randomString());
+		buildProperties.setProperty(
+			"jenkins.authentication.token", RandomTestUtil.randomString());
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		UrlReader urlReader = mockUrlReader();
+
+		Mockito.doReturn(
+			"https://test-1-1.liferay.com/queue/item/12345"
+		).when(
+			urlReader
+		).doGetResponseHeader(
+			Mockito.eq("Location"), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.anyInt(), Mockito.anyString()
+		);
+
+		JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);
+
+		Mockito.when(
+			jenkinsMaster.getRemoteURL()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		testEquals(
+			"12345",
+			String.valueOf(
+				JenkinsResultsParserUtil.invokeJenkinsBuild(
+					jenkinsMaster, "test-job", new HashMap<>())));
+	}
+
 	@Test(timeout = 30000)
 	public void testInvokeJenkinsBuildReadTimeout() throws Exception {
 		try (ServerSocket serverSocket = _createServerSocket()) {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -138,6 +138,29 @@ public class JenkinsResultsParserUtilTest
 	}
 
 	@Test
+	public void testGetJenkinsBuildQueueId() {
+		testEquals(
+			"12345",
+			String.valueOf(
+				JenkinsResultsParserUtil.getJenkinsBuildQueueId(
+					"https://test-1-1.liferay.com/queue/item/12345")));
+		testEquals(
+			"678",
+			String.valueOf(
+				JenkinsResultsParserUtil.getJenkinsBuildQueueId(
+					"http://test-1-1/queue/item/678/")));
+		testEquals(
+			"0",
+			String.valueOf(
+				JenkinsResultsParserUtil.getJenkinsBuildQueueId(null)));
+		testEquals(
+			"0",
+			String.valueOf(
+				JenkinsResultsParserUtil.getJenkinsBuildQueueId(
+					"https://test-1-1.liferay.com/job/test-job")));
+	}
+
+	@Test
 	public void testGetJobVariant() throws Exception {
 		TestSample testSample = testSamples.get("axis-integration-db2-1");
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectoryTest.java
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class PortalGitWorkingDirectoryTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetFilteredEnvironment() throws Exception {
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"ant.opts.default[master]", "-Xmx4g -Dmaster");
+		buildProperties.setProperty(
+			"ant.opts.default[ee-7.4.x]", "-Xmx8g -Dee74");
+		buildProperties.setProperty(
+			"java.jdk.default.runtime[master]", "/opt/java/jdk-zulu11-master");
+		buildProperties.setProperty(
+			"java.jdk.default.runtime[ee-7.4.x]", "/opt/java/jdk-zulu8-ee74");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Map<String, String> masterFilteredEnvironment = _getFilteredEnvironment(
+			"master");
+
+		testEquals(
+			"-Xmx4g -Dmaster", masterFilteredEnvironment.get("ANT_OPTS"));
+		testEquals(
+			"-Xmx4g -Dmaster", masterFilteredEnvironment.get("JAVA_OPTS"));
+		testEquals(
+			"/opt/java/jdk-zulu11-master",
+			masterFilteredEnvironment.get("JAVA_HOME"));
+
+		Map<String, String> releaseFilteredEnvironment =
+			_getFilteredEnvironment("ee-7.4.x");
+
+		testEquals("-Xmx8g -Dee74", releaseFilteredEnvironment.get("ANT_OPTS"));
+		testEquals(
+			"-Xmx8g -Dee74", releaseFilteredEnvironment.get("JAVA_OPTS"));
+		testEquals(
+			"/opt/java/jdk-zulu8-ee74",
+			releaseFilteredEnvironment.get("JAVA_HOME"));
+	}
+
+	private Map<String, String> _getFilteredEnvironment(
+			String upstreamBranchName)
+		throws Exception {
+
+		PortalGitWorkingDirectory portalGitWorkingDirectory = Mockito.mock(
+			PortalGitWorkingDirectory.class);
+
+		Mockito.when(
+			portalGitWorkingDirectory.getUpstreamBranchName()
+		).thenReturn(
+			upstreamBranchName
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalGitWorkingDirectory
+		).getFilteredEnvironment();
+
+		return portalGitWorkingDirectory.getFilteredEnvironment();
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectoryTest.java
@@ -27,13 +27,13 @@ public class PortalGitWorkingDirectoryTest
 		Properties buildProperties = new Properties();
 
 		buildProperties.setProperty(
-			"ant.opts.default[master]", "-Xmx4g -Dmaster");
-		buildProperties.setProperty(
 			"ant.opts.default[ee-7.4.x]", "-Xmx8g -Dee74");
 		buildProperties.setProperty(
-			"java.jdk.default.runtime[master]", "/opt/java/jdk-zulu11-master");
+			"ant.opts.default[master]", "-Xmx4g -Dmaster");
 		buildProperties.setProperty(
 			"java.jdk.default.runtime[ee-7.4.x]", "/opt/java/jdk-zulu8-ee74");
+		buildProperties.setProperty(
+			"java.jdk.default.runtime[master]", "/opt/java/jdk-zulu11-master");
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalReleaseTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalReleaseTest.java
@@ -42,12 +42,12 @@ public class PortalReleaseTest extends com.liferay.jenkins.results.parser.Test {
 
 		PortalRelease portalRelease = new PortalRelease(jsonObject);
 
-		JSONObject roundTripJSONObject = portalRelease.getJSONObject();
+		JSONObject portalReleaseJSONObject = portalRelease.getJSONObject();
 
 		for (String urlFieldName : _URL_FIELD_NAMES) {
 			testEquals(
 				_BUNDLES_BASE_URL + "/" + urlFieldName,
-				roundTripJSONObject.optString(urlFieldName, null));
+				portalReleaseJSONObject.optString(urlFieldName, null));
 		}
 
 		JSONObject unsetJSONObject = new JSONObject();
@@ -63,7 +63,7 @@ public class PortalReleaseTest extends com.liferay.jenkins.results.parser.Test {
 
 		PortalRelease unsetPortalRelease = new PortalRelease(unsetJSONObject);
 
-		JSONObject unsetRoundTripJSONObject =
+		JSONObject unsetPortalReleaseJSONObject =
 			unsetPortalRelease.getJSONObject();
 
 		for (String urlFieldName : _URL_FIELD_NAMES) {
@@ -72,7 +72,8 @@ public class PortalReleaseTest extends com.liferay.jenkins.results.parser.Test {
 			}
 
 			testEquals(
-				null, unsetRoundTripJSONObject.optString(urlFieldName, null));
+				null,
+				unsetPortalReleaseJSONObject.optString(urlFieldName, null));
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalReleaseTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalReleaseTest.java
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Collections;
+import java.util.Properties;
+
+import org.json.JSONObject;
+
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class PortalReleaseTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetJSONObject() {
+		mockEnvironment(Collections.<String, String>emptyMap());
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("build.properties.seeded", "true");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		JSONObject jsonObject = new JSONObject();
+
+		jsonObject.put(
+			"bundles_base_url", _BUNDLES_BASE_URL
+		).put(
+			"portal_version", RandomTestUtil.randomString()
+		);
+
+		for (String urlFieldName : _URL_FIELD_NAMES) {
+			jsonObject.put(
+				urlFieldName, _BUNDLES_BASE_URL + "/" + urlFieldName);
+		}
+
+		PortalRelease portalRelease = new PortalRelease(jsonObject);
+
+		JSONObject roundTripJSONObject = portalRelease.getJSONObject();
+
+		for (String urlFieldName : _URL_FIELD_NAMES) {
+			testEquals(
+				_BUNDLES_BASE_URL + "/" + urlFieldName,
+				roundTripJSONObject.optString(urlFieldName, null));
+		}
+
+		JSONObject unsetJSONObject = new JSONObject();
+
+		unsetJSONObject.put(
+			_URL_FIELD_NAME_TOMCAT,
+			_BUNDLES_BASE_URL + "/" + _URL_FIELD_NAME_TOMCAT
+		).put(
+			"bundles_base_url", _BUNDLES_BASE_URL
+		).put(
+			"portal_version", RandomTestUtil.randomString()
+		);
+
+		PortalRelease unsetPortalRelease = new PortalRelease(unsetJSONObject);
+
+		JSONObject unsetRoundTripJSONObject =
+			unsetPortalRelease.getJSONObject();
+
+		for (String urlFieldName : _URL_FIELD_NAMES) {
+			if (urlFieldName.equals(_URL_FIELD_NAME_TOMCAT)) {
+				continue;
+			}
+
+			testEquals(
+				null, unsetRoundTripJSONObject.optString(urlFieldName, null));
+		}
+	}
+
+	private static final String _BUNDLES_BASE_URL =
+		"https://release.liferay.com/portal/7.4.13-ga1";
+
+	private static final String _URL_FIELD_NAME_TOMCAT =
+		"portal_bundle_tomcat_url_string";
+
+	private static final String[] _URL_FIELD_NAMES = {
+		"plugins_war_zip_url_string", "portal_bundle_glassfish_url_string",
+		"portal_bundle_jboss_url_string", "portal_bundle_tomcat_url_string",
+		"portal_bundle_wildfly_url_string",
+		"portal_dependencies_zip_url_string", "portal_osgi_zip_url_string",
+		"portal_sql_zip_url_string", "portal_tools_zip_url_string",
+		"portal_war_url_string"
+	};
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalReleaseTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalReleaseTest.java
@@ -27,36 +27,47 @@ public class PortalReleaseTest extends com.liferay.jenkins.results.parser.Test {
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
+		String bundlesBaseURL = "https://release.liferay.com/portal/7.4.13-ga1";
+
+		String[] urlFieldNames = {
+			"plugins_war_zip_url_string", "portal_bundle_glassfish_url_string",
+			"portal_bundle_jboss_url_string", "portal_bundle_tomcat_url_string",
+			"portal_bundle_wildfly_url_string",
+			"portal_dependencies_zip_url_string", "portal_osgi_zip_url_string",
+			"portal_sql_zip_url_string", "portal_tools_zip_url_string",
+			"portal_war_url_string"
+		};
+
 		JSONObject jsonObject = new JSONObject();
 
 		jsonObject.put(
-			"bundles_base_url", _BUNDLES_BASE_URL
+			"bundles_base_url", bundlesBaseURL
 		).put(
 			"portal_version", RandomTestUtil.randomString()
 		);
 
-		for (String urlFieldName : _URL_FIELD_NAMES) {
-			jsonObject.put(
-				urlFieldName, _BUNDLES_BASE_URL + "/" + urlFieldName);
+		for (String urlFieldName : urlFieldNames) {
+			jsonObject.put(urlFieldName, bundlesBaseURL + "/" + urlFieldName);
 		}
 
 		PortalRelease portalRelease = new PortalRelease(jsonObject);
 
 		JSONObject portalReleaseJSONObject = portalRelease.getJSONObject();
 
-		for (String urlFieldName : _URL_FIELD_NAMES) {
+		for (String urlFieldName : urlFieldNames) {
 			testEquals(
-				_BUNDLES_BASE_URL + "/" + urlFieldName,
+				bundlesBaseURL + "/" + urlFieldName,
 				portalReleaseJSONObject.optString(urlFieldName, null));
 		}
+
+		String tomcatURLFieldName = "portal_bundle_tomcat_url_string";
 
 		JSONObject unsetJSONObject = new JSONObject();
 
 		unsetJSONObject.put(
-			_URL_FIELD_NAME_TOMCAT,
-			_BUNDLES_BASE_URL + "/" + _URL_FIELD_NAME_TOMCAT
+			tomcatURLFieldName, bundlesBaseURL + "/" + tomcatURLFieldName
 		).put(
-			"bundles_base_url", _BUNDLES_BASE_URL
+			"bundles_base_url", bundlesBaseURL
 		).put(
 			"portal_version", RandomTestUtil.randomString()
 		);
@@ -66,8 +77,8 @@ public class PortalReleaseTest extends com.liferay.jenkins.results.parser.Test {
 		JSONObject unsetPortalReleaseJSONObject =
 			unsetPortalRelease.getJSONObject();
 
-		for (String urlFieldName : _URL_FIELD_NAMES) {
-			if (urlFieldName.equals(_URL_FIELD_NAME_TOMCAT)) {
+		for (String urlFieldName : urlFieldNames) {
+			if (urlFieldName.equals(tomcatURLFieldName)) {
 				continue;
 			}
 
@@ -76,20 +87,5 @@ public class PortalReleaseTest extends com.liferay.jenkins.results.parser.Test {
 				unsetPortalReleaseJSONObject.optString(urlFieldName, null));
 		}
 	}
-
-	private static final String _BUNDLES_BASE_URL =
-		"https://release.liferay.com/portal/7.4.13-ga1";
-
-	private static final String _URL_FIELD_NAME_TOMCAT =
-		"portal_bundle_tomcat_url_string";
-
-	private static final String[] _URL_FIELD_NAMES = {
-		"plugins_war_zip_url_string", "portal_bundle_glassfish_url_string",
-		"portal_bundle_jboss_url_string", "portal_bundle_tomcat_url_string",
-		"portal_bundle_wildfly_url_string",
-		"portal_dependencies_zip_url_string", "portal_osgi_zip_url_string",
-		"portal_sql_zip_url_string", "portal_tools_zip_url_string",
-		"portal_war_url_string"
-	};
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalReleaseTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalReleaseTest.java
@@ -23,7 +23,8 @@ public class PortalReleaseTest extends com.liferay.jenkins.results.parser.Test {
 
 		Properties buildProperties = new Properties();
 
-		buildProperties.setProperty("build.properties.seeded", "true");
+		buildProperties.setProperty(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RetryableTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RetryableTest.java
@@ -5,6 +5,8 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Test;
 
 /**
@@ -14,34 +16,24 @@ public class RetryableTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testBreakLoop() {
-		BreakLoopRetryable breakLoopRetryable = new BreakLoopRetryable();
+		AtomicInteger executeCount = new AtomicInteger();
 
-		breakLoopRetryable.executeWithRetries();
+		Retryable<Void> retryable = new Retryable<Void>(false, 5, 0, false) {
 
-		testEquals("1", String.valueOf(breakLoopRetryable.getExecuteCount()));
-	}
+			@Override
+			public Void execute() {
+				executeCount.incrementAndGet();
 
-	private static class BreakLoopRetryable extends Retryable<Void> {
+				breakLoop();
 
-		public BreakLoopRetryable() {
-			super(false, 5, 0, false);
-		}
+				throw new RuntimeException(RandomTestUtil.randomString());
+			}
 
-		@Override
-		public Void execute() {
-			_executeCount++;
+		};
 
-			breakLoop();
+		retryable.executeWithRetries();
 
-			throw new RuntimeException(RandomTestUtil.randomString());
-		}
-
-		public int getExecuteCount() {
-			return _executeCount;
-		}
-
-		private int _executeCount;
-
+		testEquals("1", String.valueOf(executeCount.get()));
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RetryableTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RetryableTest.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class RetryableTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testBreakLoop() {
+		BreakLoopRetryable breakLoopRetryable = new BreakLoopRetryable();
+
+		breakLoopRetryable.executeWithRetries();
+
+		testEquals("1", String.valueOf(breakLoopRetryable.getExecuteCount()));
+	}
+
+	private static class BreakLoopRetryable extends Retryable<Void> {
+
+		public BreakLoopRetryable() {
+			super(false, 5, 0, false);
+		}
+
+		@Override
+		public Void execute() {
+			_executeCount++;
+
+			breakLoop();
+
+			throw new RuntimeException("Permanent failure");
+		}
+
+		public int getExecuteCount() {
+			return _executeCount;
+		}
+
+		private int _executeCount;
+
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RetryableTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RetryableTest.java
@@ -33,7 +33,7 @@ public class RetryableTest extends com.liferay.jenkins.results.parser.Test {
 
 			breakLoop();
 
-			throw new RuntimeException("Permanent failure");
+			throw new RuntimeException(RandomTestUtil.randomString());
 		}
 
 		public int getExecuteCount() {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/history/HistoryFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/history/HistoryFactoryTest.java
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.history;
+
+import org.json.JSONObject;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class HistoryFactoryTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testNewTestClassHistory() {
+		BatchHistory integrationBatchHistory = _mockBatchHistory(
+			"modules-integration", "master");
+		BatchHistory unitBatchHistory = _mockBatchHistory(
+			"modules-unit", "master");
+
+		JSONObject jsonObject = new JSONObject();
+
+		TestClassHistory testClassHistory = HistoryFactory.newTestClassHistory(
+			unitBatchHistory, jsonObject, _TEST_CLASS_NAME);
+
+		Assert.assertSame(
+			testClassHistory,
+			HistoryFactory.newTestClassHistory(
+				unitBatchHistory, jsonObject, _TEST_CLASS_NAME));
+
+		Assert.assertNotSame(
+			testClassHistory,
+			HistoryFactory.newTestClassHistory(
+				integrationBatchHistory, jsonObject, _TEST_CLASS_NAME));
+	}
+
+	@Test
+	public void testNewTestTaskHistory() {
+		BatchHistory integrationBatchHistory = _mockBatchHistory(
+			"modules-integration", "master");
+		BatchHistory unitBatchHistory = _mockBatchHistory(
+			"modules-unit", "master");
+
+		JSONObject jsonObject = new JSONObject();
+
+		TestTaskHistory testTaskHistory = HistoryFactory.newTestTaskHistory(
+			unitBatchHistory, jsonObject, _TEST_TASK_NAME);
+
+		Assert.assertNotSame(
+			testTaskHistory,
+			HistoryFactory.newTestTaskHistory(
+				integrationBatchHistory, jsonObject, _TEST_TASK_NAME));
+
+		Assert.assertSame(
+			testTaskHistory,
+			HistoryFactory.newTestTaskHistory(
+				unitBatchHistory, jsonObject, _TEST_TASK_NAME));
+	}
+
+	private BatchHistory _mockBatchHistory(
+		String batchName, String portalUpstreamBranchName) {
+
+		BatchHistory batchHistory = Mockito.mock(BatchHistory.class);
+
+		Mockito.when(
+			batchHistory.getPortalUpstreamBranchName()
+		).thenReturn(
+			portalUpstreamBranchName
+		);
+
+		Mockito.when(
+			batchHistory.getBatchName()
+		).thenReturn(
+			batchName
+		);
+
+		return batchHistory;
+	}
+
+	private static final String _TEST_CLASS_NAME =
+		"com.liferay.jenkins.results.parser.SampleTest";
+
+	private static final String _TEST_TASK_NAME = "sample-test-task";
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/history/HistoryFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/history/HistoryFactoryTest.java
@@ -53,15 +53,15 @@ public class HistoryFactoryTest
 		TestTaskHistory testTaskHistory = HistoryFactory.newTestTaskHistory(
 			unitBatchHistory, jsonObject, _TEST_TASK_NAME);
 
-		Assert.assertNotSame(
-			testTaskHistory,
-			HistoryFactory.newTestTaskHistory(
-				integrationBatchHistory, jsonObject, _TEST_TASK_NAME));
-
 		Assert.assertSame(
 			testTaskHistory,
 			HistoryFactory.newTestTaskHistory(
 				unitBatchHistory, jsonObject, _TEST_TASK_NAME));
+
+		Assert.assertNotSame(
+			testTaskHistory,
+			HistoryFactory.newTestTaskHistory(
+				integrationBatchHistory, jsonObject, _TEST_TASK_NAME));
 	}
 
 	private BatchHistory _mockBatchHistory(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/history/HistoryFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/history/HistoryFactoryTest.java
@@ -5,6 +5,8 @@
 
 package com.liferay.jenkins.results.parser.history;
 
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+
 import org.json.JSONObject;
 
 import org.junit.Assert;
@@ -27,7 +29,7 @@ public class HistoryFactoryTest
 
 		JSONObject jsonObject = new JSONObject();
 
-		String testClassName = "com.liferay.jenkins.results.parser.SampleTest";
+		String testClassName = RandomTestUtil.randomString();
 
 		TestClassHistory testClassHistory = HistoryFactory.newTestClassHistory(
 			unitBatchHistory, jsonObject, testClassName);
@@ -52,7 +54,7 @@ public class HistoryFactoryTest
 
 		JSONObject jsonObject = new JSONObject();
 
-		String testTaskName = "sample-test-task";
+		String testTaskName = RandomTestUtil.randomString();
 
 		TestTaskHistory testTaskHistory = HistoryFactory.newTestTaskHistory(
 			unitBatchHistory, jsonObject, testTaskName);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/history/HistoryFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/history/HistoryFactoryTest.java
@@ -27,18 +27,20 @@ public class HistoryFactoryTest
 
 		JSONObject jsonObject = new JSONObject();
 
+		String testClassName = "com.liferay.jenkins.results.parser.SampleTest";
+
 		TestClassHistory testClassHistory = HistoryFactory.newTestClassHistory(
-			unitBatchHistory, jsonObject, _TEST_CLASS_NAME);
+			unitBatchHistory, jsonObject, testClassName);
 
 		Assert.assertSame(
 			testClassHistory,
 			HistoryFactory.newTestClassHistory(
-				unitBatchHistory, jsonObject, _TEST_CLASS_NAME));
+				unitBatchHistory, jsonObject, testClassName));
 
 		Assert.assertNotSame(
 			testClassHistory,
 			HistoryFactory.newTestClassHistory(
-				integrationBatchHistory, jsonObject, _TEST_CLASS_NAME));
+				integrationBatchHistory, jsonObject, testClassName));
 	}
 
 	@Test
@@ -50,18 +52,20 @@ public class HistoryFactoryTest
 
 		JSONObject jsonObject = new JSONObject();
 
+		String testTaskName = "sample-test-task";
+
 		TestTaskHistory testTaskHistory = HistoryFactory.newTestTaskHistory(
-			unitBatchHistory, jsonObject, _TEST_TASK_NAME);
+			unitBatchHistory, jsonObject, testTaskName);
 
 		Assert.assertSame(
 			testTaskHistory,
 			HistoryFactory.newTestTaskHistory(
-				unitBatchHistory, jsonObject, _TEST_TASK_NAME));
+				unitBatchHistory, jsonObject, testTaskName));
 
 		Assert.assertNotSame(
 			testTaskHistory,
 			HistoryFactory.newTestTaskHistory(
-				integrationBatchHistory, jsonObject, _TEST_TASK_NAME));
+				integrationBatchHistory, jsonObject, testTaskName));
 	}
 
 	private BatchHistory _mockBatchHistory(
@@ -83,10 +87,5 @@ public class HistoryFactoryTest
 
 		return batchHistory;
 	}
-
-	private static final String _TEST_CLASS_NAME =
-		"com.liferay.jenkins.results.parser.SampleTest";
-
-	private static final String _TEST_TASK_NAME = "sample-test-task";
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/testray/BaseTestrayAttachmentUploaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/testray/BaseTestrayAttachmentUploaderTest.java
@@ -1,0 +1,142 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.testray;
+
+import com.liferay.jenkins.results.parser.Build;
+import com.liferay.jenkins.results.parser.BuildDatabase;
+
+import java.io.File;
+
+import java.net.URL;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class BaseTestrayAttachmentUploaderTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testPrepareFiles() throws Exception {
+		Build build = _mockBuild();
+
+		File preparedFilesBaseDir = _createTempDir();
+
+		File recordedFilesBaseDir = new File(
+			preparedFilesBaseDir, "recorded_logs");
+
+		FakeTestrayAttachmentUploader fakeTestrayAttachmentUploader =
+			new FakeTestrayAttachmentUploader(
+				build, preparedFilesBaseDir,
+				new FakeTestrayAttachmentRecorder(build, recordedFilesBaseDir));
+
+		fakeTestrayAttachmentUploader.prepareFiles();
+
+		List<File> preparedFiles =
+			fakeTestrayAttachmentUploader.getPreparedFiles();
+
+		Assert.assertTrue(preparedFiles.isEmpty());
+	}
+
+	private File _createTempDir() throws Exception {
+		File dir = File.createTempFile("testray-uploader-", null);
+
+		dir.delete();
+
+		dir.mkdir();
+
+		return dir;
+	}
+
+	private Build _mockBuild() {
+		Build build = Mockito.mock(Build.class);
+
+		BuildDatabase buildDatabase = Mockito.mock(BuildDatabase.class);
+
+		Mockito.when(
+			build.getBuildDatabase()
+		).thenReturn(
+			buildDatabase
+		);
+
+		Mockito.when(
+			buildDatabase.getProperties(Mockito.anyString())
+		).thenReturn(
+			new Properties()
+		);
+
+		return build;
+	}
+
+	private static class FakeTestrayAttachmentRecorder
+		extends TestrayAttachmentRecorder {
+
+		public FakeTestrayAttachmentRecorder(
+			Build build, File recordedFilesBaseDir) {
+
+			super(build);
+
+			_recordedFilesBaseDir = recordedFilesBaseDir;
+		}
+
+		@Override
+		public void record() {
+		}
+
+		@Override
+		protected File getRecordedFilesBaseDir() {
+			return _recordedFilesBaseDir;
+		}
+
+		private final File _recordedFilesBaseDir;
+
+	}
+
+	private static class FakeTestrayAttachmentUploader
+		extends BaseTestrayAttachmentUploader {
+
+		public FakeTestrayAttachmentUploader(
+			Build build, File preparedFilesBaseDir,
+			TestrayAttachmentRecorder testrayAttachmentRecorder) {
+
+			super(build, null);
+
+			_preparedFilesBaseDir = preparedFilesBaseDir;
+			_testrayAttachmentRecorder = testrayAttachmentRecorder;
+		}
+
+		@Override
+		public File getPreparedFilesBaseDir() {
+			return _preparedFilesBaseDir;
+		}
+
+		@Override
+		public TestrayAttachmentRecorder getTestrayAttachmentRecorder() {
+			return _testrayAttachmentRecorder;
+		}
+
+		@Override
+		public URL getTestrayServerLogsURL() {
+			return null;
+		}
+
+		@Override
+		public void upload() {
+		}
+
+		private final File _preparedFilesBaseDir;
+		private final TestrayAttachmentRecorder _testrayAttachmentRecorder;
+
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/testray/BaseTestrayAttachmentUploaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/testray/BaseTestrayAttachmentUploaderTest.java
@@ -5,15 +5,9 @@
 
 package com.liferay.jenkins.results.parser.testray;
 
-import com.liferay.jenkins.results.parser.Build;
-import com.liferay.jenkins.results.parser.BuildDatabase;
-
 import java.io.File;
 
-import java.net.URL;
-
 import java.util.List;
-import java.util.Properties;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -28,22 +22,49 @@ public class BaseTestrayAttachmentUploaderTest
 
 	@Test
 	public void testPrepareFiles() throws Exception {
-		Build build = _mockBuild();
-
 		File preparedFilesBaseDir = _createTempDir();
 
 		File recordedFilesBaseDir = new File(
 			preparedFilesBaseDir, "recorded_logs");
 
-		FakeTestrayAttachmentUploader fakeTestrayAttachmentUploader =
-			new FakeTestrayAttachmentUploader(
-				build, preparedFilesBaseDir,
-				new FakeTestrayAttachmentRecorder(build, recordedFilesBaseDir));
+		TestrayAttachmentRecorder testrayAttachmentRecorder = Mockito.mock(
+			TestrayAttachmentRecorder.class);
 
-		fakeTestrayAttachmentUploader.prepareFiles();
+		Mockito.when(
+			testrayAttachmentRecorder.getRecordedFilesBaseDir()
+		).thenReturn(
+			recordedFilesBaseDir
+		);
+
+		BaseTestrayAttachmentUploader baseTestrayAttachmentUploader =
+			Mockito.mock(BaseTestrayAttachmentUploader.class);
+
+		Mockito.when(
+			baseTestrayAttachmentUploader.getPreparedFilesBaseDir()
+		).thenReturn(
+			preparedFilesBaseDir
+		);
+
+		Mockito.when(
+			baseTestrayAttachmentUploader.getTestrayAttachmentRecorder()
+		).thenReturn(
+			testrayAttachmentRecorder
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseTestrayAttachmentUploader
+		).getPreparedFiles();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseTestrayAttachmentUploader
+		).prepareFiles();
+
+		baseTestrayAttachmentUploader.prepareFiles();
 
 		List<File> preparedFiles =
-			fakeTestrayAttachmentUploader.getPreparedFiles();
+			baseTestrayAttachmentUploader.getPreparedFiles();
 
 		Assert.assertTrue(preparedFiles.isEmpty());
 	}
@@ -56,87 +77,6 @@ public class BaseTestrayAttachmentUploaderTest
 		dir.mkdir();
 
 		return dir;
-	}
-
-	private Build _mockBuild() {
-		Build build = Mockito.mock(Build.class);
-
-		BuildDatabase buildDatabase = Mockito.mock(BuildDatabase.class);
-
-		Mockito.when(
-			build.getBuildDatabase()
-		).thenReturn(
-			buildDatabase
-		);
-
-		Mockito.when(
-			buildDatabase.getProperties(Mockito.anyString())
-		).thenReturn(
-			new Properties()
-		);
-
-		return build;
-	}
-
-	private static class FakeTestrayAttachmentRecorder
-		extends TestrayAttachmentRecorder {
-
-		public FakeTestrayAttachmentRecorder(
-			Build build, File recordedFilesBaseDir) {
-
-			super(build);
-
-			_recordedFilesBaseDir = recordedFilesBaseDir;
-		}
-
-		@Override
-		public void record() {
-		}
-
-		@Override
-		protected File getRecordedFilesBaseDir() {
-			return _recordedFilesBaseDir;
-		}
-
-		private final File _recordedFilesBaseDir;
-
-	}
-
-	private static class FakeTestrayAttachmentUploader
-		extends BaseTestrayAttachmentUploader {
-
-		public FakeTestrayAttachmentUploader(
-			Build build, File preparedFilesBaseDir,
-			TestrayAttachmentRecorder testrayAttachmentRecorder) {
-
-			super(build, null);
-
-			_preparedFilesBaseDir = preparedFilesBaseDir;
-			_testrayAttachmentRecorder = testrayAttachmentRecorder;
-		}
-
-		@Override
-		public File getPreparedFilesBaseDir() {
-			return _preparedFilesBaseDir;
-		}
-
-		@Override
-		public TestrayAttachmentRecorder getTestrayAttachmentRecorder() {
-			return _testrayAttachmentRecorder;
-		}
-
-		@Override
-		public URL getTestrayServerLogsURL() {
-			return null;
-		}
-
-		@Override
-		public void upload() {
-		}
-
-		private final File _preparedFilesBaseDir;
-		private final TestrayAttachmentRecorder _testrayAttachmentRecorder;
-
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7524

Resend of #2151 (@brittneyq); her original commits are carried over unchanged.

## Why

The jenkins-results-parser regressions in the LRCI-7522 bug history had no unit coverage, so each only surfaced in production CI. This adds one regression test per bug, each grounded in a real recorded regression and validated red-before-green.

## Bugs covered

- **PortalRelease dropped URL fields on JSON round-trip** (LRCI-7198) — `PortalReleaseTest`.
  The `JSONObject` constructor re-resolved every bundle URL from build properties, so a `PortalRelease` rehydrated on a node without those properties lost its URLs. The test round-trips a fully-populated `getJSONObject()` and asserts each URL field survives.
- **Retryable.breakLoop did not stop the retry loop** (LRCI-7397) — `RetryableTest`.
  `breakLoop()` zeroes `maxRetries` to abandon retries on a non-recoverable error; a regressed guard let the loop keep running. The test's `execute()` calls `breakLoop()` then throws, and asserts it ran exactly once.
- **HistoryFactory cache keyed too coarsely across batches** (LRCI-7030) — `HistoryFactoryTest`.
  History objects are memoized by branch + batch + name; dropping the batch from the key makes two batches collide. The test asserts the same batch returns the same instance and a different batch returns a distinct one.
- **Testray attachment copy skipped when no recorded files exist** (LRCI-7156) — `BaseTestrayAttachmentUploaderTest`.
  `prepareFiles()` only copies recorded files when the recorded dir exists; dropping that guard makes it throw when a build recorded nothing. The test runs `prepareFiles()` with no recorded dir and asserts the prepared list is empty.
- **GitHub message conflated upstream-job with unique failures** (LRCI-6929) — `BaseDownstreamBuildTest`.
  An UNSTABLE build must report only its unique failures to the PR and stash upstream-job failures separately; crossing the paths reports broken-master failures as the developer's own. The test stubs a distinct marker for each path and asserts each lands in the right message.
- **Environment resolved for the wrong branch** (LRCI-7344) — `PortalGitWorkingDirectoryTest`.
  `getFilteredEnvironment()` resolves `ANT_OPTS`/`JAVA_OPTS`/`JAVA_HOME` per branch; a fixed branch gives every branch one branch's JDK and heap settings. The test asserts `master` and `ee-7.4.x` each get their own values.
- **Jenkins build queue ID parsing and retrieval** (LRCI-6974) — `JenkinsResultsParserUtilTest`.
  `invokeJenkinsBuild()` reads the queue ID from the `Location` header and parses it via `getJenkinsBuildQueueId()`; a parse or seam regression loses the ID so callers can't locate the build they triggered. One test feeds several location strings to the parser; another mocks the header read and asserts the returned ID.

Two behavior-preserving production extractions make the last two testable: `getFilteredEnvironment` in `PortalGitWorkingDirectory`, and `getJenkinsBuildQueueId` plus a narrow `UrlReader.getResponseHeader` seam.

## Validation

The original nine tests ran green on CI (test-portal-acceptance-pullrequest-downstream build 146506). The follow-up commits are review-driven, behavior-preserving cleanups (ordering, inlining single-use constants, mocks over fakes, randomized arbitrary values), each verified locally with `formatSource` clean and the affected test classes green.
