### PR TITLE
LRCI-7912 Add unit tests for load balancer master selection

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.File;
+
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Calum Ragan
+ */
+public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		Environment.setInstance(Mockito.mock(Environment.class));
+
+		setDeclaredFieldValue(
+			JenkinsResultsParserUtil.class, null, "_ciNode", null);
+
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			"{\"mode\": \"NORMAL\"}", "http://test-9-1/api/json?tree=mode",
+			urlReader);
+		setUrlReaderOutput(
+			read(new File(dependenciesDirs.get(0), "computer-api.json")),
+			"http://test-9-1/computer/api/json", urlReader);
+		setUrlReaderOutput(
+			"{\"items\": []}", "http://test-9-1/queue/api/json", urlReader);
+
+		_jenkinsMaster = JenkinsMasterTestUtil.stageMaster(
+			"test-9-1", "http://test-9-1");
+	}
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMaster.maxRecentBatchAge = 120 * 1000;
+
+		JenkinsMasterTestUtil.resetCaches();
+
+		JenkinsResultsParserUtil.setBuildProperties(
+			(Hashtable<Object, Object>)null);
+	}
+
+	@Test
+	public void testGetRecentBatchSizesTotalPrunesExpiredEntries() {
+		int availableSlavesCount = _jenkinsMaster.getAvailableSlavesCount(null);
+
+		JenkinsMaster.maxRecentBatchAge = -1;
+
+		_jenkinsMaster.addRecentBatch(7, "label-a");
+
+		Map<String, Map<Long, Integer>> labelBatchSizes =
+			JenkinsMasterTestUtil.getLabelBatchSizes(_jenkinsMaster);
+
+		Map<Long, Integer> batchSizes = labelBatchSizes.get("label-a");
+
+		Assert.assertEquals(batchSizes.toString(), 1, batchSizes.size());
+
+		_jenkinsMaster.getAvailableSlavesCount("label-b");
+
+		Assert.assertTrue(batchSizes.isEmpty());
+
+		Assert.assertEquals(
+			availableSlavesCount, _jenkinsMaster.getAvailableSlavesCount(null));
+	}
+
+	@Test
+	public void testUpdatePreservesRecentBatchDebit() {
+		_jenkinsMaster.update();
+
+		int availableSlavesCount = _jenkinsMaster.getAvailableSlavesCount(null);
+
+		_jenkinsMaster.addRecentBatch(5, null);
+
+		Assert.assertEquals(
+			availableSlavesCount - 5,
+			_jenkinsMaster.getAvailableSlavesCount(null));
+
+		setDeclaredFieldValue(
+			JenkinsMaster.class, _jenkinsMaster, "_updateTimestamp", -1L);
+
+		_jenkinsMaster.update();
+
+		Assert.assertEquals(
+			availableSlavesCount - 5,
+			_jenkinsMaster.getAvailableSlavesCount(null));
+
+		Map<String, Map<Long, Integer>> labelBatchSizes =
+			JenkinsMasterTestUtil.getLabelBatchSizes(_jenkinsMaster);
+
+		Assert.assertFalse(labelBatchSizes.isEmpty());
+	}
+
+	private JenkinsMaster _jenkinsMaster;
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -63,16 +63,20 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		JenkinsMaster.maxRecentBatchAge = -1;
 
-		_jenkinsMaster.addRecentBatch(7, "label-a");
+		String label = RandomTestUtil.randomString();
+
+		_jenkinsMaster.addRecentBatch(7, label);
 
 		Map<String, Map<Long, Integer>> labelBatchSizes =
 			JenkinsMasterTestUtil.getLabelBatchSizes(_jenkinsMaster);
 
-		Map<Long, Integer> batchSizes = labelBatchSizes.get("label-a");
+		Map<Long, Integer> batchSizes = labelBatchSizes.get(label);
 
 		Assert.assertEquals(batchSizes.toString(), 1, batchSizes.size());
 
-		_jenkinsMaster.getAvailableSlavesCount("label-b");
+		String otherLabel = RandomTestUtil.randomString();
+
+		_jenkinsMaster.getAvailableSlavesCount(otherLabel);
 
 		Assert.assertTrue(batchSizes.isEmpty());
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -7,8 +7,8 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
-import java.util.Hashtable;
 import java.util.Map;
+import java.util.Properties;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -63,8 +63,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		JenkinsMasterTestUtil.resetCaches();
 
