### PR TITLE
LRCI-7783 Add unit test coverage for BaseWorkspaceGitRepository

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -8,6 +8,7 @@ package com.liferay.jenkins.results.parser;
 import java.io.File;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -191,6 +192,36 @@ public class PortalWorkspaceGitRepositoryTest
 		);
 	}
 
+	@Test
+	public void testSetUpAdditionalCaches() throws Exception {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("binaries.cache.enabled", "false");
+		buildProperties.setProperty("binaries.cache.enabled[job*]", "true");
+		buildProperties.setProperty("binaries.cache.enabled[job-1]", "false");
+		buildProperties.setProperty("binaries.cache.enabled[suite*]", "true");
+		buildProperties.setProperty("binaries.cache.enabled[suite-1]", "false");
+		buildProperties.setProperty("binaries.cache.enabled[one][two]", "true");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		_testSetUpAdditionalCaches(false, null, null);
+
+		_testSetUpAdditionalCaches(true, "suite", null);
+		_testSetUpAdditionalCaches(true, "suite-0", null);
+		_testSetUpAdditionalCaches(false, "suite-1", null);
+		_testSetUpAdditionalCaches(false, "wrong", null);
+
+		_testSetUpAdditionalCaches(true, null, "job");
+		_testSetUpAdditionalCaches(true, null, "job-0");
+		_testSetUpAdditionalCaches(false, null, "job-1");
+		_testSetUpAdditionalCaches(false, null, "wrong");
+
+		_testSetUpAdditionalCaches(false, "one", null);
+		_testSetUpAdditionalCaches(false, null, "two");
+		_testSetUpAdditionalCaches(true, "one", "two");
+	}
+
 	private boolean _isCommand(
 		Shell.ExecutionRequest executionRequest, String... substrings) {
 
@@ -307,6 +338,48 @@ public class PortalWorkspaceGitRepositoryTest
 			bundleURL,
 			portalTestProperties.getProperty(
 				"test.released.test.portal.bundle.zip.url"));
+	}
+
+	private void _testSetUpAdditionalCaches(
+			boolean binariesCacheEnabled, String ciTestSuite, String jobName)
+		throws Exception {
+
+		Map<String, String> environmentValues = new HashMap<>();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(ciTestSuite)) {
+			environmentValues.put("CI_TEST_SUITE", ciTestSuite);
+		}
+
+		environmentValues.put("MASTER_NETWORK_NAME", "aws-network");
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(jobName)) {
+			environmentValues.put("JOB_NAME", jobName);
+		}
+
+		mockEnvironment(environmentValues);
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		portalWorkspaceGitRepository.setUpAdditionalCaches();
+
+		if (binariesCacheEnabled) {
+			Assert.assertTrue(
+				portalWorkspaceGitRepository.isBinariesCacheEnabled());
+
+			Mockito.verify(
+				portalWorkspaceGitRepository, Mockito.times(1)
+			).setUpBinariesCache();
+
+			return;
+		}
+
+		Assert.assertFalse(
+			portalWorkspaceGitRepository.isBinariesCacheEnabled());
+
+		Mockito.verify(
+			portalWorkspaceGitRepository, Mockito.never()
+		).setUpBinariesCache();
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -187,6 +187,11 @@ public class PortalWorkspaceGitRepositoryTest
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
 			_newPortalWorkspaceGitRepository();
 
