### PR TITLE
LRCI-7783 Add unit tests for workspace Git repository setup

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -88,9 +88,7 @@ public class PortalWorkspaceGitRepositoryTest
 	}
 
 	@Test
-	public void testSetUpFailureDoesNotMarkTheRepositorySetUp()
-		throws Exception {
-
+	public void testSetUpFailure() throws Exception {
 		mockShell();
 
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
@@ -136,7 +134,7 @@ public class PortalWorkspaceGitRepositoryTest
 	}
 
 	@Test
-	public void testSetUpRunsStepsInOrderExactlyOnce() throws Exception {
+	public void testSetUpRunsOnce() throws Exception {
 		mockEnvironment(
 			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -70,8 +70,7 @@ public class PortalWorkspaceGitRepositoryTest
 			"The bundle version must be read from the " +
 				"PORTAL_LATEST_BUNDLE_VERSION environment variable",
 			"environment.value",
-			testProperties.getProperty(
-				"test.released.release.bundle.version"));
+			testProperties.getProperty("test.released.release.bundle.version"));
 
 		Assert.assertEquals(
 			"The bundle zip URL must be resolved from the " +

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.Assert;
@@ -24,6 +26,60 @@ import org.mockito.Mockito;
  */
 public class PortalWorkspaceGitRepositoryTest
 	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetPortalTestPropertiesReadsBundleVersionFromEnvironment()
+		throws Exception {
+
+		Map<String, String> environmentValues = new HashMap<>();
+
+		environmentValues.put(
+			"PORTAL_LATEST_BUNDLE_VERSION", "environment.value");
+
+		mockEnvironment(environmentValues);
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"portal.bundle.tomcat[environment.value]", "dummy.value");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Properties portalTestProperties = new Properties();
+
+		portalTestProperties.setProperty(
+			"test.released.release.bundle.version", "property.value");
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doReturn(
+			portalTestProperties
+		).when(
+			portalWorkspaceGitRepository
+		).getProperties(
+			"portal.test.properties"
+		);
+
+		mockShell();
+
+		Properties testProperties = _getPortalTestProperties(
+			portalWorkspaceGitRepository);
+
+		Assert.assertEquals(
+			"The bundle version must be read from the " +
+				"PORTAL_LATEST_BUNDLE_VERSION environment variable",
+			"environment.value",
+			testProperties.getProperty(
+				"test.released.release.bundle.version"));
+
+		Assert.assertEquals(
+			"The bundle zip URL must be resolved from the " +
+				"portal.bundle.tomcat property keyed by the bundle version",
+			"dummy.value",
+			testProperties.getProperty(
+				"test.released.test.portal.bundle.zip.url"));
+	}
 
 	@Test
 	public void testPrepareGitWorkingDirectoryWithGitArchiveDisabled()
@@ -424,6 +480,18 @@ public class PortalWorkspaceGitRepositoryTest
 		).putWorkspaceGitRepository(
 			Mockito.anyString(), Mockito.any(WorkspaceGitRepository.class)
 		);
+	}
+
+	private Properties _getPortalTestProperties(
+			PortalWorkspaceGitRepository portalWorkspaceGitRepository)
+		throws Exception {
+
+		Method method = PortalWorkspaceGitRepository.class.getDeclaredMethod(
+			"_getPortalTestProperties");
+
+		method.setAccessible(true);
+
+		return (Properties)method.invoke(portalWorkspaceGitRepository);
 	}
 
 	private boolean _isCommand(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -76,105 +76,9 @@ public class PortalWorkspaceGitRepositoryTest
 	}
 
 	@Test
-	public void testPrepareGitWorkingDirectoryWithGitArchiveDisabled()
-		throws Exception {
-
-		mockEnvironment(
-			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
-
-		Properties buildProperties = new Properties();
-
-		buildProperties.setProperty("binaries.cache.enabled", "true");
-		buildProperties.setProperty(
-			"cloud.ci.s3.bucket.dist.path", "s3://liferayci-dist/dist");
-		buildProperties.setProperty("git.archive.enabled", "false");
-
-		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
-
-		Shell shell = mockShell();
-
-		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			_newPortalWorkspaceGitRepository();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).isBinariesCacheEnabled();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).prepareGitWorkingDirectory();
-
-		portalWorkspaceGitRepository.prepareGitWorkingDirectory();
-
-		Mockito.verify(
-			shell, Mockito.never()
-		).doExecute(
-			Mockito.argThat(
-				executionRequest -> hasCommand(
-					executionRequest, "git-archives"))
-		);
-
-		Assert.assertTrue(
-			"The binaries cache must stay enabled when the git archive is " +
-				"disabled",
-			portalWorkspaceGitRepository.isBinariesCacheEnabled());
-	}
-
-	@Test
-	public void testPrepareGitWorkingDirectoryWithGitArchiveEnabled()
-		throws Exception {
-
-		mockEnvironment(
-			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
-
-		Properties buildProperties = new Properties();
-
-		buildProperties.setProperty("binaries.cache.enabled", "false");
-		buildProperties.setProperty(
-			"cloud.ci.s3.bucket.dist.path", "s3://liferayci-dist/dist");
-		buildProperties.setProperty("git.archive.enabled", "true");
-
-		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
-
-		Shell shell = mockShell();
-
-		Mockito.doReturn(
-			new Shell.ExecutionResult(0, "", "")
-		).when(
-			shell
-		).doExecute(
-			Mockito.any(Shell.ExecutionRequest.class)
-		);
-
-		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			_newPortalWorkspaceGitRepository();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).isBinariesCacheEnabled();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).prepareGitWorkingDirectory();
-
-		portalWorkspaceGitRepository.prepareGitWorkingDirectory();
-
-		Mockito.verify(
-			shell, Mockito.atLeastOnce()
-		).doExecute(
-			Mockito.argThat(
-				executionRequest -> hasCommand(
-					executionRequest, "git-archives"))
-		);
-
-		Assert.assertFalse(
-			"The binaries cache must stay disabled when the git archive is " +
-				"enabled",
-			portalWorkspaceGitRepository.isBinariesCacheEnabled());
+	public void testPrepareGitWorkingDirectory() throws Exception {
+		_testPrepareGitWorkingDirectory(false);
+		_testPrepareGitWorkingDirectory(true);
 	}
 
 	@Test