-		JenkinsResultsParserUtil.setBuildProperties(
-			(Hashtable<Object, Object>)null);
+		JenkinsResultsParserUtil.setBuildProperties(new Properties());
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -29,9 +29,6 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		Environment.setInstance(Mockito.mock(Environment.class));
 
-		setDeclaredFieldValue(
-			JenkinsResultsParserUtil.class, null, "_ciNode", null);
-
 		UrlReader urlReader = mockUrlReader();
 
 		setUrlReaderOutput(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -96,8 +96,8 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 			availableSlavesCount - 5,
 			_jenkinsMaster.getAvailableSlavesCount(null));
 
-		setDeclaredFieldValue(
-			JenkinsMaster.class, _jenkinsMaster, "_updateTimestamp", -1L);
+		ReflectionTestUtil.setFieldValue(
+			_jenkinsMaster, "_updateTimestamp", -1L);
 
 		_jenkinsMaster.update();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -10,6 +10,9 @@ import java.io.File;
 import java.util.Hashtable;
 import java.util.Map;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -32,13 +35,20 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		UrlReader urlReader = mockUrlReader();
 
 		setUrlReaderOutput(
-			"{\"mode\": \"NORMAL\"}", "http://test-9-1/api/json?tree=mode",
-			urlReader);
+			new JSONObject(
+			).put(
+				"items", new JSONArray()
+			).toString(),
+			"http://test-9-1/queue/api/json", urlReader);
+		setUrlReaderOutput(
+			new JSONObject(
+			).put(
+				"mode", "NORMAL"
+			).toString(),
+			"http://test-9-1/api/json?tree=mode", urlReader);
 		setUrlReaderOutput(
 			read(new File(dependenciesDirs.get(0), "computer-api.json")),
 			"http://test-9-1/computer/api/json", urlReader);