+		Mockito.doNothing(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpBinariesCache();
+
 		portalWorkspaceGitRepository.setUpAdditionalCaches();
 
 		if (binariesCacheEnabled) {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -99,12 +99,15 @@ public class PortalWorkspaceGitRepositoryTest
 
 		workingDirectory.mkdir();
 
+		String baseBranchSHA = RandomTestUtil.randomSHA();
+		String senderBranchSHA = RandomTestUtil.randomSHA();
+
 		JSONObject jsonObject = new JSONObject();
 
 		jsonObject.put(
-			"base_branch_head_sha", "1234567890123456789012345678901234567890"
+			"base_branch_head_sha", baseBranchSHA
 		).put(
-			"base_branch_sha", "1234567890123456789012345678901234567890"
+			"base_branch_sha", baseBranchSHA
 		).put(
 			"base_branch_username", RandomTestUtil.randomString()
 		).put(
@@ -117,11 +120,11 @@ public class PortalWorkspaceGitRepositoryTest
 		).put(
 			"name", "liferay-portal"
 		).put(
-			"sender_branch_head_sha", "0987654321098765432109876543210987654321"
+			"sender_branch_head_sha", senderBranchSHA
 		).put(
 			"sender_branch_name", "master"
 		).put(
-			"sender_branch_sha", "0987654321098765432109876543210987654321"
+			"sender_branch_sha", senderBranchSHA
 		).put(
 			"sender_branch_username", RandomTestUtil.randomString()
 		).put(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -106,7 +106,7 @@ public class PortalWorkspaceGitRepositoryTest
 		).put(
 			"base_branch_sha", "1234567890123456789012345678901234567890"
 		).put(
-			"base_branch_username", "liferay"
+			"base_branch_username", RandomTestUtil.randomString()
 		).put(
 			"directory",
 			JenkinsResultsParserUtil.getCanonicalPath(workingDirectory)
@@ -123,7 +123,7 @@ public class PortalWorkspaceGitRepositoryTest
 		).put(
 			"sender_branch_sha", "0987654321098765432109876543210987654321"
 		).put(
-			"sender_branch_username", "test"
+			"sender_branch_username", RandomTestUtil.randomString()
 		).put(
 			"upstream_branch_name", "master"
 		);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -105,10 +105,6 @@ public class PortalWorkspaceGitRepositoryTest
 
 		workingDirectory.mkdir();
 
-		File gitDirectory = new File(workingDirectory, ".git");
-
-		gitDirectory.mkdir();
-
 		JSONObject jsonObject = new JSONObject();
 
 		jsonObject.put(
@@ -138,33 +134,7 @@ public class PortalWorkspaceGitRepositoryTest
 			"upstream_branch_name", "master"
 		);
 
-		PortalWorkspaceGitRepository portalWorkspaceGitRepository = Mockito.spy(
-			new PortalWorkspaceGitRepository(jsonObject));
-
-		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
-			GitWorkingDirectory.class);
-
-		Mockito.doReturn(
-			gitWorkingDirectory
-		).when(
-			portalWorkspaceGitRepository
-		).getGitWorkingDirectory();
-
-		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
-
-		Mockito.doReturn(
-			"0987654321098765432109876543210987654321"
-		).when(
-			localGitBranch
-		).getSHA();
-
-		Mockito.doReturn(
-			localGitBranch
-		).when(
-			portalWorkspaceGitRepository
-		).getLocalGitBranch();
-
-		return portalWorkspaceGitRepository;
+		return Mockito.spy(new PortalWorkspaceGitRepository(jsonObject));
 	}
 
 	private void _testGetPortalTestProperties(
@@ -220,18 +190,12 @@ public class PortalWorkspaceGitRepositoryTest
 		portalWorkspaceGitRepository.setUpAdditionalCaches();
 
 		if (binariesCacheEnabled) {
-			Assert.assertTrue(
-				portalWorkspaceGitRepository.isBinariesCacheEnabled());
-
 			Mockito.verify(
 				portalWorkspaceGitRepository, Mockito.times(1)
 			).setUpBinariesCache();
 
 			return;
 		}
-
-		Assert.assertFalse(
-			portalWorkspaceGitRepository.isBinariesCacheEnabled());
 
 		Mockito.verify(
 			portalWorkspaceGitRepository, Mockito.never()

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -8,8 +8,11 @@ package com.liferay.jenkins.results.parser;
 import java.io.File;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
+import org.json.JSONObject;
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.mockito.Mockito;
@@ -19,6 +22,47 @@ import org.mockito.Mockito;
  */
 public class PortalWorkspaceGitRepositoryTest
 	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetPortalTestProperties() throws Exception {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("portal.bundle.tomcat[version.0]", "url.0");
+		buildProperties.setProperty(
+			"portal.latest.bundle.version", "version.0");
+
+		buildProperties.setProperty("portal.bundle.tomcat[version.1]", "url.1");
+		buildProperties.setProperty(
+			"portal.latest.bundle.version[master]", "version.1");
+
+		buildProperties.setProperty("portal.bundle.tomcat[version.2]", "url.2");
+		buildProperties.setProperty(
+			"portal.latest.bundle.version[7.0.x]", "version.2");
+
+		buildProperties.setProperty(
+			"portal.bundle.tomcat[version.env]", "url.env");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Map<String, String> environmentValues = Collections.emptyMap();
+
+		_testGetPortalTestProperties(
+			"url.0", "version.0", environmentValues, null);
+		_testGetPortalTestProperties(
+			"url.1", "version.1", environmentValues, "master");
+		_testGetPortalTestProperties(
+			"url.2", "version.2", environmentValues, "7.0.x");
+
+		environmentValues = Collections.singletonMap(
+			"PORTAL_LATEST_BUNDLE_VERSION", "version.env");
+
+		_testGetPortalTestProperties(
+			"url.env", "version.env", environmentValues, null);
+		_testGetPortalTestProperties(
+			"url.env", "version.env", environmentValues, "master");
+		_testGetPortalTestProperties(
+			"url.env", "version.env", environmentValues, "7.0.x");
+	}
 
 	@Test
 	public void testSetUp() throws Exception {
@@ -163,6 +207,106 @@ public class PortalWorkspaceGitRepositoryTest
 		}
 
 		return true;
+	}
+
+	private PortalWorkspaceGitRepository _newPortalWorkspaceGitRepository()
+		throws Exception {
+
+		File workingDirectory = File.createTempFile("portal-workspace-", null);
+
+		workingDirectory.delete();
+
+		workingDirectory.mkdir();
+
+		File gitDirectory = new File(workingDirectory, ".git");
+
+		gitDirectory.mkdir();
+
+		JSONObject jsonObject = new JSONObject();
+
+		jsonObject.put(
+			"base_branch_head_sha", "1234567890123456789012345678901234567890"
+		).put(
+			"base_branch_sha", "1234567890123456789012345678901234567890"
+		).put(
+			"base_branch_username", "liferay"
+		).put(
+			"directory",
+			JenkinsResultsParserUtil.getCanonicalPath(workingDirectory)
+		).put(
+			"directory_name", "liferay-portal"
+		).put(
+			"git_hub_url", "https://github.com/liferay/liferay-portal"
+		).put(
+			"name", "liferay-portal"
+		).put(
+			"sender_branch_head_sha", "0987654321098765432109876543210987654321"
+		).put(
+			"sender_branch_name", "master"
+		).put(
+			"sender_branch_sha", "0987654321098765432109876543210987654321"
+		).put(
+			"sender_branch_username", "test"
+		).put(
+			"upstream_branch_name", "master"
+		);
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository = Mockito.spy(
+			new PortalWorkspaceGitRepository(jsonObject));
+
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		Mockito.doReturn(
+			gitWorkingDirectory
+		).when(
+			portalWorkspaceGitRepository
+		).getGitWorkingDirectory();
+
+		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
+
+		Mockito.doReturn(
+			"0987654321098765432109876543210987654321"
+		).when(
+			localGitBranch
+		).getSHA();
+
+		Mockito.doReturn(
+			localGitBranch
+		).when(
+			portalWorkspaceGitRepository
+		).getLocalGitBranch();
+
+		return portalWorkspaceGitRepository;
+	}
+
+	private void _testGetPortalTestProperties(
+			String bundleURL, String bundleVersion,
+			Map<String, String> environmentValues, String upstreamBranchName)
+		throws Exception {
+
+		mockEnvironment(environmentValues);
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doReturn(
+			upstreamBranchName
+		).when(
+			portalWorkspaceGitRepository
+		).getUpstreamBranchName();
+
+		Properties portalTestProperties =
+			portalWorkspaceGitRepository.getPortalTestProperties();
+
+		Assert.assertEquals(
+			bundleVersion,
+			portalTestProperties.getProperty(
+				"test.released.release.bundle.version"));
+		Assert.assertEquals(
+			bundleURL,
+			portalTestProperties.getProperty(
+				"test.released.test.portal.bundle.zip.url"));
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -30,19 +30,16 @@ public class PortalWorkspaceGitRepositoryTest
 		Properties buildProperties = new Properties();
 
 		buildProperties.setProperty("portal.bundle.tomcat[version.0]", "url.0");
-		buildProperties.setProperty(
-			"portal.latest.bundle.version", "version.0");
-
 		buildProperties.setProperty("portal.bundle.tomcat[version.1]", "url.1");
-		buildProperties.setProperty(
-			"portal.latest.bundle.version[master]", "version.1");
-
 		buildProperties.setProperty("portal.bundle.tomcat[version.2]", "url.2");
 		buildProperties.setProperty(
-			"portal.latest.bundle.version[7.0.x]", "version.2");
-
-		buildProperties.setProperty(
 			"portal.bundle.tomcat[version.env]", "url.env");
+		buildProperties.setProperty(
+			"portal.latest.bundle.version", "version.0");
+		buildProperties.setProperty(
+			"portal.latest.bundle.version[7.0.x]", "version.2");
+		buildProperties.setProperty(
+			"portal.latest.bundle.version[master]", "version.1");
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
@@ -61,9 +58,9 @@ public class PortalWorkspaceGitRepositoryTest
 		_testGetPortalTestProperties(
 			"url.env", "version.env", environmentValues, null);
 		_testGetPortalTestProperties(
-			"url.env", "version.env", environmentValues, "master");
-		_testGetPortalTestProperties(
 			"url.env", "version.env", environmentValues, "7.0.x");
+		_testGetPortalTestProperties(
+			"url.env", "version.env", environmentValues, "master");
 	}
 
 	@Test
@@ -73,27 +70,24 @@ public class PortalWorkspaceGitRepositoryTest
 		buildProperties.setProperty("binaries.cache.enabled", "false");
 		buildProperties.setProperty("binaries.cache.enabled[job*]", "true");
 		buildProperties.setProperty("binaries.cache.enabled[job-1]", "false");
+		buildProperties.setProperty("binaries.cache.enabled[one][two]", "true");
 		buildProperties.setProperty("binaries.cache.enabled[suite*]", "true");
 		buildProperties.setProperty("binaries.cache.enabled[suite-1]", "false");
-		buildProperties.setProperty("binaries.cache.enabled[one][two]", "true");
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
 		_testSetUpAdditionalCaches(false, null, null);
-
-		_testSetUpAdditionalCaches(true, "suite", null);
-		_testSetUpAdditionalCaches(true, "suite-0", null);
+		_testSetUpAdditionalCaches(false, null, "job-1");
+		_testSetUpAdditionalCaches(false, null, "two");
+		_testSetUpAdditionalCaches(false, null, "wrong");
+		_testSetUpAdditionalCaches(false, "one", null);
 		_testSetUpAdditionalCaches(false, "suite-1", null);
 		_testSetUpAdditionalCaches(false, "wrong", null);
-
 		_testSetUpAdditionalCaches(true, null, "job");
 		_testSetUpAdditionalCaches(true, null, "job-0");
-		_testSetUpAdditionalCaches(false, null, "job-1");
-		_testSetUpAdditionalCaches(false, null, "wrong");
-
-		_testSetUpAdditionalCaches(false, "one", null);
-		_testSetUpAdditionalCaches(false, null, "two");
 		_testSetUpAdditionalCaches(true, "one", "two");
+		_testSetUpAdditionalCaches(true, "suite", null);
+		_testSetUpAdditionalCaches(true, "suite-0", null);
 	}
 
 	private PortalWorkspaceGitRepository _newPortalWorkspaceGitRepository()