@@ -555,6 +459,65 @@ public class PortalWorkspaceGitRepositoryTest
 		).getUpstreamBranchName();
 
 		return portalWorkspaceGitRepository;
+	}
+
+	private void _testPrepareGitWorkingDirectory(boolean gitArchiveEnabled)
+		throws Exception {
+
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"binaries.cache.enabled", String.valueOf(!gitArchiveEnabled));
+		buildProperties.setProperty(
+			"cloud.ci.s3.bucket.dist.path", "s3://liferayci-dist/dist");
+		buildProperties.setProperty(
+			"git.archive.enabled", String.valueOf(gitArchiveEnabled));
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Shell shell = mockShell();
+
+		if (gitArchiveEnabled) {
+			Mockito.doReturn(
+				new Shell.ExecutionResult(0, "", "")
+			).when(
+				shell
+			).doExecute(
+				Mockito.any(Shell.ExecutionRequest.class)
+			);
+		}
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).prepareGitWorkingDirectory();
+
+		portalWorkspaceGitRepository.prepareGitWorkingDirectory();
+
+		Mockito.verify(
+			shell, gitArchiveEnabled ? Mockito.atLeastOnce() : Mockito.never()
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> hasCommand(
+					executionRequest, "git-archives"))
+		);
+
+		Assert.assertEquals(
+			"The binaries cache must be enabled if and only if the git " +
+				"archive is disabled",
+			!gitArchiveEnabled,
+			portalWorkspaceGitRepository.isBinariesCacheEnabled());
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -82,165 +82,9 @@ public class PortalWorkspaceGitRepositoryTest
 	}
 
 	@Test