-		setUrlReaderOutput(
-			"{\"items\": []}", "http://test-9-1/queue/api/json", urlReader);
 
 		_jenkinsMaster = JenkinsMasterTestUtil.stageMaster(
 			"test-9-1", "http://test-9-1");

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -58,7 +58,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	@Test
-	public void testGetRecentBatchSizesTotalPrunesExpiredEntries() {
+	public void testGetAvailableSlavesCount() {
 		int availableSlavesCount = _jenkinsMaster.getAvailableSlavesCount(null);
 
 		JenkinsMaster.maxRecentBatchAge = -1;
@@ -81,7 +81,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	@Test
-	public void testUpdatePreservesRecentBatchDebit() {
+	public void testUpdate() {
 		_jenkinsMaster.update();
 
 		int availableSlavesCount = _jenkinsMaster.getAvailableSlavesCount(null);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -50,7 +50,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 			read(new File(dependenciesDirs.get(0), "computer-api.json")),
 			"http://test-9-1/computer/api/json", urlReader);
 
-		_jenkinsMaster = JenkinsMasterTestUtil.stageMaster(
+		_jenkinsMaster = JenkinsMasterTestUtil.getJenkinsMaster(
 			"test-9-1", "http://test-9-1");
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
@@ -6,7 +6,6 @@
 package com.liferay.jenkins.results.parser;
 
 import java.util.ArrayList;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -19,31 +18,27 @@ public class JenkinsMasterTestUtil {
 	public static Properties getJenkinsCohortProperties(
 		String cohortName, int masterCount) {
 
-		Hashtable<Object, Object> buildProperties = new Hashtable<>();
+		Properties properties = new Properties();
 
-		buildProperties.put(
+		properties.setProperty(
 			"base.invocation.url", "http://" + cohortName + ".liferay.com");
 
 		for (int i = 1; i <= masterCount; i++) {
 			String masterName = cohortName + "-" + i;
 
-			buildProperties.put(
+			properties.setProperty(
 				"jenkins.local.url[" + masterName + "]",
 				"http://" + masterName);
-			buildProperties.put(
+			properties.setProperty(
 				"jenkins.remote.url[" + masterName + "]",
 				"http://" + masterName + ".liferay.com");
-			buildProperties.put(
+			properties.setProperty(
 				"master.property(" + masterName + "/executors.size)", "8");
 		}
 
-		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+		JenkinsResultsParserUtil.setBuildProperties(properties);
 
 		resetCaches();
-
-		Properties properties = new Properties();
-
-		properties.putAll(buildProperties);
 
 		return properties;
 	}
@@ -51,14 +46,15 @@ public class JenkinsMasterTestUtil {
 	public static JenkinsMaster getJenkinsMaster(
 		String masterName, String masterURL) {
 
-		Hashtable<Object, Object> buildProperties = new Hashtable<>();
+		Properties properties = new Properties();
 
-		buildProperties.put("jenkins.local.url[" + masterName + "]", masterURL);
-		buildProperties.put(
+		properties.setProperty(
+			"jenkins.local.url[" + masterName + "]", masterURL);
+		properties.setProperty(
 			"jenkins.remote.url[" + masterName + "]",
 			"http://" + masterName + ".liferay.com");
 
-		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+		JenkinsResultsParserUtil.setBuildProperties(properties);
 
 		resetCaches();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @author Calum Ragan
+ */
+public class JenkinsMasterTestUtil {
+
+	public static Map<String, Map<Long, Integer>> getLabelBatchSizes(
+		JenkinsMaster jenkinsMaster) {
+
+		return (Map<String, Map<Long, Integer>>)Test.getDeclaredFieldValue(
+			JenkinsMaster.class, jenkinsMaster, "_labelBatchSizes");
+	}
+
+	public static void resetCaches() {
+		Map<String, ?> jenkinsMastersMap =
+			(Map<String, ?>)Test.getDeclaredFieldValue(
+				LoadBalancerUtil.class, null, "_jenkinsMastersMap");
+
+		jenkinsMastersMap.clear();
+
+		Map<String, ?> roundRobinCounters =
+			(Map<String, ?>)Test.getDeclaredFieldValue(
+				LoadBalancerUtil.class, null, "_roundRobinCounters");
+
+		roundRobinCounters.clear();
+
+		Map<String, ?> jenkinsMasters =
+			(Map<String, ?>)Test.getDeclaredFieldValue(
+				JenkinsMaster.class, null, "_jenkinsMasters");
+
+		jenkinsMasters.clear();
+
+		List<String> jenkinsMastersBlacklist =
+			(List<String>)Test.getDeclaredFieldValue(
+				JenkinsMaster.class, null, "_jenkinsMastersBlacklist");
+
+		jenkinsMastersBlacklist.clear();
+	}
+
+	public static Properties stageFleet(String cohortName, int masterCount) {
+		Hashtable<Object, Object> buildProperties = new Hashtable<>();
+
+		buildProperties.put(
+			"base.invocation.url", "http://" + cohortName + ".liferay.com");
+
+		for (int i = 1; i <= masterCount; i++) {
+			String masterName = cohortName + "-" + i;
+
+			buildProperties.put(
+				"jenkins.local.url[" + masterName + "]",
+				"http://" + masterName);
+			buildProperties.put(
+				"jenkins.remote.url[" + masterName + "]",
+				"http://" + masterName + ".liferay.com");
+			buildProperties.put(
+				"master.property(" + masterName + "/executors.size)", "8");
+		}
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		resetCaches();
+
+		Properties properties = new Properties();
+
+		properties.putAll(buildProperties);
+
+		return properties;
+	}
+
+	public static JenkinsMaster stageMaster(
+		String masterName, String masterURL) {
+
+		Hashtable<Object, Object> buildProperties = new Hashtable<>();
+
+		buildProperties.put("jenkins.local.url[" + masterName + "]", masterURL);
+		buildProperties.put(
+			"jenkins.remote.url[" + masterName + "]",
+			"http://" + masterName + ".liferay.com");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		resetCaches();
+
+		JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(masterName);
+
+		Test.setDeclaredFieldValue(
+			JenkinsMaster.class, jenkinsMaster, "_awsFleetClouds",
+			new ArrayList<>());
+		Test.setDeclaredFieldValue(
+			JenkinsMaster.class, jenkinsMaster,
+			"_awsFleetCloudLastUpdateTimestamp",
+			JenkinsResultsParserUtil.getCurrentTimeMillis());
+
+		return jenkinsMaster;
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
@@ -19,32 +19,28 @@ public class JenkinsMasterTestUtil {
 	public static Map<String, Map<Long, Integer>> getLabelBatchSizes(
 		JenkinsMaster jenkinsMaster) {
 
-		return (Map<String, Map<Long, Integer>>)Test.getDeclaredFieldValue(
-			JenkinsMaster.class, jenkinsMaster, "_labelBatchSizes");
+		return ReflectionTestUtil.getFieldValue(
+			jenkinsMaster, "_labelBatchSizes");
 	}
 
 	public static void resetCaches() {
-		Map<String, ?> jenkinsMastersMap =
-			(Map<String, ?>)Test.getDeclaredFieldValue(
-				LoadBalancerUtil.class, null, "_jenkinsMastersMap");
+		Map<String, ?> jenkinsMastersMap = ReflectionTestUtil.getFieldValue(
+			LoadBalancerUtil.class, "_jenkinsMastersMap");
 
 		jenkinsMastersMap.clear();
 
-		Map<String, ?> roundRobinCounters =
-			(Map<String, ?>)Test.getDeclaredFieldValue(
-				LoadBalancerUtil.class, null, "_roundRobinCounters");
+		Map<String, ?> roundRobinCounters = ReflectionTestUtil.getFieldValue(
+			LoadBalancerUtil.class, "_roundRobinCounters");
 
 		roundRobinCounters.clear();
 
-		Map<String, ?> jenkinsMasters =
-			(Map<String, ?>)Test.getDeclaredFieldValue(
-				JenkinsMaster.class, null, "_jenkinsMasters");
+		Map<String, ?> jenkinsMasters = ReflectionTestUtil.getFieldValue(
+			JenkinsMaster.class, "_jenkinsMasters");
 
 		jenkinsMasters.clear();
 
-		List<String> jenkinsMastersBlacklist =
-			(List<String>)Test.getDeclaredFieldValue(
-				JenkinsMaster.class, null, "_jenkinsMastersBlacklist");
+		List<String> jenkinsMastersBlacklist = ReflectionTestUtil.getFieldValue(
+			JenkinsMaster.class, "_jenkinsMastersBlacklist");
 
 		jenkinsMastersBlacklist.clear();
 	}
@@ -95,13 +91,11 @@ public class JenkinsMasterTestUtil {
 
 		JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(masterName);
 
-		Test.setDeclaredFieldValue(
-			JenkinsMaster.class, jenkinsMaster,
-			"_awsFleetCloudLastUpdateTimestamp",
+		ReflectionTestUtil.setFieldValue(
+			jenkinsMaster, "_awsFleetCloudLastUpdateTimestamp",
 			JenkinsResultsParserUtil.getCurrentTimeMillis());
-		Test.setDeclaredFieldValue(
-			JenkinsMaster.class, jenkinsMaster, "_awsFleetClouds",
-			new ArrayList<>());
+		ReflectionTestUtil.setFieldValue(
+			jenkinsMaster, "_awsFleetClouds", new ArrayList<>());
 
 		return jenkinsMaster;
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
@@ -96,12 +96,12 @@ public class JenkinsMasterTestUtil {
 		JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(masterName);
 
 		Test.setDeclaredFieldValue(
-			JenkinsMaster.class, jenkinsMaster, "_awsFleetClouds",
-			new ArrayList<>());
-		Test.setDeclaredFieldValue(
 			JenkinsMaster.class, jenkinsMaster,
 			"_awsFleetCloudLastUpdateTimestamp",
 			JenkinsResultsParserUtil.getCurrentTimeMillis());
+		Test.setDeclaredFieldValue(
+			JenkinsMaster.class, jenkinsMaster, "_awsFleetClouds",
+			new ArrayList<>());
 
 		return jenkinsMaster;
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
@@ -16,36 +16,9 @@ import java.util.Properties;
  */
 public class JenkinsMasterTestUtil {
 
-	public static Map<String, Map<Long, Integer>> getLabelBatchSizes(
-		JenkinsMaster jenkinsMaster) {
+	public static Properties getJenkinsCohortProperties(
+		String cohortName, int masterCount) {
 
-		return ReflectionTestUtil.getFieldValue(
-			jenkinsMaster, "_labelBatchSizes");
-	}
-
-	public static void resetCaches() {
-		Map<String, ?> jenkinsMastersMap = ReflectionTestUtil.getFieldValue(
-			LoadBalancerUtil.class, "_jenkinsMastersMap");
-
-		jenkinsMastersMap.clear();
-
-		Map<String, ?> roundRobinCounters = ReflectionTestUtil.getFieldValue(
-			LoadBalancerUtil.class, "_roundRobinCounters");
-
-		roundRobinCounters.clear();
-
-		Map<String, ?> jenkinsMasters = ReflectionTestUtil.getFieldValue(
-			JenkinsMaster.class, "_jenkinsMasters");
-
-		jenkinsMasters.clear();
-
-		List<String> jenkinsMastersBlacklist = ReflectionTestUtil.getFieldValue(
-			JenkinsMaster.class, "_jenkinsMastersBlacklist");
-
-		jenkinsMastersBlacklist.clear();
-	}
-
-	public static Properties stageFleet(String cohortName, int masterCount) {
 		Hashtable<Object, Object> buildProperties = new Hashtable<>();
 
 		buildProperties.put(
@@ -75,7 +48,7 @@ public class JenkinsMasterTestUtil {
 		return properties;
 	}
 
-	public static JenkinsMaster stageMaster(
+	public static JenkinsMaster getJenkinsMaster(
 		String masterName, String masterURL) {
 
 		Hashtable<Object, Object> buildProperties = new Hashtable<>();
@@ -98,6 +71,35 @@ public class JenkinsMasterTestUtil {
 			jenkinsMaster, "_awsFleetClouds", new ArrayList<>());
 
 		return jenkinsMaster;
+	}
+
+	public static Map<String, Map<Long, Integer>> getLabelBatchSizes(
+		JenkinsMaster jenkinsMaster) {
+
+		return ReflectionTestUtil.getFieldValue(
+			jenkinsMaster, "_labelBatchSizes");
+	}
+
+	public static void resetCaches() {
+		Map<String, ?> jenkinsMastersMap = ReflectionTestUtil.getFieldValue(
+			LoadBalancerUtil.class, "_jenkinsMastersMap");
+
+		jenkinsMastersMap.clear();
+
+		Map<String, ?> roundRobinCounters = ReflectionTestUtil.getFieldValue(
+			LoadBalancerUtil.class, "_roundRobinCounters");
+
+		roundRobinCounters.clear();
+
+		Map<String, ?> jenkinsMasters = ReflectionTestUtil.getFieldValue(
+			JenkinsMaster.class, "_jenkinsMasters");
+
+		jenkinsMasters.clear();
+
+		List<String> jenkinsMastersBlacklist = ReflectionTestUtil.getFieldValue(
+			JenkinsMaster.class, "_jenkinsMastersBlacklist");
+
+		jenkinsMastersBlacklist.clear();
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -680,8 +680,8 @@ public class JenkinsResultsParserUtilTest
 			masterNetworkName
 		);
 
-		setDeclaredFieldValue(
-			JenkinsResultsParserUtil.class, null, "_ciNode", null);
+		ReflectionTestUtil.setFieldValue(
+			JenkinsResultsParserUtil.class, "_ciNode", null);
 
 		Assert.assertEquals(
 			JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -16,7 +16,6 @@ import java.util.Properties;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -28,11 +27,6 @@ import org.mockito.Mockito;
  */
 public class JenkinsResultsParserUtilTest
 	extends com.liferay.jenkins.results.parser.Test {
-
-	@After
-	public void tearDown() {
-		Environment.setInstance(new Environment());
-	}
 
 	@Test(timeout = 30000)
 	public void testExecuteJenkinsScriptReadTimeout() throws Exception {
@@ -512,6 +506,14 @@ public class JenkinsResultsParserUtilTest
 	}
 
 	@Test
+	public void testIsCINode() {
+		_assertIsCINode("https://test-1-1.liferay.com/", null, true);
+		_assertIsCINode(null, "test-network", true);
+		_assertIsCINode("https://test-1-1.liferay.com/", "test-network", true);
+		_assertIsCINode(null, null, false);
+	}
+
+	@Test
 	public void testIsJSONArrayEqual() {
 		JSONArray expectedJSONArray = new JSONArray();
 
@@ -659,6 +661,33 @@ public class JenkinsResultsParserUtilTest
 		Environment.setInstance(environment);
 
 		return environment;
+	}
+
+	private void _assertIsCINode(
+		String jenkinsURL, String masterNetworkName, boolean expected) {
+
+		Environment environment = mockEnvironment();
+
+		Mockito.when(
+			environment.doGet("JENKINS_URL")
+		).thenReturn(
+			jenkinsURL
+		);
+
+		Mockito.when(
+			environment.doGet("MASTER_NETWORK_NAME")
+		).thenReturn(
+			masterNetworkName
+		);
+
+		setDeclaredFieldValue(
+			JenkinsResultsParserUtil.class, null, "_ciNode", null);
+
+		Assert.assertEquals(
+			JenkinsResultsParserUtil.combine(
+				"Unexpected isCINode() value for JENKINS_URL=", jenkinsURL,
+				" and MASTER_NETWORK_NAME=", masterNetworkName),
+			expected, JenkinsResultsParserUtil.isCINode());
 	}
 
 	private ServerSocket _createServerSocket() throws Exception {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -507,9 +507,9 @@ public class JenkinsResultsParserUtilTest
 
 	@Test
 	public void testIsCINode() {
+		_assertIsCINode("https://test-1-1.liferay.com/", "test-network", true);
 		_assertIsCINode("https://test-1-1.liferay.com/", null, true);
 		_assertIsCINode(null, "test-network", true);
-		_assertIsCINode("https://test-1-1.liferay.com/", "test-network", true);
 		_assertIsCINode(null, null, false);
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -35,7 +35,8 @@ public class LoadBalancerUtilTest
 
 	@Test
 	public void testGetAvailableJenkinsMasters() {
-		Properties properties = JenkinsMasterTestUtil.stageFleet("test-9", 5);
+		Properties properties =
+			JenkinsMasterTestUtil.getJenkinsCohortProperties("test-9", 5);
 
 		List<String> masterNames = _getMasterNames(
 			LoadBalancerUtil.getAvailableJenkinsMasters(
@@ -60,7 +61,8 @@ public class LoadBalancerUtilTest
 
 	@Test
 	public void testGetMostAvailableMasterURL() {
-		Properties properties = JenkinsMasterTestUtil.stageFleet("test-9", 5);
+		Properties properties =
+			JenkinsMasterTestUtil.getJenkinsCohortProperties("test-9", 5);
 
 		properties.setProperty("blacklist", "test-9-5");
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Calum Ragan
+ */
+public class LoadBalancerUtilTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
+
+		JenkinsResultsParserUtil.setBuildProperties(
+			(Hashtable<Object, Object>)null);
+	}
+
+	@Test
+	public void testGetAvailableJenkinsMastersExcludesBlacklistedMasters() {
+		Properties properties = JenkinsMasterTestUtil.stageFleet("test-9", 5);
+
+		List<String> masterNames = _getMasterNames(
+			LoadBalancerUtil.getAvailableJenkinsMasters(
+				"TEST-9-2", "test-9", properties, false));
+
+		Assert.assertEquals(masterNames.toString(), 4, masterNames.size());
+
+		Assert.assertFalse(masterNames.contains("test-9-2"));
+
+		properties.setProperty(
+			"jenkins.load.balancer.blacklist", "test-9-3, test-9-4");
+
+		masterNames = _getMasterNames(
+			LoadBalancerUtil.getAvailableJenkinsMasters(
+				null, "test-9", properties, false));
+
+		Assert.assertEquals(masterNames.toString(), 3, masterNames.size());
+
+		Assert.assertFalse(masterNames.contains("test-9-3"));
+		Assert.assertFalse(masterNames.contains("test-9-4"));
+	}
+
+	@Test
+	public void testGetMostAvailableMasterURLRoundRobin() {
+		Properties properties = JenkinsMasterTestUtil.stageFleet("test-9", 5);
+
+		properties.setProperty("blacklist", "test-9-5");
+
+		Map<String, Integer> selectionCounts = new HashMap<>();
+
+		for (int i = 0; i < 12; i++) {
+			String masterURL = LoadBalancerUtil.getMostAvailableMasterURL(
+				properties, false);
+
+			Integer selectionCount = selectionCounts.get(masterURL);
+
+			if (selectionCount == null) {
+				selectionCount = 0;
+			}
+
+			selectionCounts.put(masterURL, selectionCount + 1);
+		}
+
+		Assert.assertEquals(
+			selectionCounts.toString(), 4, selectionCounts.size());
+
+		for (int i = 1; i <= 4; i++) {
+			String masterURL = "http://test-9-" + i;
+
+			Assert.assertEquals(
+				masterURL, Integer.valueOf(3), selectionCounts.get(masterURL));
+		}
+
+		Assert.assertNull(selectionCounts.get("http://test-9-5"));
+	}
+
+	private List<String> _getMasterNames(List<JenkinsMaster> jenkinsMasters) {
+		List<String> masterNames = new ArrayList<>();
+
+		for (JenkinsMaster jenkinsMaster : jenkinsMasters) {
+			masterNames.add(jenkinsMaster.getName());
+		}
+
+		return masterNames;
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -34,7 +34,7 @@ public class LoadBalancerUtilTest
 	}
 
 	@Test
-	public void testGetAvailableJenkinsMastersExcludesBlacklistedMasters() {
+	public void testGetAvailableJenkinsMasters() {
 		Properties properties = JenkinsMasterTestUtil.stageFleet("test-9", 5);
 
 		List<String> masterNames = _getMasterNames(
@@ -59,7 +59,7 @@ public class LoadBalancerUtilTest
 	}
 
 	@Test
-	public void testGetMostAvailableMasterURLRoundRobin() {
+	public void testGetMostAvailableMasterURL() {
 		Properties properties = JenkinsMasterTestUtil.stageFleet("test-9", 5);
 
 		properties.setProperty("blacklist", "test-9-5");

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -7,7 +7,6 @@ package com.liferay.jenkins.results.parser;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -29,8 +28,7 @@ public class LoadBalancerUtilTest
 
 		JenkinsMasterTestUtil.resetCaches();
 
-		JenkinsResultsParserUtil.setBuildProperties(
-			(Hashtable<Object, Object>)null);
+		JenkinsResultsParserUtil.setBuildProperties(new Properties());
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ReflectionTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ReflectionTestUtil.java
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.lang.reflect.Field;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class ReflectionTestUtil {
+
+	public static Field getField(Class<?> clazz, String fieldName) {
+		while (clazz != null) {
+			try {
+				Field field = clazz.getDeclaredField(fieldName);
+
+				field.setAccessible(true);
+
+				return field;
+			}
+			catch (NoSuchFieldException noSuchFieldException) {
+				clazz = clazz.getSuperclass();
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
+
+		throw new RuntimeException(
+			new NoSuchFieldException("No field with name " + fieldName));
+	}
+
+	public static <T> T getFieldValue(Class<?> clazz, String fieldName) {
+		Field field = getField(clazz, fieldName);
+
+		try {
+			return (T)field.get(null);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+	}
+
+	public static <T> T getFieldValue(Object instance, String fieldName) {
+		Field field = getField(instance.getClass(), fieldName);
+
+		try {
+			return (T)field.get(instance);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+	}
+
+	public static void setFieldValue(
+		Class<?> clazz, String fieldName, Object value) {
+
+		Field field = getField(clazz, fieldName);
+
+		try {
+			field.set(null, value);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+	}
+
+	public static void setFieldValue(
+		Object instance, String fieldName, Object value) {
+
+		Field field = getField(instance.getClass(), fieldName);
+
+		try {
+			field.set(instance, value);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -9,8 +9,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 
-import java.lang.reflect.Field;
-
 import java.net.URI;
 
 import java.nio.file.Files;
@@ -54,21 +52,6 @@ public class Test {
 	@Rule
 	public ErrorCollector errorCollector = new ErrorCollector();
 
-	protected static Object getDeclaredFieldValue(
-		Class<?> clazz, Object object, String fieldName) {
-
-		try {
-			Field field = clazz.getDeclaredField(fieldName);
-
-			field.setAccessible(true);
-
-			return field.get(object);
-		}
-		catch (ReflectiveOperationException reflectiveOperationException) {
-			throw new RuntimeException(reflectiveOperationException);
-		}
-	}
-
 	protected static List<File> getDependenciesDirs(
 		List<String> simpleClassNames) {
 
@@ -80,21 +63,6 @@ public class Test {
 		}
 
 		return dirs;
-	}
-
-	protected static void setDeclaredFieldValue(
-		Class<?> clazz, Object object, String fieldName, Object value) {
-
-		try {
-			Field field = clazz.getDeclaredField(fieldName);
-
-			field.setAccessible(true);
-
-			field.set(object, value);
-		}
-		catch (ReflectiveOperationException reflectiveOperationException) {
-			throw new RuntimeException(reflectiveOperationException);
-		}
 	}
 
 	protected String getMismatchMessage(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -9,6 +9,8 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 
+import java.lang.reflect.Field;
+
 import java.net.URI;
 
 import java.nio.file.Files;
@@ -47,10 +49,28 @@ public class Test {
 		Shell.setInstance(new Shell());
 
 		UrlReader.setInstance(new UrlReader());
+
+		setDeclaredFieldValue(
+			JenkinsResultsParserUtil.class, null, "_ciNode", null);
 	}
 
 	@Rule
 	public ErrorCollector errorCollector = new ErrorCollector();
+
+	protected static Object getDeclaredFieldValue(
+		Class<?> clazz, Object object, String fieldName) {
+
+		try {
+			Field field = clazz.getDeclaredField(fieldName);
+
+			field.setAccessible(true);
+
+			return field.get(object);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new RuntimeException(reflectiveOperationException);
+		}
+	}
 
 	protected static List<File> getDependenciesDirs(
 		List<String> simpleClassNames) {
@@ -63,6 +83,21 @@ public class Test {
 		}
 
 		return dirs;
+	}
+
+	protected static void setDeclaredFieldValue(
+		Class<?> clazz, Object object, String fieldName, Object value) {
+
+		try {
+			Field field = clazz.getDeclaredField(fieldName);
+
+			field.setAccessible(true);
+
+			field.set(object, value);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new RuntimeException(reflectiveOperationException);
+		}
 	}
 
 	protected String getMismatchMessage(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -49,9 +49,6 @@ public class Test {
 		Shell.setInstance(new Shell());
 
 		UrlReader.setInstance(new UrlReader());
-
-		setDeclaredFieldValue(
-			JenkinsResultsParserUtil.class, null, "_ciNode", null);
 	}
 
 	@Rule

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/JenkinsMasterTest/computer-api.json
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/JenkinsMasterTest/computer-api.json
@@ -1,0 +1,35 @@
+{
+	"_class": "hudson.model.ComputerSet",
+	"computer": [
+		{
+			"_class": "hudson.model.Hudson$MasterComputer",
+			"assignedLabels": [
+				{
+					"name": "built-in"
+				}
+			],
+			"displayName": "Built-In Node",
+			"executors": [
+			],
+			"idle": true,
+			"offline": false,
+			"offlineCauseReason": ""
+		},
+		{
+			"_class": "hudson.slaves.SlaveComputer",
+			"assignedLabels": [
+				{
+					"name": "test-9-1-1"
+				}
+			],
+			"displayName": "test-9-1-1",
+			"executors": [
+				{
+				}
+			],
+			"idle": true,
+			"offline": false,
+			"offlineCauseReason": ""
+		}
+	]
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7912

Resend of #2160 (@CalumR23); his original commits are carried over unchanged, with review-driven cleanups on top. Rebased onto current master.

## Why

Several jenkins-results-parser regressions from the LRCI-7522 bug history had no unit coverage, so each only surfaced in production CI. This adds one regression test per bug, each grounded in a real recorded regression and validated red-before-green.

## Bugs covered

- **CI node not identified when only the network name is set** (LRCI-7022, fix `aaed3b7b`) — `JenkinsResultsParserUtilTest.testIsCINode`.
  `isCINode()` treated a node as CI only when `JENKINS_URL` was set, so a master exposing only `MASTER_NETWORK_NAME` read as non-CI. The test asserts a network-name-only master still reads as a CI node; reverting the fix flips it to false.
- **Blacklisted masters not excluded from load balancing** (LRCI-7022) — `LoadBalancerUtilTest.testGetAvailableJenkinsMasters`.
  Available masters must drop any blacklisted entry. The test stages a five-master cohort and asserts exclusion in both the request-string form and the `jenkins.load.balancer.blacklist` property form.
- **Round-robin selection uneven or picked blacklisted masters** (LRCI-7532 / LRCI-7432) — `LoadBalancerUtilTest.testGetMostAvailableMasterURL`.
  Selection must cycle evenly across eligible masters regardless of the random counter offset, and never pick a blacklisted one. The test runs twelve selections over four eligible masters and asserts each is chosen three times and the blacklisted master never.
- **update() wiped the recent-batch debit** (LRCI-7432, fix `fc3def6e`) — `JenkinsMasterTest.testUpdate`.
  A recent batch debits a master's available-slave count; `update()` cleared that debit on every refresh. The test debits, forces a second `update()`, and asserts the debit survives.
- **Expired recent-batch entries not pruned under a non-matching label** (LRCI-7202, fix `2270e6cd`) — `JenkinsMasterTest.testGetAvailableSlavesCount`.
  Expired entries were pruned only when the queried label matched, so a non-matching query left them to accumulate. The test expires an entry under one label, queries another, and asserts the entry is pruned.

Each was validated red-before-green — revert the fix (or mutate the invariant where no single fix commit exists), confirm the test fails, restore, confirm it passes.

## Test harness

- `JenkinsMasterTestUtil` stages masters purely from in-memory build properties and resets the sticky static caches in `LoadBalancerUtil` and `JenkinsMaster` between tests, driving `JenkinsMaster` offline through the base-class `UrlReader` mock fed local fixtures.
- `ReflectionTestUtil` is a small local copy of the portal `com.liferay.portal.kernel.test.ReflectionTestUtil`, holding only the field accessors these tests need, so the module keeps its mockito-only test dependencies.
- `RandomTestUtil` supplies random values for inputs the tests do not assert on.

## Follow-up commits

Review-driven, behavior-preserving cleanups — naming tests after the method under test, declaring variables as used, `JSONObject` builders for mock responses, `Properties` over `Hashtable`, and alphabetical sorting — each verified locally with `formatSource` clean and the affected test classes green.
