### PR TITLE
LRCI-7844 Add flag to run controller builds concurrently per SHA

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunner.java
@@ -36,26 +36,31 @@ public abstract class BasePortalControllerBuildRunner
 	public void run() {
 		retirePreviousBuilds();
 
+		if (allowConcurrentBuildsUniqueSHA()) {
+			if (previousBuildHasCurrentSHA()) {
+				_updateBuildDescription();
+
+				return;
+			}
+
+			invokeBuild();
+
+			return;
+		}
+
 		if (allowConcurrentBuilds() || expirePreviousBuild()) {
 			invokeBuild();
 
 			return;
 		}
 
-		S buildData = getBuildData();
-
 		if (previousBuildHasCurrentSHA()) {
-			buildData.setBuildDescription(
-				JenkinsResultsParserUtil.combine(
-					"<strong>SKIPPED</strong> - <a href=\"https://github.com/",
-					"liferay/", buildData.getPortalGitHubRepositoryName(),
-					"/commit/", buildData.getPortalBranchSHA(), "\">",
-					getPortalBranchAbbreviatedSHA(), "</a> was already ran"));
-
-			super.updateBuildDescription();
+			_updateBuildDescription();
 
 			return;
 		}
+
+		S buildData = getBuildData();
 
 		if (previousBuildHasExistingInvocation()) {
 			buildData.setBuildDescription(
@@ -94,6 +99,22 @@ public abstract class BasePortalControllerBuildRunner
 		allowConcurrentBuildsString = allowConcurrentBuildsString.trim();
 
 		return allowConcurrentBuildsString.equals("true");
+	}
+
+	protected boolean allowConcurrentBuildsUniqueSHA() {
+		String allowConcurrentBuildsUniqueSHAString = Environment.get(
+			"ALLOW_CONCURRENT_BUILDS_UNIQUE_SHA");
+
+		if (allowConcurrentBuildsUniqueSHAString == null) {
+			return false;
+		}
+
+		allowConcurrentBuildsUniqueSHAString =
+			allowConcurrentBuildsUniqueSHAString.toLowerCase();
+		allowConcurrentBuildsUniqueSHAString =
+			allowConcurrentBuildsUniqueSHAString.trim();
+
+		return allowConcurrentBuildsUniqueSHAString.equals("true");
 	}
 
 	protected boolean expirePreviousBuild() {
@@ -372,6 +393,19 @@ public abstract class BasePortalControllerBuildRunner
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
 		}
+	}
+
+	private void _updateBuildDescription() {
+		S buildData = getBuildData();
+
+		buildData.setBuildDescription(
+			JenkinsResultsParserUtil.combine(
+				"<strong>SKIPPED</strong> - <a href=\"https://github.com/",
+				"liferay/", buildData.getPortalGitHubRepositoryName(),
+				"/commit/", buildData.getPortalBranchSHA(), "\">",
+				getPortalBranchAbbreviatedSHA(), "</a> was already ran"));
+
+		super.updateBuildDescription();
 	}
 
 	private static final Integer _CONTROLLER_BUILD_TIMEOUT_DEFAULT =

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -63,20 +63,6 @@ public class BaseDownstreamBuildTest
 		Element upstreamJobFailureElement = Dom4JUtil.getNewElement(
 			"code", null, upstreamJobFailureMarker);
 
-		Mockito.when(
-			baseDownstreamBuild.getTestResultGitHubElements(
-				Mockito.anyList(), Mockito.eq(true))
-		).thenReturn(
-			Arrays.asList(uniqueFailureElement)
-		);
-
-		Mockito.when(
-			baseDownstreamBuild.getTestResultGitHubElements(
-				Mockito.anyList(), Mockito.eq(false))
-		).thenReturn(
-			Arrays.asList(upstreamJobFailureElement)
-		);
-
 		Mockito.doCallRealMethod(
 		).when(
 			baseDownstreamBuild
@@ -86,6 +72,20 @@ public class BaseDownstreamBuildTest
 		).when(
 			baseDownstreamBuild
 		).getGitHubMessageUpstreamJobFailureElement();
+
+		Mockito.when(
+			baseDownstreamBuild.getTestResultGitHubElements(
+				Mockito.anyList(), Mockito.eq(false))
+		).thenReturn(
+			Arrays.asList(upstreamJobFailureElement)
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getTestResultGitHubElements(
+				Mockito.anyList(), Mockito.eq(true))
+		).thenReturn(
+			Arrays.asList(uniqueFailureElement)
+		);
 
 		Element gitHubMessageElement =
 			baseDownstreamBuild.getGitHubMessageElement();

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import org.junit.Test;
+
+import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
+
+/**
+ * @author Kenji Heigel
+ */
+public class BasePortalControllerBuildRunnerTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testRun() {
+		_testRun("false");
+		_testRun("true");
+	}
+
+	private void _testRun(String allowConcurrentBuildsUniqueSHAString) {
+		Environment environment = Mockito.mock(Environment.class);
+
+		Environment.setInstance(environment);
+
+		Mockito.when(
+			environment.doGet("ALLOW_CONCURRENT_BUILDS_UNIQUE_SHA")
+		).thenReturn(
+			allowConcurrentBuildsUniqueSHAString
+		);
+
+		BasePortalControllerBuildRunner<?> basePortalControllerBuildRunner =
+			Mockito.mock(BasePortalControllerBuildRunner.class);
+
+		Mockito.doReturn(
+			false
+		).when(
+			basePortalControllerBuildRunner
+		).previousBuildHasCurrentSHA();
+
+		Mockito.doCallRealMethod(
+		).when(
+			basePortalControllerBuildRunner
+		).allowConcurrentBuildsUniqueSHA();
+
+		Mockito.doCallRealMethod(
+		).when(
+			basePortalControllerBuildRunner
+		).run();
+
+		basePortalControllerBuildRunner.run();
+
+		VerificationMode verificationMode = Mockito.times(1);
+
+		if (allowConcurrentBuildsUniqueSHAString.equals("true")) {
+			verificationMode = Mockito.never();
+		}
+
+		Mockito.verify(
+			basePortalControllerBuildRunner, verificationMode
+		).allowConcurrentBuilds();
+
+		Mockito.verify(
+			basePortalControllerBuildRunner
+		).invokeBuild();
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
@@ -36,12 +36,6 @@ public class BasePortalControllerBuildRunnerTest
 		BasePortalControllerBuildRunner<?> basePortalControllerBuildRunner =
 			Mockito.mock(BasePortalControllerBuildRunner.class);
 
-		Mockito.doReturn(
-			false
-		).when(
-			basePortalControllerBuildRunner
-		).previousBuildHasCurrentSHA();
-
 		Mockito.doCallRealMethod(
 		).when(
 			basePortalControllerBuildRunner
@@ -51,6 +45,12 @@ public class BasePortalControllerBuildRunnerTest
 		).when(
 			basePortalControllerBuildRunner
 		).run();
+
+		Mockito.doReturn(
+			false
+		).when(
+			basePortalControllerBuildRunner
+		).previousBuildHasCurrentSHA();
 
 		basePortalControllerBuildRunner.run();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectoryTest.java
@@ -66,16 +66,16 @@ public class PortalGitWorkingDirectoryTest
 		PortalGitWorkingDirectory portalGitWorkingDirectory = Mockito.mock(
 			PortalGitWorkingDirectory.class);
 
+		Mockito.doCallRealMethod(
+		).when(
+			portalGitWorkingDirectory
+		).getFilteredEnvironment();
+
 		Mockito.when(
 			portalGitWorkingDirectory.getUpstreamBranchName()
 		).thenReturn(
 			upstreamBranchName
 		);
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalGitWorkingDirectory
-		).getFilteredEnvironment();
 
 		return portalGitWorkingDirectory.getFilteredEnvironment();
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -71,6 +71,26 @@ public class PortalWorkspaceGitRepositoryTest
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
 			Mockito.mock(PortalWorkspaceGitRepository.class);
 
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).prepareGitWorkingDirectory();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUp();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpBinariesCache();
+
 		Mockito.doReturn(
 			workingDirectory
 		).when(
@@ -106,26 +126,6 @@ public class PortalWorkspaceGitRepositoryTest
 		).when(
 			portalWorkspaceGitRepository
 		).isBinariesCacheEnabled();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).prepareGitWorkingDirectory();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUp();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUpAdditionalCaches();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUpBinariesCache();
 
 		portalWorkspaceGitRepository.setUp();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/testray/BaseTestrayAttachmentUploaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/testray/BaseTestrayAttachmentUploaderTest.java