-	public void testSetUp() throws Exception {
-		mockEnvironment(
-			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
-
-		Properties buildProperties = new Properties();
-
-		buildProperties.setProperty(
-			"binaries.cache.s3.path",
-			"s3://liferayci-file-propagator/binaries-cache/master.tar.gz");
-		buildProperties.setProperty("git.archive.enabled", "true");
-
-		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
-
-		BuildDatabaseUtil.setBuildDatabase(
-			BuildDatabaseTestUtil.newBuildDatabaseWithPullRequest());
-
-		Shell shell = mockShell();
-
-		Mockito.doReturn(
-			new Shell.ExecutionResult(0, "", "")
-		).when(
-			shell
-		).doExecute(
-			Mockito.any(Shell.ExecutionRequest.class)
-		);
-
-		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			_newPortalWorkspaceGitRepository();
-
-		Mockito.doReturn(
-			true
-		).when(
-			portalWorkspaceGitRepository
-		).isBinariesCacheEnabled();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).prepareGitWorkingDirectory();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUp();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUpAdditionalCaches();
-
-		portalWorkspaceGitRepository.setUp();
-
-		Mockito.verify(
-			shell
-		).doExecute(
-			Mockito.argThat(
-				executionRequest -> hasCommand(
-					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
-		);
-
-		Mockito.verify(
-			shell
-		).doExecute(
-			Mockito.argThat(
-				executionRequest -> hasCommand(
-					executionRequest, "tar --directory=",
-					"binaries-cache.tar.gz"))
-		);
-	}
-
-	@Test
-	public void testSetUpAdditionalCachesWithBinariesCacheDisabled()
-		throws Exception {
-
-		mockEnvironment(
-			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
-
-		Properties buildProperties = new Properties();
-
-		buildProperties.setProperty("binaries.cache.enabled", "false");
-		buildProperties.setProperty("git.archive.enabled", "true");
-
-		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
-
-		Shell shell = mockShell();
-
-		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			_newPortalWorkspaceGitRepository();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).isBinariesCacheEnabled();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUpAdditionalCaches();
-
-		portalWorkspaceGitRepository.setUpAdditionalCaches();
-
-		Mockito.verify(
-			shell, Mockito.never()
-		).doExecute(
-			Mockito.argThat(
-				executionRequest -> hasCommand(
-					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
-		);
-	}
-
-	@Test
-	public void testSetUpAdditionalCachesWithBinariesCacheEnabled()
-		throws Exception {
-
-		mockEnvironment(
-			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
-
-		Properties buildProperties = new Properties();
-
-		buildProperties.setProperty("binaries.cache.enabled", "true");
-		buildProperties.setProperty(
-			"binaries.cache.s3.path",
-			"s3://liferayci-file-propagator/binaries-cache/master.tar.gz");
-		buildProperties.setProperty("git.archive.enabled", "false");
-
-		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
-
-		Shell shell = mockShell();
-
-		Mockito.doReturn(
-			new Shell.ExecutionResult(0, "", "")
-		).when(
-			shell
-		).doExecute(
-			Mockito.any(Shell.ExecutionRequest.class)
-		);
-
-		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			_newPortalWorkspaceGitRepository();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).isBinariesCacheEnabled();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUpAdditionalCaches();
-
-		portalWorkspaceGitRepository.setUpAdditionalCaches();
-
-		Mockito.verify(
-			shell
-		).doExecute(
-			Mockito.argThat(
-				executionRequest -> hasCommand(
-					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
-		);
+	public void testSetUpAdditionalCaches() throws Exception {
+		_testSetUpAdditionalCaches(false);
+		_testSetUpAdditionalCaches(true);
 	}
 
 	@Test
@@ -518,6 +362,75 @@ public class PortalWorkspaceGitRepositoryTest
 				"archive is disabled",
 			!gitArchiveEnabled,
 			portalWorkspaceGitRepository.isBinariesCacheEnabled());
+	}
+
+	private void _testSetUpAdditionalCaches(boolean binariesCacheEnabled)
+		throws Exception {
+
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"binaries.cache.enabled", String.valueOf(binariesCacheEnabled));
+
+		if (binariesCacheEnabled) {
+			buildProperties.setProperty(
+				"binaries.cache.s3.path",
+				"s3://liferayci-file-propagator/binaries-cache/master.tar.gz");
+		}
+
+		buildProperties.setProperty(
+			"git.archive.enabled", String.valueOf(!binariesCacheEnabled));
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Shell shell = mockShell();
+
+		if (binariesCacheEnabled) {
+			Mockito.doReturn(
+				new Shell.ExecutionResult(0, "", "")
+			).when(
+				shell
+			).doExecute(
+				Mockito.any(Shell.ExecutionRequest.class)
+			);
+		}
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
+		portalWorkspaceGitRepository.setUpAdditionalCaches();
+
+		Mockito.verify(
+			shell, binariesCacheEnabled ? Mockito.times(1) : Mockito.never()
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> hasCommand(
+					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
+		);
+
+		if (binariesCacheEnabled) {
+			Mockito.verify(
+				shell
+			).doExecute(
+				Mockito.argThat(
+					executionRequest -> hasCommand(
+						executionRequest, "tar --directory=",
+						"binaries-cache.tar.gz"))
+			);
+		}
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -15,6 +15,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 /**
@@ -293,6 +294,87 @@ public class PortalWorkspaceGitRepositoryTest
 		Assert.assertFalse(
 			"The git archive must stay disabled when binaries cache is enabled",
 			_isGitArchiveEnabled(portalWorkspaceGitRepository));
+	}
+
+	@Test
+	public void testSetUpRunsStepsInOrderExactlyOnce() throws Exception {
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("git.archive.enabled", "true");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		BuildDatabase buildDatabase = Mockito.mock(BuildDatabase.class);
+
+		BuildDatabaseUtil.setBuildDatabase(buildDatabase);
+
+		mockShell();
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isSetUp();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setSetUp(
+			Mockito.anyBoolean()
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUp();
+
+		Assert.assertFalse(
+			"The repository must not be set up before setUp() runs",
+			portalWorkspaceGitRepository.isSetUp());
+
+		portalWorkspaceGitRepository.setUp();
+
+		Assert.assertTrue(
+			"The repository must be set up after setUp() runs",
+			portalWorkspaceGitRepository.isSetUp());
+
+		InOrder inOrder = Mockito.inOrder(
+			buildDatabase, portalWorkspaceGitRepository);
+
+		inOrder.verify(
+			portalWorkspaceGitRepository
+		).prepareGitWorkingDirectory();
+
+		inOrder.verify(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
+		inOrder.verify(
+			buildDatabase
+		).putWorkspaceGitRepository(
+			Mockito.anyString(), Mockito.any(WorkspaceGitRepository.class)
+		);
+
+		portalWorkspaceGitRepository.setUp();
+
+		Mockito.verify(
+			portalWorkspaceGitRepository, Mockito.times(1)
+		).prepareGitWorkingDirectory();
+
+		Mockito.verify(
+			portalWorkspaceGitRepository, Mockito.times(1)
+		).setUpAdditionalCaches();
+
+		Mockito.verify(
+			buildDatabase, Mockito.times(1)
+		).putWorkspaceGitRepository(
+			Mockito.anyString(), Mockito.any(WorkspaceGitRepository.class)
+		);
 	}
 
 	private boolean _isCommand(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -112,7 +112,7 @@ public class PortalWorkspaceGitRepositoryTest
 			shell, Mockito.never()
 		).doExecute(
 			Mockito.argThat(
-				executionRequest -> _isCommand(
+				executionRequest -> hasCommand(
 					executionRequest, "git-archives"))
 		);
 
@@ -167,7 +167,7 @@ public class PortalWorkspaceGitRepositoryTest
 			shell, Mockito.atLeastOnce()
 		).doExecute(
 			Mockito.argThat(
-				executionRequest -> _isCommand(
+				executionRequest -> hasCommand(
 					executionRequest, "git-archives"))
 		);
 
@@ -234,7 +234,7 @@ public class PortalWorkspaceGitRepositoryTest
 			shell
 		).doExecute(
 			Mockito.argThat(
-				executionRequest -> _isCommand(
+				executionRequest -> hasCommand(
 					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
 		);
 
@@ -242,7 +242,7 @@ public class PortalWorkspaceGitRepositoryTest
 			shell
 		).doExecute(
 			Mockito.argThat(
-				executionRequest -> _isCommand(
+				executionRequest -> hasCommand(
 					executionRequest, "tar --directory=",
 					"binaries-cache.tar.gz"))
 		);
@@ -283,7 +283,7 @@ public class PortalWorkspaceGitRepositoryTest
 			shell, Mockito.never()
 		).doExecute(
 			Mockito.argThat(
-				executionRequest -> _isCommand(
+				executionRequest -> hasCommand(
 					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
 		);
 
@@ -338,7 +338,7 @@ public class PortalWorkspaceGitRepositoryTest
 			shell
 		).doExecute(
 			Mockito.argThat(
-				executionRequest -> _isCommand(
+				executionRequest -> hasCommand(
 					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
 		);
 
@@ -486,24 +486,6 @@ public class PortalWorkspaceGitRepositoryTest
 		method.setAccessible(true);
 
 		return (Properties)method.invoke(portalWorkspaceGitRepository);
-	}
-
-	private boolean _isCommand(
-		Shell.ExecutionRequest executionRequest, String... substrings) {
-
-		if (executionRequest == null) {
-			return false;
-		}
-
-		String command = executionRequest.getCommands()[0];
-
-		for (String substring : substrings) {
-			if (!command.contains(substring)) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 
 	private boolean _isGitArchiveEnabled(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -11,8 +11,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 
 import org.junit.Assert;
@@ -31,12 +29,9 @@ public class PortalWorkspaceGitRepositoryTest
 	public void testGetPortalTestPropertiesReadsBundleVersionFromEnvironment()
 		throws Exception {
 
-		Map<String, String> environmentValues = new HashMap<>();
-
-		environmentValues.put(
-			"PORTAL_LATEST_BUNDLE_VERSION", "environment.value");
-
-		mockEnvironment(environmentValues);
+		mockEnvironment(
+			Collections.singletonMap(
+				"PORTAL_LATEST_BUNDLE_VERSION", "environment.value"));
 
 		Properties buildProperties = new Properties();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -6,6 +6,7 @@
 package com.liferay.jenkins.results.parser;
 
 import java.io.File;
+import java.io.IOException;
 
 import java.lang.reflect.Method;
 
@@ -294,6 +295,54 @@ public class PortalWorkspaceGitRepositoryTest
 		Assert.assertFalse(
 			"The git archive must stay disabled when binaries cache is enabled",
 			_isGitArchiveEnabled(portalWorkspaceGitRepository));
+	}
+
+	@Test
+	public void testSetUpFailureDoesNotMarkTheRepositorySetUp()
+		throws Exception {
+
+		mockShell();
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isSetUp();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setSetUp(
+			Mockito.anyBoolean()
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUp();
+
+		IOException ioException = new IOException(
+			"The additional caches could not be set up");
+
+		Mockito.doThrow(
+			ioException
+		).when(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
+		RuntimeException runtimeException = Assert.assertThrows(
+			RuntimeException.class, portalWorkspaceGitRepository::setUp);
+
+		Assert.assertSame(
+			"setUp() must rethrow the mid-sequence IOException as the " +
+				"RuntimeException cause",
+			ioException, runtimeException.getCause());
+
+		Assert.assertFalse(
+			"A failed setUp() must not mark the repository set up",
+			portalWorkspaceGitRepository.isSetUp());
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -24,17 +24,109 @@ public class PortalWorkspaceGitRepositoryTest
 	extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
+	public void testPrepareGitWorkingDirectoryWithGitArchiveDisabled()
+		throws Exception {
+
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("binaries.cache.enabled", "true");
+		buildProperties.setProperty(
+			"cloud.ci.s3.bucket.dist.path", "s3://liferayci-dist/dist");
+		buildProperties.setProperty("git.archive.enabled", "false");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Shell shell = mockShell();
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).prepareGitWorkingDirectory();
+
+		portalWorkspaceGitRepository.prepareGitWorkingDirectory();
+
+		Mockito.verify(
+			shell, Mockito.never()
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _isCommand(
+					executionRequest, "git-archives"))
+		);
+
+		Assert.assertTrue(
+			"The binaries cache must stay enabled when the git archive is " +
+				"disabled",
+			portalWorkspaceGitRepository.isBinariesCacheEnabled());
+	}
+
+	@Test
+	public void testPrepareGitWorkingDirectoryWithGitArchiveEnabled()
+		throws Exception {
+
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("binaries.cache.enabled", "false");
+		buildProperties.setProperty(
+			"cloud.ci.s3.bucket.dist.path", "s3://liferayci-dist/dist");
+		buildProperties.setProperty("git.archive.enabled", "true");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Shell shell = mockShell();
+
+		Mockito.doReturn(
+			new Shell.ExecutionResult(0, "", "")
+		).when(
+			shell
+		).doExecute(
+			Mockito.any(Shell.ExecutionRequest.class)
+		);
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).prepareGitWorkingDirectory();
+
+		portalWorkspaceGitRepository.prepareGitWorkingDirectory();
+
+		Mockito.verify(
+			shell, Mockito.atLeastOnce()
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _isCommand(
+					executionRequest, "git-archives"))
+		);
+
+		Assert.assertFalse(
+			"The binaries cache must stay disabled when the git archive is " +
+				"enabled",
+			portalWorkspaceGitRepository.isBinariesCacheEnabled());
+	}
+
+	@Test
 	public void testSetUp() throws Exception {
-		File workingDirectory = File.createTempFile("portal-workspace-", null);
-
-		workingDirectory.delete();
-
-		workingDirectory.mkdir();
-
-		File gitDirectory = new File(workingDirectory, ".git");
-
-		gitDirectory.mkdir();
-
 		mockEnvironment(
 			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
 
@@ -60,49 +152,8 @@ public class PortalWorkspaceGitRepositoryTest
 			Mockito.any(Shell.ExecutionRequest.class)
 		);
 
-		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
-
-		Mockito.doReturn(
-			"1234567890123456789012345678901234567890"
-		).when(
-			localGitBranch
-		).getSHA();
-
-		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
-			GitWorkingDirectory.class);
-
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			Mockito.mock(PortalWorkspaceGitRepository.class);
-
-		Mockito.doReturn(
-			workingDirectory
-		).when(
-			portalWorkspaceGitRepository
-		).getDirectory();
-
-		Mockito.doReturn(
-			"liferay-portal"
-		).when(
-			portalWorkspaceGitRepository
-		).getDirectoryName();
-
-		Mockito.doReturn(
-			gitWorkingDirectory
-		).when(
-			portalWorkspaceGitRepository
-		).getGitWorkingDirectory();
-
-		Mockito.doReturn(
-			localGitBranch
-		).when(
-			portalWorkspaceGitRepository
-		).getLocalGitBranch();
-
-		Mockito.doReturn(
-			"master"
-		).when(
-			portalWorkspaceGitRepository
-		).getUpstreamBranchName();
+			_newPortalWorkspaceGitRepository();
 
 		Mockito.doReturn(
 			true
@@ -164,6 +215,16 @@ public class PortalWorkspaceGitRepositoryTest
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
 			_newPortalWorkspaceGitRepository();
 
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
 		portalWorkspaceGitRepository.setUpAdditionalCaches();
 
 		Mockito.verify(
@@ -208,6 +269,16 @@ public class PortalWorkspaceGitRepositoryTest
 
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
 			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
 
 		portalWorkspaceGitRepository.setUpAdditionalCaches();
 
@@ -254,6 +325,22 @@ public class PortalWorkspaceGitRepositoryTest
 		return (Boolean)method.invoke(workspaceGitRepository);
 	}
 
+	private GitWorkingDirectory _newGitWorkingDirectory() {
+		return Mockito.mock(GitWorkingDirectory.class);
+	}
+
+	private LocalGitBranch _newLocalGitBranch() {
+		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
+
+		Mockito.doReturn(
+			"1234567890123456789012345678901234567890"
+		).when(
+			localGitBranch
+		).getSHA();
+
+		return localGitBranch;
+	}
+
 	private PortalWorkspaceGitRepository _newPortalWorkspaceGitRepository()
 		throws Exception {
 
@@ -263,8 +350,18 @@ public class PortalWorkspaceGitRepositoryTest
 
 		workingDirectory.mkdir();
 
+		File gitDirectory = new File(workingDirectory, ".git");
+
+		gitDirectory.mkdir();
+
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
 			Mockito.mock(PortalWorkspaceGitRepository.class);
+
+		Mockito.doReturn(
+			"1234567890123456789012345678901234567890"
+		).when(
+			portalWorkspaceGitRepository
+		).getBaseBranchSHA();
 
 		Mockito.doReturn(
 			workingDirectory
@@ -273,20 +370,34 @@ public class PortalWorkspaceGitRepositoryTest
 		).getDirectory();
 
 		Mockito.doReturn(
+			"liferay-portal"
+		).when(
+			portalWorkspaceGitRepository
+		).getDirectoryName();
+
+		Mockito.doReturn(
+			_newGitWorkingDirectory()
+		).when(
+			portalWorkspaceGitRepository
+		).getGitWorkingDirectory();
+
+		Mockito.doReturn(
+			_newLocalGitBranch()
+		).when(
+			portalWorkspaceGitRepository
+		).getLocalGitBranch();
+
+		Mockito.doReturn(
+			"0987654321098765432109876543210987654321"
+		).when(
+			portalWorkspaceGitRepository
+		).getSenderBranchSHA();
+
+		Mockito.doReturn(
 			"master"
 		).when(
 			portalWorkspaceGitRepository
 		).getUpstreamBranchName();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).isBinariesCacheEnabled();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUpAdditionalCaches();
 
 		return portalWorkspaceGitRepository;
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -7,9 +7,12 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.lang.reflect.Method;
+
 import java.util.Collections;
 import java.util.Properties;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.mockito.Mockito;
@@ -142,6 +145,85 @@ public class PortalWorkspaceGitRepositoryTest
 		);
 	}
 
+	@Test
+	public void testSetUpAdditionalCachesWithBinariesCacheDisabled()
+		throws Exception {
+
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("binaries.cache.enabled", "false");
+		buildProperties.setProperty("git.archive.enabled", "true");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Shell shell = mockShell();
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		portalWorkspaceGitRepository.setUpAdditionalCaches();
+
+		Mockito.verify(
+			shell, Mockito.never()
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _isCommand(
+					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
+		);
+
+		Assert.assertTrue(
+			"The git archive must stay enabled when binaries cache is disabled",
+			_isGitArchiveEnabled(portalWorkspaceGitRepository));
+	}
+
+	@Test
+	public void testSetUpAdditionalCachesWithBinariesCacheEnabled()
+		throws Exception {
+
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("binaries.cache.enabled", "true");
+		buildProperties.setProperty(
+			"binaries.cache.s3.path",
+			"s3://liferayci-file-propagator/binaries-cache/master.tar.gz");
+		buildProperties.setProperty("git.archive.enabled", "false");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Shell shell = mockShell();
+
+		Mockito.doReturn(
+			new Shell.ExecutionResult(0, "", "")
+		).when(
+			shell
+		).doExecute(
+			Mockito.any(Shell.ExecutionRequest.class)
+		);
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		portalWorkspaceGitRepository.setUpAdditionalCaches();
+
+		Mockito.verify(
+			shell
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _isCommand(
+					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
+		);
+
+		Assert.assertFalse(
+			"The git archive must stay disabled when binaries cache is enabled",
+			_isGitArchiveEnabled(portalWorkspaceGitRepository));
+	}
+
 	private boolean _isCommand(
 		Shell.ExecutionRequest executionRequest, String... substrings) {
 
@@ -158,6 +240,55 @@ public class PortalWorkspaceGitRepositoryTest
 		}
 
 		return true;
+	}
+
+	private boolean _isGitArchiveEnabled(
+			WorkspaceGitRepository workspaceGitRepository)
+		throws Exception {
+
+		Method method = BaseWorkspaceGitRepository.class.getDeclaredMethod(
+			"_isGitArchiveEnabled");
+
+		method.setAccessible(true);
+
+		return (Boolean)method.invoke(workspaceGitRepository);
+	}
+
+	private PortalWorkspaceGitRepository _newPortalWorkspaceGitRepository()
+		throws Exception {
+
+		File workingDirectory = File.createTempFile("portal-workspace-", null);
+
+		workingDirectory.delete();
+
+		workingDirectory.mkdir();
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			Mockito.mock(PortalWorkspaceGitRepository.class);
+
+		Mockito.doReturn(
+			workingDirectory
+		).when(
+			portalWorkspaceGitRepository
+		).getDirectory();
+
+		Mockito.doReturn(
+			"master"
+		).when(
+			portalWorkspaceGitRepository
+		).getUpstreamBranchName();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
+		return portalWorkspaceGitRepository;
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -286,10 +286,6 @@ public class PortalWorkspaceGitRepositoryTest
 				executionRequest -> hasCommand(
 					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
 		);
-
-		Assert.assertTrue(
-			"The git archive must stay enabled when binaries cache is disabled",
-			_isGitArchiveEnabled(portalWorkspaceGitRepository));
 	}
 
 	@Test
@@ -341,10 +337,6 @@ public class PortalWorkspaceGitRepositoryTest
 				executionRequest -> hasCommand(
 					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
 		);
-
-		Assert.assertFalse(
-			"The git archive must stay disabled when binaries cache is enabled",
-			_isGitArchiveEnabled(portalWorkspaceGitRepository));
 	}
 
 	@Test
@@ -486,18 +478,6 @@ public class PortalWorkspaceGitRepositoryTest
 		method.setAccessible(true);
 
 		return (Properties)method.invoke(portalWorkspaceGitRepository);
-	}
-
-	private boolean _isGitArchiveEnabled(
-			WorkspaceGitRepository workspaceGitRepository)
-		throws Exception {
-
-		Method method = BaseWorkspaceGitRepository.class.getDeclaredMethod(
-			"_isGitArchiveEnabled");
-
-		method.setAccessible(true);
-
-		return (Boolean)method.invoke(workspaceGitRepository);
 	}
 
 	private GitWorkingDirectory _newGitWorkingDirectory() {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -46,7 +46,7 @@ public class PortalWorkspaceGitRepositoryTest
 			"test.released.release.bundle.version", "property.value");
 
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			_newPortalWorkspaceGitRepository();
+			_mockPortalWorkspaceGitRepository();
 
 		Mockito.doReturn(
 			portalTestProperties
@@ -92,7 +92,7 @@ public class PortalWorkspaceGitRepositoryTest
 		mockShell();
 
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			_newPortalWorkspaceGitRepository();
+			_mockPortalWorkspaceGitRepository();
 
 		Mockito.doCallRealMethod(
 		).when(
@@ -151,7 +151,7 @@ public class PortalWorkspaceGitRepositoryTest
 		mockShell();
 
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			_newPortalWorkspaceGitRepository();
+			_mockPortalWorkspaceGitRepository();
 
 		Mockito.doCallRealMethod(
 		).when(
@@ -226,11 +226,11 @@ public class PortalWorkspaceGitRepositoryTest
 		return (Properties)method.invoke(portalWorkspaceGitRepository);
 	}
 
-	private GitWorkingDirectory _newGitWorkingDirectory() {
+	private GitWorkingDirectory _mockGitWorkingDirectory() {
 		return Mockito.mock(GitWorkingDirectory.class);
 	}
 
-	private LocalGitBranch _newLocalGitBranch() {
+	private LocalGitBranch _mockLocalGitBranch() {
 		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
 
 		Mockito.doReturn(
@@ -242,7 +242,7 @@ public class PortalWorkspaceGitRepositoryTest
 		return localGitBranch;
 	}
 
-	private PortalWorkspaceGitRepository _newPortalWorkspaceGitRepository()
+	private PortalWorkspaceGitRepository _mockPortalWorkspaceGitRepository()
 		throws Exception {
 
 		File workingDirectory = File.createTempFile("portal-workspace-", null);
@@ -277,13 +277,13 @@ public class PortalWorkspaceGitRepositoryTest
 		).getDirectoryName();
 
 		Mockito.doReturn(
-			_newGitWorkingDirectory()
+			_mockGitWorkingDirectory()
 		).when(
 			portalWorkspaceGitRepository
 		).getGitWorkingDirectory();
 
 		Mockito.doReturn(
-			_newLocalGitBranch()
+			_mockLocalGitBranch()
 		).when(
 			portalWorkspaceGitRepository
 		).getLocalGitBranch();
@@ -333,7 +333,7 @@ public class PortalWorkspaceGitRepositoryTest
 		}
 
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			_newPortalWorkspaceGitRepository();
+			_mockPortalWorkspaceGitRepository();
 
 		Mockito.doCallRealMethod(
 		).when(
@@ -397,7 +397,7 @@ public class PortalWorkspaceGitRepositoryTest
 		}
 
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			_newPortalWorkspaceGitRepository();
+			_mockPortalWorkspaceGitRepository();
 
 		Mockito.doCallRealMethod(
 		).when(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -5,9 +5,12 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.io.File;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.mockito.InOrder;
@@ -18,6 +21,31 @@ import org.mockito.Mockito;
  */
 public class WorkspaceGitRepositoryTest
 	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testIsFullDotGitDirArchiveRequiredOnlyForEE62X()
+		throws Exception {
+
+		Assert.assertTrue(
+			"A full .git dir archive is required for ee-6.2.x working dirs",
+			_isFullDotGitDirArchiveRequired(
+				_newWorkspaceGitRepository("liferay-plugins-ee-6.2.x")));
+
+		Assert.assertTrue(
+			"A full .git dir archive is required for ee-6.2.x working dirs",
+			_isFullDotGitDirArchiveRequired(
+				_newWorkspaceGitRepository("liferay-portal-ee-6.2.x")));
+
+		Assert.assertFalse(
+			"A full .git dir archive is not required for master working dirs",
+			_isFullDotGitDirArchiveRequired(
+				_newWorkspaceGitRepository("liferay-portal")));
+
+		Assert.assertFalse(
+			"A full .git dir archive is not required for 7.0.x working dirs",
+			_isFullDotGitDirArchiveRequired(
+				_newWorkspaceGitRepository("liferay-portal-7.0.x")));
+	}
 
 	@Test
 	public void testValidateSHAInRemoteGitRefFetchesBeforeContainsCheck()
@@ -68,6 +96,42 @@ public class WorkspaceGitRepositoryTest
 		).refContainsSHA(
 			localGitBranch, sha
 		);
+	}
+
+	private boolean _isFullDotGitDirArchiveRequired(
+			WorkspaceGitRepository workspaceGitRepository)
+		throws Exception {
+
+		Method method = BaseWorkspaceGitRepository.class.getDeclaredMethod(
+			"_isFullDotGitDirArchiveRequired");
+
+		method.setAccessible(true);
+
+		return (Boolean)method.invoke(workspaceGitRepository);
+	}
+
+	private WorkspaceGitRepository _newWorkspaceGitRepository(
+		String workingDirectoryName) {
+
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		Mockito.when(
+			gitWorkingDirectory.getWorkingDirectory()
+		).thenReturn(
+			new File(workingDirectoryName)
+		);
+
+		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
+			Mockito.mock(DefaultWorkspaceGitRepository.class);
+
+		Mockito.when(
+			defaultWorkspaceGitRepository.getGitWorkingDirectory()
+		).thenReturn(
+			gitWorkingDirectory
+		);
+
+		return defaultWorkspaceGitRepository;
 	}
 
 	private void _validateSHAInRemoteGitRef(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class WorkspaceGitRepositoryTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testValidateSHAInRemoteGitRefFetchesBeforeContainsCheck()
+		throws Exception {
+
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
+		RemoteGitRef remoteGitRef = Mockito.mock(RemoteGitRef.class);
+
+		String sha = "0123456789012345678901234567890123456789";
+
+		Mockito.when(
+			gitWorkingDirectory.fetch(remoteGitRef)
+		).thenReturn(
+			localGitBranch
+		);
+
+		Mockito.when(
+			gitWorkingDirectory.refContainsSHA(localGitBranch, sha)
+		).thenReturn(
+			true
+		);
+
+		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
+			Mockito.mock(DefaultWorkspaceGitRepository.class);
+
+		Mockito.when(
+			defaultWorkspaceGitRepository.getGitWorkingDirectory()
+		).thenReturn(
+			gitWorkingDirectory
+		);
+
+		_validateSHAInRemoteGitRef(
+			defaultWorkspaceGitRepository, "master", remoteGitRef, sha);
+
+		InOrder inOrder = Mockito.inOrder(gitWorkingDirectory);
+
+		inOrder.verify(
+			gitWorkingDirectory
+		).fetch(
+			remoteGitRef
+		);
+
+		inOrder.verify(
+			gitWorkingDirectory
+		).refContainsSHA(
+			localGitBranch, sha
+		);
+	}
+
+	private void _validateSHAInRemoteGitRef(
+			WorkspaceGitRepository workspaceGitRepository, String branchName,
+			RemoteGitRef remoteGitRef, String sha)
+		throws Exception {
+
+		Method method = BaseWorkspaceGitRepository.class.getDeclaredMethod(
+			"_validateSHAInRemoteGitRef", String.class, RemoteGitRef.class,
+			String.class);
+
+		method.setAccessible(true);
+
+		try {
+			method.invoke(
+				workspaceGitRepository, branchName, remoteGitRef, sha);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			Throwable throwable = invocationTargetException.getCause();
+
+			if (throwable instanceof RuntimeException) {
+				throw (RuntimeException)throwable;
+			}
+
+			throw invocationTargetException;
+		}
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -29,28 +29,26 @@ public class WorkspaceGitRepositoryTest
 		Assert.assertTrue(
 			"A full .git dir archive is required for ee-6.2.x working dirs",
 			_isFullDotGitDirArchiveRequired(
-				_newWorkspaceGitRepository("liferay-plugins-ee-6.2.x")));
+				_mockWorkspaceGitRepository("liferay-plugins-ee-6.2.x")));
 
 		Assert.assertTrue(
 			"A full .git dir archive is required for ee-6.2.x working dirs",
 			_isFullDotGitDirArchiveRequired(
-				_newWorkspaceGitRepository("liferay-portal-ee-6.2.x")));
+				_mockWorkspaceGitRepository("liferay-portal-ee-6.2.x")));
 
 		Assert.assertFalse(
 			"A full .git dir archive is not required for master working dirs",
 			_isFullDotGitDirArchiveRequired(
-				_newWorkspaceGitRepository("liferay-portal")));
+				_mockWorkspaceGitRepository("liferay-portal")));
 
 		Assert.assertFalse(
 			"A full .git dir archive is not required for 7.0.x working dirs",
 			_isFullDotGitDirArchiveRequired(
-				_newWorkspaceGitRepository("liferay-portal-7.0.x")));
+				_mockWorkspaceGitRepository("liferay-portal-7.0.x")));
 	}
 
 	@Test
