### PR TITLE
LRCI-7844 Add flag to run controller builds concurrently per SHA

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunner.java
@@ -36,26 +36,31 @@ public abstract class BasePortalControllerBuildRunner
 	public void run() {
 		retirePreviousBuilds();
 
+		if (allowConcurrentBuildsUniqueSHA()) {
+			if (previousBuildHasCurrentSHA()) {
+				_updateBuildDescription();
+
+				return;
+			}
+
+			invokeBuild();
+
+			return;
+		}
+
 		if (allowConcurrentBuilds() || expirePreviousBuild()) {
 			invokeBuild();
 
 			return;
 		}
 
-		S buildData = getBuildData();
-
 		if (previousBuildHasCurrentSHA()) {
-			buildData.setBuildDescription(
-				JenkinsResultsParserUtil.combine(
-					"<strong>SKIPPED</strong> - <a href=\"https://github.com/",
-					"liferay/", buildData.getPortalGitHubRepositoryName(),
-					"/commit/", buildData.getPortalBranchSHA(), "\">",
-					getPortalBranchAbbreviatedSHA(), "</a> was already ran"));
-
-			super.updateBuildDescription();
+			_updateBuildDescription();
 
 			return;
 		}
+
+		S buildData = getBuildData();
 
 		if (previousBuildHasExistingInvocation()) {
 			buildData.setBuildDescription(
@@ -94,6 +99,22 @@ public abstract class BasePortalControllerBuildRunner
 		allowConcurrentBuildsString = allowConcurrentBuildsString.trim();
 
 		return allowConcurrentBuildsString.equals("true");
+	}
+
+	protected boolean allowConcurrentBuildsUniqueSHA() {
+		String allowConcurrentBuildsUniqueSHAString = Environment.get(
+			"ALLOW_CONCURRENT_BUILDS_UNIQUE_SHA");
+
+		if (allowConcurrentBuildsUniqueSHAString == null) {
+			return false;
+		}
+
+		allowConcurrentBuildsUniqueSHAString =
+			allowConcurrentBuildsUniqueSHAString.toLowerCase();
+		allowConcurrentBuildsUniqueSHAString =
+			allowConcurrentBuildsUniqueSHAString.trim();
+
+		return allowConcurrentBuildsUniqueSHAString.equals("true");
 	}
 
 	protected boolean expirePreviousBuild() {
@@ -372,6 +393,19 @@ public abstract class BasePortalControllerBuildRunner
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
 		}
+	}
+
+	private void _updateBuildDescription() {
+		S buildData = getBuildData();
+
+		buildData.setBuildDescription(
+			JenkinsResultsParserUtil.combine(
+				"<strong>SKIPPED</strong> - <a href=\"https://github.com/",
+				"liferay/", buildData.getPortalGitHubRepositoryName(),
+				"/commit/", buildData.getPortalBranchSHA(), "\">",
+				getPortalBranchAbbreviatedSHA(), "</a> was already ran"));
+
+		super.updateBuildDescription();
 	}
 
 	private static final Integer _CONTROLLER_BUILD_TIMEOUT_DEFAULT =

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import org.junit.Test;
+
+import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
+
+/**
+ * @author Kenji Heigel
+ */
+public class BasePortalControllerBuildRunnerTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testRun() {
+		_testRun("false");
+		_testRun("true");
+	}
+
+	private void _testRun(String allowConcurrentBuildsUniqueSHAString) {
+		Environment environment = Mockito.mock(Environment.class);
+
+		Environment.setInstance(environment);
+
+		Mockito.when(
+			environment.doGet("ALLOW_CONCURRENT_BUILDS_UNIQUE_SHA")
+		).thenReturn(
+			allowConcurrentBuildsUniqueSHAString
+		);
+
+		BasePortalControllerBuildRunner<?> basePortalControllerBuildRunner =
+			Mockito.mock(BasePortalControllerBuildRunner.class);
+
+		Mockito.doReturn(
+			false
+		).when(
+			basePortalControllerBuildRunner
+		).previousBuildHasCurrentSHA();
+
+		Mockito.doCallRealMethod(
+		).when(
+			basePortalControllerBuildRunner
+		).allowConcurrentBuildsUniqueSHA();
+
+		Mockito.doCallRealMethod(
+		).when(
+			basePortalControllerBuildRunner
+		).run();
+
+		basePortalControllerBuildRunner.run();
+
+		VerificationMode verificationMode = Mockito.times(1);
+
+		if (allowConcurrentBuildsUniqueSHAString.equals("true")) {
+			verificationMode = Mockito.never();
+		}
+
+		Mockito.verify(
+			basePortalControllerBuildRunner, verificationMode
+		).allowConcurrentBuilds();
+
+		Mockito.verify(
+			basePortalControllerBuildRunner
+		).invokeBuild();
+	}
+
+}


### PR DESCRIPTION
## What

Adds an `ALLOW_CONCURRENT_BUILDS_UNIQUE_SHA` env flag to `BasePortalControllerBuildRunner.run()`. When set, the controller invokes a build for any SHA it has not already run — bypassing the `IN QUEUE` / `IN PROGRESS` in-flight guards — while still skipping a SHA that a prior build already covered.

## Why

The bundles controller pre-builds portal SHAs on a `*/10` cron so downstream upstream-testsuite jobs start with a warm bundle. Today `run()` self-skips (`SKIPPED - Job is already running`) whenever the previous bundle build is still in flight, so only one SHA can be warmed at a time and the cron is effectively serialized behind each build.

With the flag on, distinct SHAs warm concurrently; the same SHA is never launched twice because `previousBuildHasCurrentSHA()` still short-circuits to `SKIPPED ... was already ran` (the in-progress build's description carries the Git ID).

## Blast radius

Additive and opt-in. With the flag unset, `run()` follows the original path byte-for-byte, so every existing controller cohort — including the `master_analytics-cloud-*` jobs already running with `ALLOW_CONCURRENT_BUILDS=true` — is unchanged. Only `master_bundles` will set the new flag (config lands in liferay-jenkins-ee).

## Testing

Behavior will be exercised on a liferay-jenkins-ee branch carrying a custom parser jar + the `master_bundles` config, against a CI run. Unit coverage to follow.