@@ -39,6 +39,16 @@ public class BaseTestrayAttachmentUploaderTest
 		BaseTestrayAttachmentUploader baseTestrayAttachmentUploader =
 			Mockito.mock(BaseTestrayAttachmentUploader.class);
 
+		Mockito.doCallRealMethod(
+		).when(
+			baseTestrayAttachmentUploader
+		).getPreparedFiles();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseTestrayAttachmentUploader
+		).prepareFiles();
+
 		Mockito.when(
 			baseTestrayAttachmentUploader.getPreparedFilesBaseDir()
 		).thenReturn(
@@ -50,16 +60,6 @@ public class BaseTestrayAttachmentUploaderTest
 		).thenReturn(
 			testrayAttachmentRecorder
 		);
-
-		Mockito.doCallRealMethod(
-		).when(
-			baseTestrayAttachmentUploader
-		).getPreparedFiles();
-
-		Mockito.doCallRealMethod(
-		).when(
-			baseTestrayAttachmentUploader
-		).prepareFiles();
 
 		baseTestrayAttachmentUploader.prepareFiles();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7844

## What Is Being Fixed

The bundles controller pre-builds portal SHAs on a `*/10` cron so that downstream upstream-testsuite jobs start with a warm bundle instead of paying the cold-start penalty. Today `BasePortalControllerBuildRunner.run()` self-skips with `SKIPPED - Job is already running` whenever the previous bundle build is still in flight, so only one SHA can be warmed at a time and the cron is effectively serialized behind each build. Flipping the existing `ALLOW_CONCURRENT_BUILDS` flag would let the controller run concurrently but also bypasses the same-SHA dedupe, so it re-triggers a build for an unchanged SHA on every tick.

