### PR TITLE
LRCI-7941 Survive a downstream invocation with no resolvable build URL

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -176,7 +176,11 @@ public abstract class BaseBuild implements Build {
 		for (Invocation invocation :
 				_invocations.subList(0, _invocations.size() - 1)) {
 
-			badBuildURLs.add(invocation.getBuildURL());
+			String buildURL = invocation.getBuildURL();
+
+			if (buildURL != null) {
+				badBuildURLs.add(buildURL);
+			}
 		}
 
 		return badBuildURLs;
@@ -2437,10 +2441,16 @@ public abstract class BaseBuild implements Build {
 			if (status.equals("running")) {
 				Invocation previousInvocation = getPreviousInvocation();
 
+				String previousBuildURL = null;
+
 				if (previousInvocation != null) {
+					previousBuildURL = previousInvocation.getBuildURL();
+				}
+
+				if (previousBuildURL != null) {
 					sb.append(" ");
 
-					sb.append(previousInvocation.getBuildURL());
+					sb.append(previousBuildURL);
 
 					sb.append(" restarted at ");
 				}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1679,10 +1679,19 @@ public abstract class BaseBuild implements Build {
 
 	@Override
 	public void saveBuildURLInBuildDatabase() {
+		String buildURL = getBuildURL();
+		String jobVariant = getJobVariant();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(buildURL) ||
+			JenkinsResultsParserUtil.isNullOrEmpty(jobVariant)) {
+
+			return;
+		}
+
 		BuildDatabase buildDatabase = getBuildDatabase();
 
 		buildDatabase.putProperty(
-			BUILD_URLS_PROPERTIES_KEY, getJobVariant(), getBuildURL(), false);
+			BUILD_URLS_PROPERTIES_KEY, jobVariant, buildURL, false);
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
@@ -687,17 +687,29 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 
 	@Override
 	public void saveBuildURLInBuildDatabase() {
+		String buildURL = getBuildURL();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(buildURL)) {
+			return;
+		}
+
 		BuildDatabase buildDatabase = getBuildDatabase();
 
 		if (isBuildCached()) {
 			buildDatabase.putProperty(
-				CACHED_BUILD_URLS_PROPERTIES_KEY, getBuildURL(), "", false);
+				CACHED_BUILD_URLS_PROPERTIES_KEY, buildURL, "", false);
 
 			return;
 		}
 
+		String axisName = getAxisName();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(axisName)) {
+			return;
+		}
+
 		buildDatabase.putProperty(
-			BUILD_URLS_PROPERTIES_KEY, getAxisName(), getBuildURL(), false);
+			BUILD_URLS_PROPERTIES_KEY, axisName, buildURL, false);
 
 		_saveBadBuildURLsInBuildDatabase(getBadBuildURLs());
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
@@ -2256,12 +2256,18 @@ public abstract class BaseTopLevelBuild
 			return;
 		}
 