-	public void testValidateSHAInRemoteGitRefFetchesBeforeContainsCheck()
-		throws Exception {
-
+	public void testValidateSHAInRemoteGitRef() throws Exception {
 		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
 			GitWorkingDirectory.class);
 
@@ -110,7 +108,7 @@ public class WorkspaceGitRepositoryTest
 		return (Boolean)method.invoke(workspaceGitRepository);
 	}
 
-	private WorkspaceGitRepository _newWorkspaceGitRepository(
+	private WorkspaceGitRepository _mockWorkspaceGitRepository(
 		String workingDirectoryName) {
 
 		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7783

Supersedes https://github.com/pyoo47/liferay-portal/pull/4421, originally authored by @michaelhashimoto. His commits are preserved here with test-quality refactors on top.

## Why

`PortalWorkspaceGitRepositoryTest` on master covered only `testSetUp`. This PR expands the workspace Git repository setup coverage and reworks the tests for shape. Each behavior is validated red-before-green by mutating the invariant, confirming the test fails, restoring, and confirming it passes.

## Behaviors covered

- **Bundle version read from the environment** (LRCI-7015) — `PortalWorkspaceGitRepositoryTest.testGetPortalTestPropertiesReadsBundleVersionFromEnvironment`.
  Asserts the released bundle version is read from the `PORTAL_LATEST_BUNDLE_VERSION` environment variable and the bundle zip URL resolves from the `portal.bundle.tomcat` property keyed by that version.
- **Git archive runs only on the archive path** (LRCI-7447) — `PortalWorkspaceGitRepositoryTest.testPrepareGitWorkingDirectory`.
  Asserts the git archive path runs only when `git.archive.enabled` is true. Both the enabled and disabled cases run through one parameterized helper.
- **Binaries cache restore runs only on the cache path** (LRCI-7076) — `PortalWorkspaceGitRepositoryTest.testSetUpAdditionalCaches`.
  Asserts the binaries cache download and extract run only when `binaries.cache.enabled` is true. Both cases run through one parameterized helper. The removed `testSetUp` asserted the download and extract during a full `setUp`, and both assertions are folded in here.
- **setUp step order and single run** (LRCI-7447) — `PortalWorkspaceGitRepositoryTest.testSetUpRunsOnce` and `testSetUpFailure`.
  `testSetUpRunsOnce` asserts the step order of prepare, then additional caches, then store, and that a repeated call does not rerun. `testSetUpFailure` asserts a mid sequence failure rethrows as a RuntimeException and leaves the repository not marked set up.
- **SHA fetched before the containment check** (LRCI-7487) — `WorkspaceGitRepositoryTest.testValidateSHAInRemoteGitRef`.
  Asserts the ref is fetched before the contains check.
- **Full .git archive only for ee-6.2.x** (LRCI-7070) — `WorkspaceGitRepositoryTest.testIsFullDotGitDirArchiveRequiredOnlyForEE62X`.
  Asserts a full `.git` directory archive is required only for ee-6.2.x working directories.

## Structural changes

Command matching goes through the `hasCommand` helper on the base `Test` class rather than a local matcher. The mock factory helpers are named `_mock*`. Private methods with no public seam are exercised through reflection.

## Validation

Full jenkins-results-parser unit suite passes and formatSource is clean.
