### PR TITLE
LRCI-7528 Let each rule pick the portal test suite for its jobs

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsGitRepositoryJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsGitRepositoryJob.java
@@ -85,7 +85,21 @@ public class JenkinsGitRepositoryJob extends GitRepositoryJob {
 				continue;
 			}
 
-			invokedJobNames.addAll(_getInvokedJobNames(propertyName));
+			for (String invokedJobName : _getInvokedJobNames(propertyName)) {
+				String portalTestSuiteName =
+					JenkinsResultsParserUtil.getProperty(
+						buildProperties,
+						"jenkins.pull.request.job.portal.test.suite", false,
+						propertyOptions.get(0), invokedJobName);
+
+				if (!JenkinsResultsParserUtil.isNullOrEmpty(
+						portalTestSuiteName)) {
+
+					invokedJobName += "/" + portalTestSuiteName;
+				}
+
+				invokedJobNames.add(invokedJobName);
+			}
 		}
 
 		if (invokedJobNames.isEmpty()) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7528

## What Is Being Fixed

Follow up to the merged relevant test suite selection. The selection could only run a given job under one portal test suite, since job entries were bare names deduplicated in a set and the portal suite came from a single per job property row. Review on the jenkins-ee half asked for the suite to be determined by the rule, so two rules can dispatch the same job under different suites.

## How It Is Being Fixed

getInvokedJobNames now resolves jenkins.pull.request.job.portal.test.suite with the rule name and job name as property options and appends the resolved suite to the entry as jobName/suite. Bare job rows act as shared defaults through the existing most specific wins property matching, and a job with no suite row keeps its bare name. The composite entries flow into the invoke loop as job build names, matching the vocabulary already used by the invocation map in build-common.xml, so the same job under two suites becomes two invocations. The consuming jenkins-ee change is on kenjiheigel/liferay-jenkins-ee pull 179.

## Why Are There No Tests?

The unit test class for the selection logic remains parked until the property vocabulary settles in review, and the jenkins-ee half gets a staged CI test before rollout.

## PR Check

**pr-check: PASS** — tested on `4c9c261a4763c3e70f7cbb5d51b44b66c949201e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

Java Unit Tests ran the full module suite, 151 of 152 passing. The one failure is PropertyValidatorTest, a pre-existing environment break from the LRCI-7925 SecretsUtil merge that fails identically on a clean master checkout, so it is excluded from the verdict.

<!-- pr-check {"result": "success", "sha": "4c9c261a4763c3e70f7cbb5d51b44b66c949201e"} -->
