### PR TITLE
LRCI-7949 Run the selected unit tests instead of no tests at all

### DIFF
--- a/.claude/skills/pr-check/validations/java-unit-test.md
+++ b/.claude/skills/pr-check/validations/java-unit-test.md
@@ -26,13 +26,15 @@ For OSGi modules — run only the specific test class, batching counterparts wit
 "${REPO_ROOT}/gradlew" \
 	--continue \
 	--project-dir "${REPO_ROOT}/modules" \
-	--tests "<FQN1>" \
-	--tests "<FQN2>" \
 	-Dtest.ignore.failures=false \
-	:<path>:test
+	:<path>:test \
+	--tests "<FQN1>" \
+	--tests "<FQN2>"
 ```
 
 `--continue` keeps Gradle going when a downstream task fails so the test results still surface; `-Dtest.ignore.failures=false` overrides Liferay's default of swallowing test failures.
+
+Each `--tests` flag is an option on the `test` task rather than a Gradle flag, so it follows the task path and breaks the usual alphabetical flag order. Ahead of the task path, Gradle rejects the option and runs nothing.
 
 For portal-core — `test-class` (defined in `build-common.xml`) is the target that filters by `test.class` (`test-unit` ignores it and runs the full suite):
 
@@ -41,6 +43,8 @@ For portal-core — `test-class` (defined in `build-common.xml`) is the target t
 ```
 
 The space-separated Ant fileset pattern is the same one used by **Structural Smoke** — see that file for the explanation.
+
+Decide PASS or FAIL from the `tests`, `failures`, and `errors` counts in the `TEST-*.xml` files the run writes, not from a `BUILD SUCCESSFUL` marker, because the `tail` pipe discards the build's exit status and an absent marker does not distinguish tests that failed from tests that never ran. Gradle writes the files under `modules/<path>/test-results/unit/test` and the Ant target writes them under `portal-impl/test-results/unit`. A command that was given test classes and executed none of them is a FAIL. When Selection finds no test class to run there is nothing to execute, so the validation reports PASS.
 
 ## Checklist
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7949

## What Is Being Fixed

The Java Unit Tests validation put the `--tests` flags ahead of the Gradle task path. Gradle treats `--tests` as an option on the `test` task, so the documented command was rejected during command line parsing and ran no tests at all.

The skill also pipes validation output through `tail`, which reports its own exit status rather than Gradle's, so the only surviving signal was a missing `BUILD SUCCESSFUL` line. That reads as nothing failed rather than nothing ran, which makes a false pass reachable on the validation responsible for unit tests. It was hit live during the LRCI-7941 pr-check run on 2026-07-24.

## How It Is Being Fixed

The `--tests` flags now follow the task path, with a note on why that breaks the usual alphabetical flag order. The Command section also decides PASS or FAIL from the `tests`, `failures`, and `errors` counts in the `TEST-*.xml` files rather than from a build success marker, and fails a command that was given test classes and executed none of them. A validation with no test class to select has nothing to execute and still passes. The liferay-jenkins-ee pr-check already decides from the result XML for the same reason.

## Why Are There No Tests?

The change is Markdown only. Both command forms were run against `jenkins-results-parser` to confirm the documented one runs nothing and the corrected one runs the selected classes.

## PR Check

**pr-check: PASS** — tested on `b9bca0e6eeb1c0cfb08b22a874fcbe5181ea0d70`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "b9bca0e6eeb1c0cfb08b22a874fcbe5181ea0d70"} -->