## How It Is Being Fixed

A new `ALLOW_CONCURRENT_BUILDS_UNIQUE_SHA` environment flag is read by a new `allowConcurrentBuildsUniqueSHA()` accessor that mirrors `allowConcurrentBuilds()`. When the flag is set, `run()` takes a self-contained branch at the top: if a previous build already ran the current SHA it skips with the shared `was already ran` description, otherwise it invokes the build immediately, bypassing the `IN QUEUE` / `IN PROGRESS` in-flight guards. Distinct SHAs therefore warm concurrently while the same SHA is never launched twice, because the in-progress build's description carries the Git ID that `previousBuildHasCurrentSHA()` matches against. The change is additive and opt-in: with the flag unset, `run()` follows the original path unchanged, so every existing controller cohort, including the `master_analytics-cloud-*` jobs already running with `ALLOW_CONCURRENT_BUILDS=true`, behaves exactly as before. Only the `master_bundles` controller sets the new flag, in liferay-jenkins-ee.

This supersedes #4456, which was closed after review feedback to sort the Mockito stub run in `BasePortalControllerBuildRunnerTest` by stubbed method name. That block is now ordered `allowConcurrentBuildsUniqueSHA`, `previousBuildHasCurrentSHA`, `run`.

## PR Check

**pr-check: PASS** — tested on `ad51f0d267b7c275a62a134d8ea90bdd1415712d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ad51f0d267b7c275a62a134d8ea90bdd1415712d"} -->