+		String buildURL = getBuildURL();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(buildURL)) {
+			return;
+		}
+
 		long start = JenkinsResultsParserUtil.getCurrentTimeMillis();
 
 		Properties archiveProperties = new Properties();
 
 		archiveProperties.setProperty(
-			"top.level.build.url", replaceBuildURL(getBuildURL()));
+			"top.level.build.url", replaceBuildURL(buildURL));
 
 		StringWriter sw = new StringWriter();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -282,6 +282,10 @@ public interface Build {
 			_buildURL = JenkinsResultsParserUtil.getBuildURL(
 				_build.getJobName(), getJenkinsMaster(), getQueueId());
 
+			if (_buildURL == null) {
+				return null;
+			}
+
 			String localBuildURL = JenkinsResultsParserUtil.getLocalURL(
 				_buildURL);
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Kenji Heigel
+ */
+public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetBadBuildURLs() {
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+
+		Build.Invocation firstInvocation = new Build.Invocation(baseBuild);
+		Build.Invocation lastInvocation = new Build.Invocation(baseBuild);
+
+		String firstBuildURL = "https://test-1-1.liferay.com/job/test/1/";
+
+		firstInvocation.setBuildURL(firstBuildURL);
+
+		lastInvocation.setBuildURL("https://test-1-1.liferay.com/job/test/3/");
+
+		ReflectionTestUtil.setFieldValue(
+			baseBuild, "_invocations",
+			Arrays.asList(
+				firstInvocation, new Build.Invocation(baseBuild),
+				lastInvocation));
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).getBadBuildURLs();
+
+		Assert.assertEquals(
+			Arrays.asList(firstBuildURL), baseBuild.getBadBuildURLs());
+	}
+
+	@Test
+	public void testSaveBuildURLInBuildDatabase() {
+		_testSaveBuildURLInBuildDatabase(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true);
+		_testSaveBuildURLInBuildDatabase(
+			RandomTestUtil.randomString(), null, false);
+		_testSaveBuildURLInBuildDatabase(
+			null, RandomTestUtil.randomString(), false);
+	}
+
+	private void _testSaveBuildURLInBuildDatabase(
+		String buildURL, String jobVariant, boolean saved) {
+
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+		BuildDatabase buildDatabase = Mockito.mock(BuildDatabase.class);
+
+		Mockito.when(
+			baseBuild.getBuildDatabase()
+		).thenReturn(
+			buildDatabase
+		);
+
+		Mockito.when(
+			baseBuild.getBuildURL()
+		).thenReturn(
+			buildURL
+		);
+
+		Mockito.when(
+			baseBuild.getJobVariant()
+		).thenReturn(
+			jobVariant
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).saveBuildURLInBuildDatabase();
+
+		baseBuild.saveBuildURLInBuildDatabase();
+
+		if (saved) {
+			Mockito.verify(
+				buildDatabase
+			).putProperty(
+				BaseBuild.BUILD_URLS_PROPERTIES_KEY, jobVariant, buildURL, false
+			);
+		}
+		else {
+			Mockito.verifyNoInteractions(buildDatabase);
+		}
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7941

## What Is Being Fixed

When a downstream build was invoked more than once and an earlier invocation never resolved to a build URL, the top level build crashed during report generation instead of finishing. All downstream builds reached Completed, then the reporting phase threw and failed the whole run.

```
java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "remoteURL" is null
	at com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.getLocalURL(JenkinsResultsParserUtil.java:2786)
	at com.liferay.jenkins.results.parser.Build$Invocation.getBuildURL(Build.java:285)
	at com.liferay.jenkins.results.parser.BaseBuild.getBadBuildURLs(BaseBuild.java:179)
```

The root cause is that `JenkinsResultsParserUtil.getBuildURL` returns null once Jenkins prunes the queue item, and every path that consumed that value assumed it was present. The same null surfaced on two more paths, an exception swallowed once per monitoring cycle from `saveBuildURLInBuildDatabase`, and a failed archive step from `_archiveProperties`.

Observed on test-1-43 test-jenkins-acceptance-pullrequest build 175 during LRCI-7528 staged testing, where a downstream job accumulated three failed invocations and then walked into the null at report time.


## How It Is Being Fixed

`Invocation.getBuildURL` now returns null when the queue item cannot be resolved rather than passing that null into `getLocalURL`. Both readers of the resolved value treat an unresolvable invocation as data about that invocation rather than a fatal error, so `getBadBuildURLs` leaves it out and the build status message falls back to its started wording instead of printing a null. `saveBuildURLInBuildDatabase` returns early while the build URL or the name it stores under is still unknown, in the base class and in the `BaseDownstreamBuild` override, which does not call super and is the path downstream axes take. `_archiveProperties` skips archiving a top level build whose URL cannot be resolved, since a null value is what `Properties.setProperty` rejected.

Nothing changes on the happy path. Every edit is a guard on a value that was already null in the failing case.

## Contract Note

`Build.Invocation.getBuildURL` is on the jar published interface that liferay-jenkins-ee and osb-github-web consume, and its return contract widens to include null. All three production call sites are in this repository and all three are handled here, and no BeanShell block in liferay-jenkins-ee calls it, so no consumer change is needed.

## Tests

`BaseBuildTest.testGetBadBuildURLs` covers the frame the stack trace names. The invocation list is reached with `ReflectionTestUtil`, the way `JenkinsMasterTestUtil` already reaches private state, so a mocked build carries three invocations without running the constructor. The first and last resolve and the middle one does not, which pins the null filter and the bound that excludes the current invocation.

`BaseBuildTest.testSaveBuildURLInBuildDatabase` covers one scenario per unknown value plus a positive scenario, so the arguments the method stores are asserted rather than only its early return.

Both fail when the guards are reverted, the first with the exact NullPointerException quoted above. Swapping the two arguments the save writes, and widening the bad build URL bound by one, each fail a test as well.

The `BaseDownstreamBuild` override and `_archiveProperties` are not covered directly. Both are guards mirroring a case the tests above already pin, and `_archiveProperties` is private behind a report callable, so covering it would mean widening the module's ReflectionTestUtil for one guard.

## PR Check

**pr-check: PASS** — tested on `28978f447d4f15414b4ed6fb21feb1cd792f1544`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

The full module suite was also run separately at 153 of 154 passing. The one failure is PropertyValidatorTest, which reports four `one.password.*` properties that SecretsUtil still consumes after commit 3c221a63f59 in liferay-jenkins-ee removed their declarations. It fails identically on a clean master checkout and is unrelated to this change, so it is excluded from the verdict. Hashimoto confirmed the cached secrets path is being removed and is tracking it as LRCI-7947.

<!-- pr-check {"result": "success", "sha": "28978f447d4f15414b4ed6fb21feb1cd792f1544"} -->