@@ -157,13 +151,13 @@ public class PortalWorkspaceGitRepositoryTest
 			portalWorkspaceGitRepository.getPortalTestProperties();
 
 		Assert.assertEquals(
-			bundleVersion,
-			portalTestProperties.getProperty(
-				"test.released.release.bundle.version"));
-		Assert.assertEquals(
 			bundleURL,
 			portalTestProperties.getProperty(
 				"test.released.test.portal.bundle.zip.url"));
+		Assert.assertEquals(
+			bundleVersion,
+			portalTestProperties.getProperty(
+				"test.released.release.bundle.version"));
 	}
 
 	private void _testSetUpAdditionalCaches(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.json.JSONObject;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -66,133 +67,6 @@ public class PortalWorkspaceGitRepositoryTest
 	}
 
 	@Test
-	public void testSetUp() throws Exception {
-		File workingDirectory = File.createTempFile("portal-workspace-", null);
-
-		workingDirectory.delete();
-
-		workingDirectory.mkdir();
-
-		File gitDirectory = new File(workingDirectory, ".git");
-
-		gitDirectory.mkdir();
-
-		mockEnvironment(
-			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
-
-		Properties buildProperties = new Properties();
-
-		buildProperties.setProperty(
-			"binaries.cache.s3.path",
-			"s3://liferayci-file-propagator/binaries-cache/master.tar.gz");
-		buildProperties.setProperty("git.archive.enabled", "true");
-
-		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
-
-		BuildDatabaseUtil.setBuildDatabase(
-			BuildDatabaseTestUtil.newBuildDatabaseWithPullRequest());
-
-		Shell shell = mockShell();
-
-		Mockito.doReturn(
-			new Shell.ExecutionResult(0, "", "")
-		).when(
-			shell
-		).doExecute(
-			Mockito.any(Shell.ExecutionRequest.class)
-		);
-
-		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
-
-		Mockito.doReturn(
-			"1234567890123456789012345678901234567890"
-		).when(
-			localGitBranch
-		).getSHA();
-
-		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
-			GitWorkingDirectory.class);
-
-		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			Mockito.mock(PortalWorkspaceGitRepository.class);
-
-		Mockito.doReturn(
-			workingDirectory
-		).when(
-			portalWorkspaceGitRepository
-		).getDirectory();
-
-		Mockito.doReturn(
-			"liferay-portal"
-		).when(
-			portalWorkspaceGitRepository
-		).getDirectoryName();
-
-		Mockito.doReturn(
-			gitWorkingDirectory
-		).when(
-			portalWorkspaceGitRepository
-		).getGitWorkingDirectory();
-
-		Mockito.doReturn(
-			localGitBranch
-		).when(
-			portalWorkspaceGitRepository
-		).getLocalGitBranch();
-
-		Mockito.doReturn(
-			"master"
-		).when(
-			portalWorkspaceGitRepository
-		).getUpstreamBranchName();
-
-		Mockito.doReturn(
-			true
-		).when(
-			portalWorkspaceGitRepository
-		).isBinariesCacheEnabled();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).prepareGitWorkingDirectory();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUp();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUpAdditionalCaches();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUpBinariesCache();
-
-		portalWorkspaceGitRepository.setUp();
-
-		Mockito.verify(
-			shell
-		).doExecute(
-			Mockito.argThat(
-				executionRequest -> _isCommand(
-					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
-		);
-
-		Mockito.verify(
-			shell
-		).doExecute(
-			Mockito.argThat(
-				executionRequest -> _isCommand(
-					executionRequest, "tar --directory=",
-					"binaries-cache.tar.gz"))
-		);
-	}
-
-	@Test
 	public void testSetUpAdditionalCaches() throws Exception {
 		Properties buildProperties = new Properties();
 
@@ -220,24 +94,6 @@ public class PortalWorkspaceGitRepositoryTest
 		_testSetUpAdditionalCaches(false, "one", null);
 		_testSetUpAdditionalCaches(false, null, "two");
 		_testSetUpAdditionalCaches(true, "one", "two");
-	}
-
-	private boolean _isCommand(
-		Shell.ExecutionRequest executionRequest, String... substrings) {
-
-		if (executionRequest == null) {
-			return false;
-		}
-
-		String command = executionRequest.getCommands()[0];
-
-		for (String substring : substrings) {
-			if (!command.contains(substring)) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 
 	private PortalWorkspaceGitRepository _newPortalWorkspaceGitRepository()

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RandomTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RandomTestUtil.java
@@ -21,6 +21,16 @@ public class RandomTestUtil {
 		return _random.nextLong();
 	}
 
+	public static String randomSHA() {
+		StringBuilder sb = new StringBuilder(40);
+
+		for (int i = 0; i < 40; i++) {
+			sb.append(Integer.toHexString(_random.nextInt(16)));
+		}
+
+		return sb.toString();
+	}
+
 	public static String randomString() {
 		UUID uuid = UUID.randomUUID();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -7,7 +7,11 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.json.JSONObject;
 
@@ -91,6 +95,53 @@ public class WorkspaceGitRepositoryTest
 		Assert.assertFalse(_isSnapshotAfterPromoteGitArchive(false, false));
 	}
 
+	@Test
+	public void testSnapshotStateAfterUploadGitArchives() throws Exception {
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("top-level-job", true, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("top-level-job", true, false));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("top-level-job", false, true));
+		Assert.assertFalse(
+			_isSnapshotAfterUploadGitArchives("top-level-job", false, false));
+
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("downstream-job", true, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("downstream-job", true, false));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("downstream-job", false, true));
+		Assert.assertFalse(
+			_isSnapshotAfterUploadGitArchives("downstream-job", false, false));
+
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool", true, true));
+		Assert.assertFalse(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool", true, false));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool", false, true));
+		Assert.assertFalse(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool", false, false));
+
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool-batch", true, true));
+		Assert.assertFalse(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool-batch", true, false));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool-batch", false, true));
+		Assert.assertFalse(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool-batch", false, false));
+	}
+
 	private boolean _isFullDotGitDirArchiveRequired(String workingDirectoryName)
 		throws Exception {
 
@@ -138,6 +189,83 @@ public class WorkspaceGitRepositoryTest
 		defaultWorkspaceGitRepository.setSnapshot(snapshot);
 
 		defaultWorkspaceGitRepository.promoteGitArchive();
+
+		return defaultWorkspaceGitRepository.isSnapshot();
+	}
+
+	private boolean _isSnapshotAfterUploadGitArchives(
+			String jobName, boolean gitArchiveEnabled, boolean snapshot)
+		throws Exception {
+
+		Map<String, String> environmentValues = new HashMap<>();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(jobName)) {
+			environmentValues.put("JOB_NAME", jobName);
+		}
+
+		environmentValues.put("MASTER_NETWORK_NAME", "aws-network");
+
+		mockEnvironment(environmentValues);
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"git.archive.enabled", String.valueOf(gitArchiveEnabled));
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Set<String> topLevelJobNames = new HashSet<>();
+
+		topLevelJobNames.add("root-cause-analysis-tool");
+		topLevelJobNames.add("top-level-job");
+
+		JenkinsResultsParserUtil.setTopLevelJobNames(topLevelJobNames);
+
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
+			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+
+		Mockito.doNothing(
+		).when(
+			defaultWorkspaceGitRepository
+		).uploadGitArchive();
+
+		Mockito.doNothing(
+		).when(
+			defaultWorkspaceGitRepository
+		).uploadDotGitArchive();
+
+		Mockito.doNothing(
+		).when(
+			defaultWorkspaceGitRepository
+		).updateBuildDatabase();
+
+		defaultWorkspaceGitRepository.setSnapshot(snapshot);
+
+		defaultWorkspaceGitRepository.uploadGitArchives();
+
+		if (gitArchiveEnabled && !snapshot &&
+			topLevelJobNames.contains(jobName)) {
+
+			Mockito.verify(
+				defaultWorkspaceGitRepository, Mockito.times(1)
+			).uploadGitArchive();
+
+			Mockito.verify(
+				defaultWorkspaceGitRepository, Mockito.times(1)
+			).uploadDotGitArchive();
+		}
+		else {
+			Mockito.verify(
+				defaultWorkspaceGitRepository, Mockito.never()
+			).uploadGitArchive();
+
+			Mockito.verify(
+				defaultWorkspaceGitRepository, Mockito.never()
+			).uploadDotGitArchive();
+		}
 
 		return defaultWorkspaceGitRepository.isSnapshot();
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -14,6 +14,7 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 /**
@@ -39,6 +40,47 @@ public class WorkspaceGitRepositoryTest
 		_testPrepareGitWorkingDirectory(true, false);
 		_testPrepareGitWorkingDirectory(false, true);
 		_testPrepareGitWorkingDirectory(false, false);
+	}
+
+	@Test
+	public void testSetUp() throws Exception {
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
+			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+
+		Mockito.doNothing(
+		).when(
+			defaultWorkspaceGitRepository
+		).prepareGitWorkingDirectory();
+
+		Mockito.doNothing(
+		).when(
+			defaultWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
+		Mockito.doNothing(
+		).when(
+			defaultWorkspaceGitRepository
+		).uploadGitArchives();
+
+		defaultWorkspaceGitRepository.setUp();
+		defaultWorkspaceGitRepository.setUp();
+
+		InOrder inOrder = Mockito.inOrder(defaultWorkspaceGitRepository);
+
+		inOrder.verify(
+			defaultWorkspaceGitRepository, Mockito.times(1)
+		).prepareGitWorkingDirectory();
+
+		inOrder.verify(
+			defaultWorkspaceGitRepository, Mockito.times(1)
+		).setUpAdditionalCaches();
+
+		inOrder.verify(
+			defaultWorkspaceGitRepository, Mockito.times(1)
+		).uploadGitArchives();
 	}
 
 	private boolean _isFullDotGitDirArchiveRequired(String workingDirectoryName)

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -142,6 +142,47 @@ public class WorkspaceGitRepositoryTest
 				"root-cause-analysis-tool-batch", false, false));
 	}
 
+	@Test
+	public void testValidateSHAInRemoteGitRef() throws Exception {
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
+		RemoteGitRef remoteGitRef = Mockito.mock(RemoteGitRef.class);
+
+		Mockito.when(
+			gitWorkingDirectory.fetch(remoteGitRef)
+		).thenReturn(
+			localGitBranch
+		);
+
+		Mockito.when(
+			gitWorkingDirectory.refContainsSHA(localGitBranch, null)
+		).thenReturn(
+			true
+		);
+
+		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
+			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+
+		defaultWorkspaceGitRepository.validateSHAInRemoteGitRef(
+			"master", remoteGitRef, null);
+
+		InOrder inOrder = Mockito.inOrder(gitWorkingDirectory);
+
+		inOrder.verify(
+			gitWorkingDirectory
+		).fetch(
+			remoteGitRef
+		);
+
+		inOrder.verify(
+			gitWorkingDirectory
+		).refContainsSHA(
+			localGitBranch, null
+		);
+	}
+
 	private boolean _isFullDotGitDirArchiveRequired(String workingDirectoryName)
 		throws Exception {
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -47,6 +47,14 @@ public class WorkspaceGitRepositoryTest
 	}
 
 	@Test
+	public void testPromoteGitArchive() throws Exception {
+		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(true, true));
+		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(true, false));
+		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(false, true));
+		Assert.assertFalse(_isSnapshotAfterPromoteGitArchive(false, false));
+	}
+
+	@Test
 	public void testSetUp() throws Exception {
 		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
 			_newDefaultWorkspaceGitRepository();
@@ -97,15 +105,7 @@ public class WorkspaceGitRepositoryTest
 	}
 
 	@Test
-	public void testSnapshotStateAfterPromoteGitArchive() throws Exception {
-		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(true, true));
-		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(true, false));
-		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(false, true));
-		Assert.assertFalse(_isSnapshotAfterPromoteGitArchive(false, false));
-	}
-
-	@Test
-	public void testSnapshotStateAfterUploadGitArchives() throws Exception {
+	public void testUploadGitArchives() throws Exception {
 		Assert.assertTrue(
 			_isSnapshotAfterUploadGitArchives("top-level-job", true, true));
 		Assert.assertTrue(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -29,29 +29,29 @@ public class WorkspaceGitRepositoryTest
 
 	@Test
 	public void testIsFullDotGitDirArchiveRequired() throws Exception {
+		Assert.assertFalse(_isFullDotGitDirArchiveRequired("liferay-portal"));
+		Assert.assertFalse(
+			_isFullDotGitDirArchiveRequired("liferay-portal-7.0.x"));
 		Assert.assertTrue(
 			_isFullDotGitDirArchiveRequired("liferay-plugins-ee-6.2.x"));
 		Assert.assertTrue(
 			_isFullDotGitDirArchiveRequired("liferay-portal-ee-6.2.x"));
-		Assert.assertFalse(_isFullDotGitDirArchiveRequired("liferay-portal"));
-		Assert.assertFalse(
-			_isFullDotGitDirArchiveRequired("liferay-portal-7.0.x"));
 	}
 
 	@Test
 	public void testPrepareGitWorkingDirectory() throws Exception {
-		_testPrepareGitWorkingDirectory(true, true);
-		_testPrepareGitWorkingDirectory(true, false);
-		_testPrepareGitWorkingDirectory(false, true);
 		_testPrepareGitWorkingDirectory(false, false);
+		_testPrepareGitWorkingDirectory(false, true);
+		_testPrepareGitWorkingDirectory(true, false);
+		_testPrepareGitWorkingDirectory(true, true);
 	}
 
 	@Test
 	public void testPromoteGitArchive() throws Exception {
-		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(true, true));
-		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(true, false));
-		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(false, true));
 		Assert.assertFalse(_isSnapshotAfterPromoteGitArchive(false, false));
+		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(false, true));
+		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(true, false));
+		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(true, true));
 	}
 
 	@Test
@@ -106,49 +106,46 @@ public class WorkspaceGitRepositoryTest
 
 	@Test
 	public void testUploadGitArchives() throws Exception {
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("top-level-job", true, true));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("top-level-job", true, false));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("top-level-job", false, true));
-		Assert.assertFalse(
-			_isSnapshotAfterUploadGitArchives("top-level-job", false, false));
-
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("downstream-job", true, true));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("downstream-job", true, false));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("downstream-job", false, true));
 		Assert.assertFalse(
 			_isSnapshotAfterUploadGitArchives("downstream-job", false, false));
-
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool", true, true));
-		Assert.assertFalse(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool", true, false));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool", false, true));
 		Assert.assertFalse(
 			_isSnapshotAfterUploadGitArchives(
 				"root-cause-analysis-tool", false, false));
-
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool-batch", true, true));
 		Assert.assertFalse(
 			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool-batch", true, false));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool-batch", false, true));
+				"root-cause-analysis-tool", true, false));
 		Assert.assertFalse(
 			_isSnapshotAfterUploadGitArchives(
 				"root-cause-analysis-tool-batch", false, false));
+		Assert.assertFalse(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool-batch", true, false));
+		Assert.assertFalse(
+			_isSnapshotAfterUploadGitArchives("top-level-job", false, false));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("downstream-job", false, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("downstream-job", true, false));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("downstream-job", true, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool", false, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool", true, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool-batch", false, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(
+				"root-cause-analysis-tool-batch", true, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("top-level-job", false, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("top-level-job", true, false));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives("top-level-job", true, true));
 	}
 
 	@Test
@@ -229,12 +226,6 @@ public class WorkspaceGitRepositoryTest
 		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
 			_newDefaultWorkspaceGitRepository();
 
-		Mockito.doReturn(
-			gitArchiveAvailable
-		).when(
-			defaultWorkspaceGitRepository
-		).isGitArchivesAvailable();
-
 		Mockito.doNothing(
 		).when(
 			defaultWorkspaceGitRepository
@@ -244,6 +235,12 @@ public class WorkspaceGitRepositoryTest
 		).when(
 			defaultWorkspaceGitRepository
 		).updateBuildDatabase();
+
+		Mockito.doReturn(
+			gitArchiveAvailable
+		).when(
+			defaultWorkspaceGitRepository
+		).isGitArchivesAvailable();
 
 		defaultWorkspaceGitRepository.setSnapshot(snapshot);
 
@@ -286,7 +283,7 @@ public class WorkspaceGitRepositoryTest
 		Mockito.doNothing(
 		).when(
 			defaultWorkspaceGitRepository
-		).uploadGitArchive();
+		).updateBuildDatabase();
 
 		Mockito.doNothing(
 		).when(
@@ -296,7 +293,7 @@ public class WorkspaceGitRepositoryTest
 		Mockito.doNothing(
 		).when(
 			defaultWorkspaceGitRepository
-		).updateBuildDatabase();
+		).uploadGitArchive();
 
 		defaultWorkspaceGitRepository.setSnapshot(snapshot);
 
@@ -307,20 +304,20 @@ public class WorkspaceGitRepositoryTest
 
 			Mockito.verify(
 				defaultWorkspaceGitRepository, Mockito.times(1)
-			).uploadGitArchive();
+			).uploadDotGitArchive();
 
 			Mockito.verify(
 				defaultWorkspaceGitRepository, Mockito.times(1)
-			).uploadDotGitArchive();
+			).uploadGitArchive();
 		}
 		else {
 			Mockito.verify(
 				defaultWorkspaceGitRepository, Mockito.never()
-			).uploadGitArchive();
+			).uploadDotGitArchive();
 
 			Mockito.verify(
 				defaultWorkspaceGitRepository, Mockito.never()
-			).uploadDotGitArchive();
+			).uploadGitArchive();
 		}
 
 		return defaultWorkspaceGitRepository.isSnapshot();
@@ -386,12 +383,6 @@ public class WorkspaceGitRepositoryTest
 			defaultWorkspaceGitRepository
 		).downloadGitArchives();
 
-		Mockito.doReturn(
-			snapshot
-		).when(
-			defaultWorkspaceGitRepository
-		).isSnapshot();
-
 		Mockito.doNothing(
 		).when(
 			defaultWorkspaceGitRepository
@@ -401,6 +392,12 @@ public class WorkspaceGitRepositoryTest
 		).when(
 			defaultWorkspaceGitRepository
 		).promoteGitArchive();
+
+		Mockito.doReturn(
+			snapshot
+		).when(
+			defaultWorkspaceGitRepository
+		).isSnapshot();
 
 		defaultWorkspaceGitRepository.prepareGitWorkingDirectory();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -332,15 +332,17 @@ public class WorkspaceGitRepositoryTest
 
 		workingDirectory.mkdir();
 
+		String baseBranchSHA = RandomTestUtil.randomSHA();
 		String baseBranchUsername = RandomTestUtil.randomString();
 		String repositoryName = RandomTestUtil.randomString();
+		String senderBranchSHA = RandomTestUtil.randomSHA();
 
 		JSONObject jsonObject = new JSONObject();
 
 		jsonObject.put(
-			"base_branch_head_sha", "1234567890123456789012345678901234567890"
+			"base_branch_head_sha", baseBranchSHA
 		).put(
-			"base_branch_sha", "1234567890123456789012345678901234567890"
+			"base_branch_sha", baseBranchSHA
 		).put(
 			"base_branch_username", baseBranchUsername
 		).put(
@@ -355,11 +357,11 @@ public class WorkspaceGitRepositoryTest
 		).put(
 			"name", repositoryName
 		).put(
-			"sender_branch_head_sha", "0987654321098765432109876543210987654321"
+			"sender_branch_head_sha", senderBranchSHA
 		).put(
 			"sender_branch_name", "master"
 		).put(
-			"sender_branch_sha", "0987654321098765432109876543210987654321"
+			"sender_branch_sha", senderBranchSHA
 		).put(
 			"sender_branch_username", RandomTestUtil.randomString()
 		).put(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -107,46 +107,49 @@ public class WorkspaceGitRepositoryTest
 
 	@Test
 	public void testUploadGitArchives() throws Exception {
+		String jobName = "downstream-job";
+
 		Assert.assertFalse(
-			_isSnapshotAfterUploadGitArchives("downstream-job", false, false));
+			_isSnapshotAfterUploadGitArchives(jobName, false, false));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(jobName, false, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(jobName, true, false));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(jobName, true, true));
+
+		jobName = "root-cause-analysis-tool";
+
 		Assert.assertFalse(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool", false, false));
+			_isSnapshotAfterUploadGitArchives(jobName, false, false));
 		Assert.assertFalse(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool", true, false));
+			_isSnapshotAfterUploadGitArchives(jobName, true, false));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(jobName, false, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(jobName, true, true));
+
+		jobName = "root-cause-analysis-tool-batch";
+
 		Assert.assertFalse(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool-batch", false, false));
+			_isSnapshotAfterUploadGitArchives(jobName, false, false));
 		Assert.assertFalse(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool-batch", true, false));
+			_isSnapshotAfterUploadGitArchives(jobName, true, false));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(jobName, false, true));
+		Assert.assertTrue(
+			_isSnapshotAfterUploadGitArchives(jobName, true, true));
+
+		jobName = "top-level-job";
+
 		Assert.assertFalse(
-			_isSnapshotAfterUploadGitArchives("top-level-job", false, false));
+			_isSnapshotAfterUploadGitArchives(jobName, false, false));
 		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("downstream-job", false, true));
+			_isSnapshotAfterUploadGitArchives(jobName, false, true));
 		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("downstream-job", true, false));
+			_isSnapshotAfterUploadGitArchives(jobName, true, false));
 		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("downstream-job", true, true));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool", false, true));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool", true, true));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool-batch", false, true));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives(
-				"root-cause-analysis-tool-batch", true, true));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("top-level-job", false, true));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("top-level-job", true, false));
-		Assert.assertTrue(
-			_isSnapshotAfterUploadGitArchives("top-level-job", true, true));
+			_isSnapshotAfterUploadGitArchives(jobName, true, true));
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -332,6 +332,9 @@ public class WorkspaceGitRepositoryTest
 
 		workingDirectory.mkdir();
 
+		String baseBranchUsername = RandomTestUtil.randomString();
+		String repositoryName = RandomTestUtil.randomString();
+
 		JSONObject jsonObject = new JSONObject();
 
 		jsonObject.put(
@@ -339,16 +342,18 @@ public class WorkspaceGitRepositoryTest
 		).put(
 			"base_branch_sha", "1234567890123456789012345678901234567890"
 		).put(
-			"base_branch_username", "liferay"
+			"base_branch_username", baseBranchUsername
 		).put(
 			"directory",
 			JenkinsResultsParserUtil.getCanonicalPath(workingDirectory)
 		).put(
-			"directory_name", "test-repository"
+			"directory_name", repositoryName
 		).put(
-			"git_hub_url", "https://github.com/liferay/test-repository"
+			"git_hub_url",
+			JenkinsResultsParserUtil.combine(
+				"https://github.com/", baseBranchUsername, "/", repositoryName)
 		).put(
-			"name", "test-repository"
+			"name", repositoryName
 		).put(
 			"sender_branch_head_sha", "0987654321098765432109876543210987654321"
 		).put(
@@ -356,7 +361,7 @@ public class WorkspaceGitRepositoryTest
 		).put(
 			"sender_branch_sha", "0987654321098765432109876543210987654321"
 		).put(
-			"sender_branch_username", "test"
+			"sender_branch_username", RandomTestUtil.randomString()
 		).put(
 			"upstream_branch_name", "master"
 		);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -48,11 +48,8 @@ public class WorkspaceGitRepositoryTest
 
 	@Test
 	public void testSetUp() throws Exception {
-		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
-			GitWorkingDirectory.class);
-
 		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
-			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+			_newDefaultWorkspaceGitRepository();
 
 		Mockito.doNothing(
 		).when(
@@ -163,7 +160,13 @@ public class WorkspaceGitRepositoryTest
 		);
 
 		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
-			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+			_newDefaultWorkspaceGitRepository();
+
+		Mockito.doReturn(
+			gitWorkingDirectory
+		).when(
+			defaultWorkspaceGitRepository
+		).getGitWorkingDirectory();
 
 		defaultWorkspaceGitRepository.validateSHAInRemoteGitRef(
 			"master", remoteGitRef, null);
@@ -196,7 +199,13 @@ public class WorkspaceGitRepositoryTest
 		).getWorkingDirectory();
 
 		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
-			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+			_newDefaultWorkspaceGitRepository();
+
+		Mockito.doReturn(
+			gitWorkingDirectory
+		).when(
+			defaultWorkspaceGitRepository
+		).getGitWorkingDirectory();
 
 		return defaultWorkspaceGitRepository.isFullDotGitDirArchiveRequired();
 	}
@@ -205,11 +214,8 @@ public class WorkspaceGitRepositoryTest
 			boolean gitArchiveAvailable, boolean snapshot)
 		throws Exception {
 
-		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
-			GitWorkingDirectory.class);
-
 		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
-			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+			_newDefaultWorkspaceGitRepository();
 
 		Mockito.doReturn(
 			gitArchiveAvailable
@@ -262,11 +268,8 @@ public class WorkspaceGitRepositoryTest
 
 		JenkinsResultsParserUtil.setTopLevelJobNames(topLevelJobNames);
 
-		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
-			GitWorkingDirectory.class);
-
 		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
-			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+			_newDefaultWorkspaceGitRepository();
 
 		Mockito.doNothing(
 		).when(
@@ -311,8 +314,7 @@ public class WorkspaceGitRepositoryTest
 		return defaultWorkspaceGitRepository.isSnapshot();
 	}
 
-	private DefaultWorkspaceGitRepository _newDefaultWorkspaceGitRepository(
-			GitWorkingDirectory gitWorkingDirectory)
+	private DefaultWorkspaceGitRepository _newDefaultWorkspaceGitRepository()
 		throws Exception {
 
 		File workingDirectory = File.createTempFile("workspace-", null);
@@ -350,16 +352,7 @@ public class WorkspaceGitRepositoryTest
 			"upstream_branch_name", "master"
 		);
 
-		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
-			Mockito.spy(new DefaultWorkspaceGitRepository(jsonObject));
-
-		Mockito.doReturn(
-			gitWorkingDirectory
-		).when(
-			defaultWorkspaceGitRepository
-		).getGitWorkingDirectory();
-
-		return defaultWorkspaceGitRepository;
+		return Mockito.spy(new DefaultWorkspaceGitRepository(jsonObject));
 	}
 
 	private void _testPrepareGitWorkingDirectory(
@@ -373,11 +366,8 @@ public class WorkspaceGitRepositoryTest
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
-		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
-			GitWorkingDirectory.class);
-
 		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
-			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+			_newDefaultWorkspaceGitRepository();
 
 		Mockito.doNothing(
 		).when(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -72,14 +72,26 @@ public class WorkspaceGitRepositoryTest
 		InOrder inOrder = Mockito.inOrder(defaultWorkspaceGitRepository);
 
 		inOrder.verify(
-			defaultWorkspaceGitRepository, Mockito.times(1)
+			defaultWorkspaceGitRepository
 		).prepareGitWorkingDirectory();
 
 		inOrder.verify(
-			defaultWorkspaceGitRepository, Mockito.times(1)
+			defaultWorkspaceGitRepository
 		).setUpAdditionalCaches();
 
 		inOrder.verify(
+			defaultWorkspaceGitRepository
+		).uploadGitArchives();
+
+		Mockito.verify(
+			defaultWorkspaceGitRepository, Mockito.times(1)
+		).prepareGitWorkingDirectory();
+
+		Mockito.verify(
+			defaultWorkspaceGitRepository, Mockito.times(1)
+		).setUpAdditionalCaches();
+
+		Mockito.verify(
 			defaultWorkspaceGitRepository, Mockito.times(1)
 		).uploadGitArchives();
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -83,6 +83,14 @@ public class WorkspaceGitRepositoryTest
 		).uploadGitArchives();
 	}
 
+	@Test
+	public void testSnapshotStateAfterPromoteGitArchive() throws Exception {
+		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(true, true));
+		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(true, false));
+		Assert.assertTrue(_isSnapshotAfterPromoteGitArchive(false, true));
+		Assert.assertFalse(_isSnapshotAfterPromoteGitArchive(false, false));
+	}
+
 	private boolean _isFullDotGitDirArchiveRequired(String workingDirectoryName)
 		throws Exception {
 
@@ -99,6 +107,39 @@ public class WorkspaceGitRepositoryTest
 			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
 
 		return defaultWorkspaceGitRepository.isFullDotGitDirArchiveRequired();
+	}
+
+	private boolean _isSnapshotAfterPromoteGitArchive(
+			boolean gitArchiveAvailable, boolean snapshot)
+		throws Exception {
+
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
+			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+
+		Mockito.doReturn(
+			gitArchiveAvailable
+		).when(
+			defaultWorkspaceGitRepository
+		).isGitArchivesAvailable();
+
+		Mockito.doNothing(
+		).when(
+			defaultWorkspaceGitRepository
+		).touchGitArchives();
+
+		Mockito.doNothing(
+		).when(
+			defaultWorkspaceGitRepository
+		).updateBuildDatabase();
+
+		defaultWorkspaceGitRepository.setSnapshot(snapshot);
+
+		defaultWorkspaceGitRepository.promoteGitArchive();
+
+		return defaultWorkspaceGitRepository.isSnapshot();
 	}
 
 	private DefaultWorkspaceGitRepository _newDefaultWorkspaceGitRepository(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
 
 /**
  * @author Michael Hashimoto
@@ -195,6 +196,14 @@ public class WorkspaceGitRepositoryTest
 		);
 	}
 
+	private VerificationMode _getVerificationMode(boolean invoked) {
+		if (invoked) {
+			return Mockito.times(1);
+		}
+
+		return Mockito.never();
+	}
+
 	private boolean _isFullDotGitDirArchiveRequired(String workingDirectoryName)
 		throws Exception {
 
@@ -299,26 +308,17 @@ public class WorkspaceGitRepositoryTest
 
 		defaultWorkspaceGitRepository.uploadGitArchives();
 
-		if (gitArchiveEnabled && !snapshot &&
-			topLevelJobNames.contains(jobName)) {
+		VerificationMode verificationMode = _getVerificationMode(
+			gitArchiveEnabled && !snapshot &&
+			topLevelJobNames.contains(jobName));
 
-			Mockito.verify(
-				defaultWorkspaceGitRepository, Mockito.times(1)
-			).uploadDotGitArchive();
+		Mockito.verify(
+			defaultWorkspaceGitRepository, verificationMode
+		).uploadDotGitArchive();
 
-			Mockito.verify(
-				defaultWorkspaceGitRepository, Mockito.times(1)
-			).uploadGitArchive();
-		}
-		else {
-			Mockito.verify(
-				defaultWorkspaceGitRepository, Mockito.never()
-			).uploadDotGitArchive();
-
-			Mockito.verify(
-				defaultWorkspaceGitRepository, Mockito.never()
-			).uploadGitArchive();
-		}
+		Mockito.verify(
+			defaultWorkspaceGitRepository, verificationMode
+		).uploadGitArchive();
 
 		return defaultWorkspaceGitRepository.isSnapshot();
 	}
@@ -406,38 +406,20 @@ public class WorkspaceGitRepositoryTest
 
 		defaultWorkspaceGitRepository.prepareGitWorkingDirectory();
 
-		if (!gitArchiveEnabled || !snapshot) {
-			Mockito.verify(
-				defaultWorkspaceGitRepository, Mockito.never()
-			).downloadGitArchives();
-		}
-		else {
-			Mockito.verify(
-				defaultWorkspaceGitRepository, Mockito.times(1)
-			).downloadGitArchives();
-		}
+		Mockito.verify(
+			defaultWorkspaceGitRepository,
+			_getVerificationMode(gitArchiveEnabled && snapshot)
+		).downloadGitArchives();
 
-		if (gitArchiveEnabled && snapshot) {
-			Mockito.verify(
-				defaultWorkspaceGitRepository, Mockito.never()
-			).initializeGitWorkingDirectory();
-		}
-		else {
-			Mockito.verify(
-				defaultWorkspaceGitRepository, Mockito.times(1)
-			).initializeGitWorkingDirectory();
-		}
+		Mockito.verify(
+			defaultWorkspaceGitRepository,
+			_getVerificationMode(!gitArchiveEnabled || !snapshot)
+		).initializeGitWorkingDirectory();
 
-		if (!gitArchiveEnabled) {
-			Mockito.verify(
-				defaultWorkspaceGitRepository, Mockito.never()
-			).promoteGitArchive();
-		}
-		else {
-			Mockito.verify(
-				defaultWorkspaceGitRepository, Mockito.times(1)
-			).promoteGitArchive();
-		}
+		Mockito.verify(
+			defaultWorkspaceGitRepository,
+			_getVerificationMode(gitArchiveEnabled)
+		).promoteGitArchive();
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.File;
+
+import org.json.JSONObject;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class WorkspaceGitRepositoryTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testIsFullDotGitDirArchiveRequired() throws Exception {
+		Assert.assertTrue(
+			_isFullDotGitDirArchiveRequired("liferay-plugins-ee-6.2.x"));
+		Assert.assertTrue(
+			_isFullDotGitDirArchiveRequired("liferay-portal-ee-6.2.x"));
+		Assert.assertFalse(_isFullDotGitDirArchiveRequired("liferay-portal"));
+		Assert.assertFalse(
+			_isFullDotGitDirArchiveRequired("liferay-portal-7.0.x"));
+	}
+
+	private boolean _isFullDotGitDirArchiveRequired(String workingDirectoryName)
+		throws Exception {
+
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		Mockito.doReturn(
+			new File(workingDirectoryName)
+		).when(
+			gitWorkingDirectory
+		).getWorkingDirectory();
+
+		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
+			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+
+		return defaultWorkspaceGitRepository.isFullDotGitDirArchiveRequired();
+	}
+
+	private DefaultWorkspaceGitRepository _newDefaultWorkspaceGitRepository(
+			GitWorkingDirectory gitWorkingDirectory)
+		throws Exception {
+
+		File workingDirectory = File.createTempFile("workspace-", null);
+
+		workingDirectory.delete();
+
+		workingDirectory.mkdir();
+
+		JSONObject jsonObject = new JSONObject();
+
+		jsonObject.put(
+			"base_branch_head_sha", "1234567890123456789012345678901234567890"
+		).put(
+			"base_branch_sha", "1234567890123456789012345678901234567890"
+		).put(
+			"base_branch_username", "liferay"
+		).put(
+			"directory",
+			JenkinsResultsParserUtil.getCanonicalPath(workingDirectory)
+		).put(
+			"directory_name", "test-repository"
+		).put(
+			"git_hub_url", "https://github.com/liferay/test-repository"
+		).put(
+			"name", "test-repository"
+		).put(
+			"sender_branch_head_sha", "0987654321098765432109876543210987654321"
+		).put(
+			"sender_branch_name", "master"
+		).put(
+			"sender_branch_sha", "0987654321098765432109876543210987654321"
+		).put(
+			"sender_branch_username", "test"
+		).put(
+			"upstream_branch_name", "master"
+		);
+
+		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
+			Mockito.spy(new DefaultWorkspaceGitRepository(jsonObject));
+
+		Mockito.doReturn(
+			gitWorkingDirectory
+		).when(
+			defaultWorkspaceGitRepository
+		).getGitWorkingDirectory();
+
+		return defaultWorkspaceGitRepository;
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -7,6 +7,8 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.util.Properties;
+
 import org.json.JSONObject;
 
 import org.junit.Assert;
@@ -29,6 +31,14 @@ public class WorkspaceGitRepositoryTest
 		Assert.assertFalse(_isFullDotGitDirArchiveRequired("liferay-portal"));
 		Assert.assertFalse(
 			_isFullDotGitDirArchiveRequired("liferay-portal-7.0.x"));
+	}
+
+	@Test
+	public void testPrepareGitWorkingDirectory() throws Exception {
+		_testPrepareGitWorkingDirectory(true, true);
+		_testPrepareGitWorkingDirectory(true, false);
+		_testPrepareGitWorkingDirectory(false, true);
+		_testPrepareGitWorkingDirectory(false, false);
 	}
 
 	private boolean _isFullDotGitDirArchiveRequired(String workingDirectoryName)
@@ -98,6 +108,80 @@ public class WorkspaceGitRepositoryTest
 		).getGitWorkingDirectory();
 
 		return defaultWorkspaceGitRepository;
+	}
+
+	private void _testPrepareGitWorkingDirectory(
+			boolean gitArchiveEnabled, boolean snapshot)
+		throws Exception {
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"git.archive.enabled", String.valueOf(gitArchiveEnabled));
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
+			_newDefaultWorkspaceGitRepository(gitWorkingDirectory);
+
+		Mockito.doNothing(
+		).when(
+			defaultWorkspaceGitRepository
+		).downloadGitArchives();
+
+		Mockito.doReturn(
+			snapshot
+		).when(
+			defaultWorkspaceGitRepository
+		).isSnapshot();
+
+		Mockito.doNothing(
+		).when(
+			defaultWorkspaceGitRepository
+		).initializeGitWorkingDirectory();
+
+		Mockito.doNothing(
+		).when(
+			defaultWorkspaceGitRepository
+		).promoteGitArchive();
+
+		defaultWorkspaceGitRepository.prepareGitWorkingDirectory();
+
+		if (!gitArchiveEnabled || !snapshot) {
+			Mockito.verify(
+				defaultWorkspaceGitRepository, Mockito.never()
+			).downloadGitArchives();
+		}
+		else {
+			Mockito.verify(
+				defaultWorkspaceGitRepository, Mockito.times(1)
+			).downloadGitArchives();
+		}
+
+		if (gitArchiveEnabled && snapshot) {
+			Mockito.verify(
+				defaultWorkspaceGitRepository, Mockito.never()
+			).initializeGitWorkingDirectory();
+		}
+		else {
+			Mockito.verify(
+				defaultWorkspaceGitRepository, Mockito.times(1)
+			).initializeGitWorkingDirectory();
+		}
+
+		if (!gitArchiveEnabled) {
+			Mockito.verify(
+				defaultWorkspaceGitRepository, Mockito.never()
+			).promoteGitArchive();
+		}
+		else {
+			Mockito.verify(
+				defaultWorkspaceGitRepository, Mockito.times(1)
+			).promoteGitArchive();
+		}
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7783

Carries @michaelhashimoto's PR pyoo47#4467 with review cleanup applied on top. His eight commits are unchanged.

## What Is Being Fixed

`WorkspaceGitRepository` and `PortalWorkspaceGitRepository` carried no unit test coverage, so the workspace setup path in `jenkins-results-parser` was only exercised indirectly through CI runs. Behavior such as archive requirements, Git working directory preparation, the one-time `setUp()` sequence, and the snapshot state written after promoting or uploading Git archives could regress silently.

## How It Is Being Fixed

Adds a new `WorkspaceGitRepositoryTest` covering `isFullDotGitDirArchiveRequired()`, `prepareGitWorkingDirectory()`, `setUp()`, `validateSHAInRemoteGitRef()`, and the snapshot state after `promoteGitArchive()` and `uploadGitArchives()`. The tests use Mockito to stand in for `GitWorkingDirectory` and the surrounding Git infrastructure, so each behavior is verified in isolation without touching a real repository. `setUp()` is invoked twice, with an `InOrder` chain asserting the step sequence and plain `Mockito.verify` calls asserting that each step still ran exactly once, which is what pins the `isSetUp()` guard.

`PortalWorkspaceGitRepositoryTest` is expanded in the same style with coverage for `getPortalTestProperties()` and `setUpAdditionalCaches()`, and its existing setup is refactored onto the shared mocking approach so both test classes stay consistent.

## Review Cleanup

Unused mocks and stubs removed, the binaries cache stubbed out of the toggle test so it no longer runs the real body, snapshot tests named after the methods under test, fixture values switched to `RandomTestUtil` including a new `randomSHA()`, verify branches replaced with a verification mode helper, and same object call runs sorted.

## PR Check

**pr-check: PASS** — tested on `df0c01899ed9798e1ea6a0405561f5dbb3f4810b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "df0c01899ed9798e1ea6a0405561f5dbb3f4810b"} -->
