### PR TITLE
LRCI-7868 Load Chart.js 4.x in the report HTML

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/index.html
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/index.html
@@ -61,7 +61,9 @@
 				<div>
 					<h4>Categorized CI Builds over time</h4>
 
-					<canvas height="800" id="build-history-canvas"></canvas>
+					<div class="chart-container">
+						<canvas id="build-history-canvas"></canvas>
+					</div>
 				</div>
 
 				<div>
@@ -84,36 +86,37 @@
 			<button class="accordion"><h3>Average Build Duration</h3></button>
 
 			<div class="panel">
-				<div>
-					<canvas height="800" id="build-duration-canvas"></canvas>
+				<div class="chart-container">
+					<canvas id="build-duration-canvas"></canvas>
 				</div>
 			</div>
 
 			<button class="accordion"><h3>Average Queue Duration</h3></button>
 
 			<div class="panel">
-				<div>
-					<canvas height="800" id="queue-duration-canvas"></canvas>
+				<div class="chart-container">
+					<canvas id="queue-duration-canvas"></canvas>
 				</div>
 			</div>
 		</div>
 
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
 
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-adapter-moment/1.0.1/chartjs-adapter-moment.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.5.0/chart.umd.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/js/sortable.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
 
-		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@1a5c67264e8db6aae2e38967a20c3f3a31416d27/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js"></script>
+		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js"></script>
 
 		<script src="js/table-data.js"></script>
 		<script src="js/timeline-data.js"></script>
 
-		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@1a5c67264e8db6aae2e38967a20c3f3a31416d27/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/js/main.js"></script>
+		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/js/main.js"></script>
 
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/css/sortable-theme-bootstrap.min.css" rel="stylesheet" />
-		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@cbdaa1da84693a1850cfdf792d92fadbdc4f01d5/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/css/report.css" rel="stylesheet" />
-		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@cbdaa1da84693a1850cfdf792d92fadbdc4f01d5/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/css/main.css" rel="stylesheet" />
+		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/css/report.css" rel="stylesheet" />
+		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/css/main.css" rel="stylesheet" />
 	</body>
 </html>

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/build-comparison-report/index.html
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/build-comparison-report/index.html
@@ -27,14 +27,13 @@
 		<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" rel="stylesheet" />
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
 
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/js/sortable.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
 
-		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@1a5c67264e8db6aae2e38967a20c3f3a31416d27/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js"></script>
+		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js"></script>
 
-		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@cbdaa1da84693a1850cfdf792d92fadbdc4f01d5/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/css/report.css" rel="stylesheet" />
+		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/css/report.css" rel="stylesheet" />
 
 		<script src="js/table-data.js"></script>
 

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/test-suite-report/index.html
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/test-suite-report/index.html
@@ -15,7 +15,9 @@
 		<div>
 			<h4>Server Duration of Test Suites</h4>
 
-			<canvas height="600" id="server-duration-canvas"></canvas>
+			<div class="chart-container">
+				<canvas id="server-duration-canvas"></canvas>
+			</div>
 
 			<br />
 		</div>
@@ -35,19 +37,19 @@
 		<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" rel="stylesheet" />
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
 
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.5.0/chart.umd.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/js/sortable.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
 
-		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@4f72bfada7529c4b05d4441dd47953d199dabbe8/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js"></script>
+		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js"></script>
 
-		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@4f72bfada7529c4b05d4441dd47953d199dabbe8/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/css/report.css" rel="stylesheet" />
+		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/css/report.css" rel="stylesheet" />
 
 		<script src="js/table-data.js"></script>
 
-		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@4f72bfada7529c4b05d4441dd47953d199dabbe8/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/test-suite-report/css/main.css" rel="stylesheet" />
+		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/test-suite-report/css/main.css" rel="stylesheet" />
 
-		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@4f72bfada7529c4b05d4441dd47953d199dabbe8/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/test-suite-report/js/main.js"></script>
+		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/test-suite-report/js/main.js"></script>
 	</body>
 </html>

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/utilization-report/index.html
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/utilization-report/index.html
@@ -15,7 +15,9 @@
 		<div>
 			<h4>Utilization Percentage of CI Nodes</h4>
 
-			<canvas height="600" id="utilization-canvas"></canvas>
+			<div class="chart-container">
+				<canvas id="utilization-canvas"></canvas>
+			</div>
 
 			<br />
 		</div>
@@ -53,19 +55,19 @@
 		<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" rel="stylesheet" />
 		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
 
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.5.0/chart.umd.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/js/sortable.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
 
-		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@eb6c4a40f5420f224aaf72a9923dd293984b272a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js"></script>
+		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js"></script>
 
-		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@eb6c4a40f5420f224aaf72a9923dd293984b272a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/css/report.css" rel="stylesheet" />
+		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/css/report.css" rel="stylesheet" />
 
 		<script src="js/table-data.js"></script>
 
 		<link href="css/main.css" rel="stylesheet" />
 
-		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@eb6c4a40f5420f224aaf72a9923dd293984b272a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/utilization-report/js/main.js"></script>
+		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/utilization-report/js/main.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7868

## What Is Being Fixed

The Chart.js 4.x chart configs merged in a first step, but the report HTML still loads Chart.js 2.x from the CDN and pins its js and css at the pre-migration revisions, so the reports run the new configs against the old library. The build comparison report also carries a Chart.js script tag it never uses.

## How It Is Being Fixed

This is the second of the two steps for these files. Each report page now loads Chart.js 4.5.0 and the date-fns adapter in place of Chart.js 2.x and the moment adapter, the build history report gains timeago.js for its generated-date line, and every canvas is wrapped in the chart-container introduced by the first step. The unused Chart.js tag is dropped from the build comparison report. Every pinned jsdelivr revision now points at the merge commit of the first step (5efc335), so the four reports load one revision instead of the three they were split across. All five report pages were rendered headless against the live jsdelivr URLs at that revision with the production data synced from test-1-0, with zero console errors and matching tooltip, legend, accordion, search, and sort behavior.

## Why Are There No Tests?

The changes are report HTML with no test harness in the module; verification was rendering all five reports headless against the live CDN revision and production data, exercising the chart tooltips, accordion, table search, and column sorting with zero console errors.

## PR Check

**pr-check: PASS** — tested on `758120e92f074dbbdb845964f71e3dc513fe1321`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "758120e92f074dbbdb845964f71e3dc513fe1321"} -->
