### PR TITLE
LRCI-7912 Add unit tests for load balancer master selection

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.File;
+
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Calum Ragan
+ */
+public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		Environment.setInstance(Mockito.mock(Environment.class));
+
+		setDeclaredFieldValue(
+			JenkinsResultsParserUtil.class, null, "_ciNode", null);
+
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			"{\"mode\": \"NORMAL\"}", "http://test-9-1/api/json?tree=mode",
+			urlReader);
+		setUrlReaderOutput(
+			read(new File(dependenciesDirs.get(0), "computer-api.json")),
+			"http://test-9-1/computer/api/json", urlReader);
+		setUrlReaderOutput(
+			"{\"items\": []}", "http://test-9-1/queue/api/json", urlReader);
+
+		_jenkinsMaster = JenkinsMasterTestUtil.stageMaster(
+			"test-9-1", "http://test-9-1");
+	}
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMaster.maxRecentBatchAge = 120 * 1000;
+
+		JenkinsMasterTestUtil.resetCaches();
+
+		JenkinsResultsParserUtil.setBuildProperties(
+			(Hashtable<Object, Object>)null);
+	}
+
+	@Test
+	public void testGetRecentBatchSizesTotalPrunesExpiredEntries() {
+		int availableSlavesCount = _jenkinsMaster.getAvailableSlavesCount(null);
+
+		JenkinsMaster.maxRecentBatchAge = -1;
+
+		_jenkinsMaster.addRecentBatch(7, "label-a");
+
+		Map<String, Map<Long, Integer>> labelBatchSizes =
+			JenkinsMasterTestUtil.getLabelBatchSizes(_jenkinsMaster);
+
+		Map<Long, Integer> batchSizes = labelBatchSizes.get("label-a");
+
+		Assert.assertEquals(batchSizes.toString(), 1, batchSizes.size());
+
+		_jenkinsMaster.getAvailableSlavesCount("label-b");
+
+		Assert.assertTrue(batchSizes.isEmpty());
+
+		Assert.assertEquals(
+			availableSlavesCount, _jenkinsMaster.getAvailableSlavesCount(null));
+	}
+
+	@Test
+	public void testUpdatePreservesRecentBatchDebit() {
+		_jenkinsMaster.update();
+
+		int availableSlavesCount = _jenkinsMaster.getAvailableSlavesCount(null);
+
+		_jenkinsMaster.addRecentBatch(5, null);
+
+		Assert.assertEquals(
+			availableSlavesCount - 5,
+			_jenkinsMaster.getAvailableSlavesCount(null));
+
+		setDeclaredFieldValue(
+			JenkinsMaster.class, _jenkinsMaster, "_updateTimestamp", -1L);
+
+		_jenkinsMaster.update();
+
+		Assert.assertEquals(
+			availableSlavesCount - 5,
+			_jenkinsMaster.getAvailableSlavesCount(null));
+
+		Map<String, Map<Long, Integer>> labelBatchSizes =
+			JenkinsMasterTestUtil.getLabelBatchSizes(_jenkinsMaster);
+
+		Assert.assertFalse(labelBatchSizes.isEmpty());
+	}
+
+	private JenkinsMaster _jenkinsMaster;
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @author Calum Ragan
+ */
+public class JenkinsMasterTestUtil {
+
+	public static Map<String, Map<Long, Integer>> getLabelBatchSizes(
+		JenkinsMaster jenkinsMaster) {
+
+		return (Map<String, Map<Long, Integer>>)Test.getDeclaredFieldValue(
+			JenkinsMaster.class, jenkinsMaster, "_labelBatchSizes");
+	}
+
+	public static void resetCaches() {
+		Map<String, ?> jenkinsMastersMap =
+			(Map<String, ?>)Test.getDeclaredFieldValue(
+				LoadBalancerUtil.class, null, "_jenkinsMastersMap");
+
+		jenkinsMastersMap.clear();
+
+		Map<String, ?> roundRobinCounters =
+			(Map<String, ?>)Test.getDeclaredFieldValue(
+				LoadBalancerUtil.class, null, "_roundRobinCounters");
+
+		roundRobinCounters.clear();
+
+		Map<String, ?> jenkinsMasters =
+			(Map<String, ?>)Test.getDeclaredFieldValue(
+				JenkinsMaster.class, null, "_jenkinsMasters");
+
+		jenkinsMasters.clear();
+
+		List<String> jenkinsMastersBlacklist =
+			(List<String>)Test.getDeclaredFieldValue(
+				JenkinsMaster.class, null, "_jenkinsMastersBlacklist");
+
+		jenkinsMastersBlacklist.clear();
+	}
+
+	public static Properties stageFleet(String cohortName, int masterCount) {
+		Hashtable<Object, Object> buildProperties = new Hashtable<>();
+
+		buildProperties.put(
+			"base.invocation.url", "http://" + cohortName + ".liferay.com");
+
+		for (int i = 1; i <= masterCount; i++) {
+			String masterName = cohortName + "-" + i;
+
+			buildProperties.put(
+				"jenkins.local.url[" + masterName + "]",
+				"http://" + masterName);
+			buildProperties.put(
+				"jenkins.remote.url[" + masterName + "]",
+				"http://" + masterName + ".liferay.com");
+			buildProperties.put(
+				"master.property(" + masterName + "/executors.size)", "8");
+		}
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		resetCaches();
+
+		Properties properties = new Properties();
+
+		properties.putAll(buildProperties);
+
+		return properties;
+	}
+
+	public static JenkinsMaster stageMaster(
+		String masterName, String masterURL) {
+
+		Hashtable<Object, Object> buildProperties = new Hashtable<>();
+
+		buildProperties.put("jenkins.local.url[" + masterName + "]", masterURL);
+		buildProperties.put(
+			"jenkins.remote.url[" + masterName + "]",
+			"http://" + masterName + ".liferay.com");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		resetCaches();
+
+		JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(masterName);
+
+		Test.setDeclaredFieldValue(
+			JenkinsMaster.class, jenkinsMaster, "_awsFleetClouds",
+			new ArrayList<>());
+		Test.setDeclaredFieldValue(
+			JenkinsMaster.class, jenkinsMaster,
+			"_awsFleetCloudLastUpdateTimestamp",
+			JenkinsResultsParserUtil.getCurrentTimeMillis());
+
+		return jenkinsMaster;
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -16,7 +16,6 @@ import java.util.Properties;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -28,11 +27,6 @@ import org.mockito.Mockito;
  */
 public class JenkinsResultsParserUtilTest
 	extends com.liferay.jenkins.results.parser.Test {
-
-	@After
-	public void tearDown() {
-		Environment.setInstance(new Environment());
-	}
 
 	@Test(timeout = 30000)
 	public void testExecuteJenkinsScriptReadTimeout() throws Exception {
@@ -512,6 +506,14 @@ public class JenkinsResultsParserUtilTest
 	}
 
 	@Test
+	public void testIsCINode() {
+		_assertIsCINode("https://test-1-1.liferay.com/", null, true);
+		_assertIsCINode(null, "test-network", true);
+		_assertIsCINode("https://test-1-1.liferay.com/", "test-network", true);
+		_assertIsCINode(null, null, false);
+	}
+
+	@Test
 	public void testIsJSONArrayEqual() {
 		JSONArray expectedJSONArray = new JSONArray();
 
@@ -659,6 +661,33 @@ public class JenkinsResultsParserUtilTest
 		Environment.setInstance(environment);
 
 		return environment;
+	}
+
+	private void _assertIsCINode(
+		String jenkinsURL, String masterNetworkName, boolean expected) {
+
+		Environment environment = mockEnvironment();
+
+		Mockito.when(
+			environment.doGet("JENKINS_URL")
+		).thenReturn(
+			jenkinsURL
+		);
+
+		Mockito.when(
+			environment.doGet("MASTER_NETWORK_NAME")
+		).thenReturn(
+			masterNetworkName
+		);
+
+		setDeclaredFieldValue(
+			JenkinsResultsParserUtil.class, null, "_ciNode", null);
+
+		Assert.assertEquals(
+			JenkinsResultsParserUtil.combine(
+				"Unexpected isCINode() value for JENKINS_URL=", jenkinsURL,
+				" and MASTER_NETWORK_NAME=", masterNetworkName),
+			expected, JenkinsResultsParserUtil.isCINode());
 	}
 
 	private ServerSocket _createServerSocket() throws Exception {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Calum Ragan
+ */
+public class LoadBalancerUtilTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
+
+		JenkinsResultsParserUtil.setBuildProperties(
+			(Hashtable<Object, Object>)null);
+	}
+
+	@Test
+	public void testGetAvailableJenkinsMastersExcludesBlacklistedMasters() {
+		Properties properties = JenkinsMasterTestUtil.stageFleet("test-9", 5);
+
+		List<String> masterNames = _getMasterNames(
+			LoadBalancerUtil.getAvailableJenkinsMasters(
+				"TEST-9-2", "test-9", properties, false));
+
+		Assert.assertEquals(masterNames.toString(), 4, masterNames.size());
+
+		Assert.assertFalse(masterNames.contains("test-9-2"));
+
+		properties.setProperty(
+			"jenkins.load.balancer.blacklist", "test-9-3, test-9-4");
+
+		masterNames = _getMasterNames(
+			LoadBalancerUtil.getAvailableJenkinsMasters(
+				null, "test-9", properties, false));
+
+		Assert.assertEquals(masterNames.toString(), 3, masterNames.size());
+
+		Assert.assertFalse(masterNames.contains("test-9-3"));
+		Assert.assertFalse(masterNames.contains("test-9-4"));
+	}
+
+	@Test
+	public void testGetMostAvailableMasterURLRoundRobin() {
+		Properties properties = JenkinsMasterTestUtil.stageFleet("test-9", 5);
+
+		properties.setProperty("blacklist", "test-9-5");
+
+		Map<String, Integer> selectionCounts = new HashMap<>();
+
+		for (int i = 0; i < 12; i++) {
+			String masterURL = LoadBalancerUtil.getMostAvailableMasterURL(
+				properties, false);
+
+			Integer selectionCount = selectionCounts.get(masterURL);
+
+			if (selectionCount == null) {
+				selectionCount = 0;
+			}
+
+			selectionCounts.put(masterURL, selectionCount + 1);
+		}
+
+		Assert.assertEquals(
+			selectionCounts.toString(), 4, selectionCounts.size());
+
+		for (int i = 1; i <= 4; i++) {
+			String masterURL = "http://test-9-" + i;
+
+			Assert.assertEquals(
+				masterURL, Integer.valueOf(3), selectionCounts.get(masterURL));
+		}
+
+		Assert.assertNull(selectionCounts.get("http://test-9-5"));
+	}
+
+	private List<String> _getMasterNames(List<JenkinsMaster> jenkinsMasters) {
+		List<String> masterNames = new ArrayList<>();
+
+		for (JenkinsMaster jenkinsMaster : jenkinsMasters) {
+			masterNames.add(jenkinsMaster.getName());
+		}
+
+		return masterNames;
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -9,6 +9,8 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 
+import java.lang.reflect.Field;
+
 import java.net.URI;
 
 import java.nio.file.Files;
@@ -47,10 +49,28 @@ public class Test {
 		Shell.setInstance(new Shell());
 
 		UrlReader.setInstance(new UrlReader());
+
+		setDeclaredFieldValue(
+			JenkinsResultsParserUtil.class, null, "_ciNode", null);
 	}
 
 	@Rule
 	public ErrorCollector errorCollector = new ErrorCollector();
+
+	protected static Object getDeclaredFieldValue(
+		Class<?> clazz, Object object, String fieldName) {
+
+		try {
+			Field field = clazz.getDeclaredField(fieldName);
+
+			field.setAccessible(true);
+
+			return field.get(object);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new RuntimeException(reflectiveOperationException);
+		}
+	}
 
 	protected static List<File> getDependenciesDirs(
 		List<String> simpleClassNames) {
@@ -63,6 +83,21 @@ public class Test {
 		}
 
 		return dirs;
+	}
+
+	protected static void setDeclaredFieldValue(
+		Class<?> clazz, Object object, String fieldName, Object value) {
+
+		try {
+			Field field = clazz.getDeclaredField(fieldName);
+
+			field.setAccessible(true);
+
+			field.set(object, value);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new RuntimeException(reflectiveOperationException);
+		}
 	}
 
 	protected String getMismatchMessage(

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/JenkinsMasterTest/computer-api.json
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/JenkinsMasterTest/computer-api.json
@@ -1,0 +1,35 @@
+{
+	"_class": "hudson.model.ComputerSet",
+	"computer": [
+		{
+			"_class": "hudson.model.Hudson$MasterComputer",
+			"assignedLabels": [
+				{
+					"name": "built-in"
+				}
+			],
+			"displayName": "Built-In Node",
+			"executors": [
+			],
+			"idle": true,
+			"offline": false,
+			"offlineCauseReason": ""
+		},
+		{
+			"_class": "hudson.slaves.SlaveComputer",
+			"assignedLabels": [
+				{
+					"name": "test-9-1-1"
+				}
+			],
+			"displayName": "test-9-1-1",
+			"executors": [
+				{
+				}
+			],
+			"idle": true,
+			"offline": false,
+			"offlineCauseReason": ""
+		}
+	]
+}


### PR DESCRIPTION
Part of LRCI-7527 (Phase 2 of LRCI-7522): high-value unit tests for `jenkins-results-parser`, each guarding a real regression that reached CI. Test-only — no production code changes.

## Tests

| Test | Guards | Regression |
| --- | --- | --- |
| `JenkinsResultsParserUtilTest.testIsCINode` | a network-name-only master must still read as a CI node | LRCI-7022 (`aaed3b7b`) |
| `LoadBalancerUtilTest` blacklist | blacklisted masters excluded in both request-string and property forms | LRCI-7022 |
| `LoadBalancerUtilTest` round-robin | selection cycles evenly across eligible masters regardless of the random counter offset; blacklisted never selected | LRCI-7532 / LRCI-7432 |
| `JenkinsMasterTest.testUpdatePreservesRecentBatchDebit` | `update()` must not wipe the recent-batch debit | LRCI-7432 (`fc3def6e`) |
| `JenkinsMasterTest.testGetRecentBatchSizesTotalPrunesExpiredEntries` | expired entries pruned even under a non-matching label | LRCI-7202 (`2270e6cd`) |

Each was validated red→green by reverting its fix commit locally.

## Notes

- `JenkinsMasterTestUtil` stages masters purely from in-memory build properties and resets the sticky static caches in `LoadBalancerUtil`/`JenkinsMaster` between tests.
- The `update()`/pruning tests drive `JenkinsMaster` offline through the base-class `UrlReader` mock, fed local fixtures.
- No time seam: the pruning test uses the existing `protected maxRecentBatchAge`, and the debit test resets `_updateTimestamp` via reflection to force the second `update()`.
