### PR TITLE
LRCI-7969 Fix cross-class static state pollution in the unit tests

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -42,8 +42,6 @@ public class BuildQueueRebalancerTest
 
 		jenkinsCohorts.remove(_JENKINS_COHORT_NAME);
 
-		JenkinsResultsParserUtil.setBuildProperties(new Properties());
-
 		super.tearDown();
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -8,7 +8,6 @@ package com.liferay.jenkins.results.parser;
 import java.io.File;
 
 import java.util.Map;
-import java.util.Properties;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -62,8 +61,6 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		JenkinsMaster.maxRecentBatchAge = 120 * 1000;
 
 		JenkinsMasterTestUtil.resetCaches();
-
-		JenkinsResultsParserUtil.setBuildProperties(new Properties());
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -27,8 +27,6 @@ public class LoadBalancerUtilTest
 		super.tearDown();
 
 		JenkinsMasterTestUtil.resetCaches();
-
-		JenkinsResultsParserUtil.setBuildProperties(new Properties());
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.hamcrest.CoreMatchers;
 
@@ -43,6 +44,13 @@ public class Test {
 		BuildDatabaseUtil.clearBuildDatabases();
 
 		Environment.setInstance(new Environment());
+
+		JenkinsResultsParserUtil.setBuildProperties(new Properties());
+
+		Map<String, Job> jobs = ReflectionTestUtil.getFieldValue(
+			JobFactory.class, "_jobs");
+
+		jobs.clear();
 
 		Shell.setInstance(new Shell());
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/AntAllRelevantRuleTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/AntAllRelevantRuleTest.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -30,6 +31,11 @@ public class AntAllRelevantRuleTest {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		Class.forName("com.liferay.jenkins.results.parser.GitWorkingDirectory");
+	}
+
+	@After
+	public void tearDown() {
+		RelevantRuleEngine.clear();
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/BaseRelevantRuleTestCase.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/BaseRelevantRuleTestCase.java
@@ -11,6 +11,7 @@ import com.liferay.jenkins.results.parser.Job;
 import com.liferay.jenkins.results.parser.JobFactory;
 import com.liferay.jenkins.results.parser.PortalAcceptancePullRequestJob;
 import com.liferay.jenkins.results.parser.PortalGitWorkingDirectory;
+import com.liferay.jenkins.results.parser.Test;
 
 import java.io.File;
 
@@ -23,10 +24,13 @@ import org.junit.After;
 /**
  * @author Kenji Heigel
  */
-public abstract class BaseRelevantRuleTestCase {
+public abstract class BaseRelevantRuleTestCase extends Test {
 
 	@After
+	@Override
 	public void tearDown() {
+		super.tearDown();
+
 		RelevantRuleEngine.clear();
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7969

## What Is Being Fixed

The module's unit tests pass under Gradle only because `LiferayOSGiPlugin` forks a fresh JVM per test class (`forkEvery = 1`). Run in a shared JVM — which is how PIT executes them — 11 tests fail, because test classes leak static state into each other. That forces excluding the `Relevant*Test` classes from every mutation-testing run, blinding PIT on the selection logic LRCI-7528 depends on. LRCI-7766 was a live regression of the same shape.

Three leaks, reproduced with `test { forkEvery = 0 }`:

1. Eight test classes install fake build-properties tables via `JenkinsResultsParserUtil.setBuildProperties(...)`; only three restored them.
2. `JobFactory._jobs` caches jobs by `profile_jobName_branch_suite` — the portal directory is not part of the key — so a job built by `BatchTestClassGroupTestUtil` against a mocked working directory is served verbatim to the `Relevant*` tests, which ask for the same job name and suite.
3. The `RelevantRuleEngine` constructor self-registers as the static singleton, and `AntAllRelevantRuleTest` constructs one with a mocked working directory and suite `"test-rule"` without ever clearing it.

## How It Is Being Fixed

The base test class (`com.liferay.jenkins.results.parser.Test`) already restores `Environment`, `Shell`, and `UrlReader` in `tearDown`; build properties and the `JobFactory` job cache were the missing members of that set, so the reset for both moves there. The three subclasses that carried their own build-properties reset drop the now-redundant line. `BaseRelevantRuleTestCase` now extends the base test class so the relevant-rule tests both get cleaned up after and stop polluting each other, and `AntAllRelevantRuleTest` gets the missing `@After` that clears the engine singleton it registers.

With the fix, a shared-JVM run of the full suite (155 tests) has zero pollution failures — the only remaining red is `PropertyValidatorTest`, the pre-existing local failure tracked by LRCI-7947. The normal per-class run is unchanged. No production code is touched.

## PR Check

**PASS**

Tested: `cc14a9dd50fbfae6e32e654113cca1fff4e0976a`

| Validation | Result |
| --- | --- |
| Source Format | PASS (no autocommit needed) |
| Per-Module Compile | PASS (`ant compile install-portal-snapshots` + `:test:jenkins-results-parser:deploy`) |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS (16 tests / 0 failures: BuildQueueRebalancerTest, JenkinsMasterTest, LoadBalancerUtilTest, AntAllRelevantRuleTest, RelevantRuleEngineTest, RelevantTestSuiteTest) |
| Transaction Usage | PASS (no new transaction usage) |

<!-- pr-check {"result": "success", "sha": "cc14a9dd50fbfae6e32e654113cca1fff4e0976a"} -->
