### PR TITLE
LRCI-7936 Expire stale controller invocations on AWS Jenkins masters

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunner.java
@@ -412,8 +412,8 @@ public abstract class BasePortalControllerBuildRunner
 		1000 * 60 * 60 * 24;
 
 	private static final Pattern _buildURLPattern = Pattern.compile(
-		"https://(?<masterHostname>test-\\d+-\\d+)\\.liferay\\.com/job/" +
-			"(?<jobName>[^/]+)/(?<buildNumber>\\d+)/?");
+		"https://(?<masterHostname>test-\\d+-\\d+)(-aws)?\\.liferay\\.com/" +
+			"job/(?<jobName>[^/]+)/(?<buildNumber>\\d+)/?");
 	private static final Pattern _jobURLPattern = Pattern.compile(
 		"https://(?<masterHostname>test-\\d+-\\d+)\\.liferay\\.com/job/" +
 			"(?<jobName>[^/\"]+)/?");

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
@@ -5,6 +5,13 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.util.Arrays;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.mockito.Mockito;
@@ -15,6 +22,98 @@ import org.mockito.verification.VerificationMode;
  */
 public class BasePortalControllerBuildRunnerTest
 	extends com.liferay.jenkins.results.parser.Test {
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
+	}
+
+	@Test
+	public void testExpirePreviousBuild() throws Exception {
+		JenkinsMasterTestUtil.getJenkinsMaster("test-1-48", "http://test-1-48");
+
+		String controllerBuildURL =
+			"https://test-1-0-aws.liferay.com/job/test-portal-testsuite-" +
+				"upstream-controller(master_content-management)/339/";
+		String invocationJobName = "test-portal-testsuite-upstream(master)";
+
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			new JSONObject(
+			).put(
+				"items",
+				new JSONArray(
+				).put(
+					new JSONObject(
+					).put(
+						"actions",
+						new JSONArray(
+						).put(
+							new JSONObject(
+							).put(
+								"_class", "hudson.model.ParametersAction"
+							).put(
+								"parameters",
+								new JSONArray(
+								).put(
+									new JSONObject(
+									).put(
+										"name", "CONTROLLER_BUILD_URL"
+									).put(
+										"value", controllerBuildURL
+									)
+								)
+							)
+						)
+					).put(
+						"task",
+						new JSONObject(
+						).put(
+							"url",
+							"http://test-1-48/job/" + invocationJobName + "/"
+						)
+					)
+				)
+			).toString(),
+			"queue/api/json", urlReader);
+
+		BasePortalControllerBuildRunner<?> basePortalControllerBuildRunner =
+			Mockito.mock(BasePortalControllerBuildRunner.class);
+
+		Mockito.doCallRealMethod(
+		).when(
+			basePortalControllerBuildRunner
+		).expirePreviousBuild();
+
+		Mockito.doReturn(
+			Arrays.asList(
+				new JSONObject(
+				).put(
+					"description",
+					"<a href=\"https://test-1-48.liferay.com/job/" +
+						invocationJobName + "\"><strong>IN QUEUE</strong></a>"
+				).put(
+					"url", controllerBuildURL
+				))
+		).when(
+			basePortalControllerBuildRunner
+		).getPreviousBuildJSONObjects();
+
+		Assert.assertFalse(
+			basePortalControllerBuildRunner.expirePreviousBuild());
+
+		Mockito.verify(
+			urlReader
+		).doRead(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
+			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
+			Mockito.contains("queue/api/json")
+		);
+	}
 
 	@Test
 	public void testRun() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7936

## What Is Being Fixed

Controller jobs could stay stuck on `IN QUEUE` forever. `test-portal-testsuite-upstream-controller(master_content-management)` sat there for five days and missed five daily runs.

The code to recover from this already existed. `expirePreviousBuild` looks for the invocation the previous build queued, and when it is really gone, clears the marker and triggers a new build. It never got that far. The first thing it does is parse the controller's own build URL, and since the controllers moved to an AWS master in LRCI-7786 that URL looks like this:

```
https://test-1-0-aws.liferay.com/job/test-portal-testsuite-upstream-controller(master_content-management)/339/
```

The pattern expected `.liferay.com` directly after the master name, so `-aws` made it fail to match. The parse failed, the method gave up before checking anything, and it always answered that there was nothing to expire.

## How It Is Being Fixed

The pattern now accepts `-aws`, but does not include it in the master name it pulls out. That name is later used as a hostname to POST to, and the master called `test-1-0-aws` is reached at `test-1-0`. Including `-aws` would POST to a host that does not exist, so the controller build would fail instead of expiring. `BaseBuildData` splits the same URL the same way.

`testExpirePreviousBuild` sets up the reported situation: a previous build on an AWS master, marked `IN QUEUE`, whose invocation really is still queued. It then checks that the job looked in the queue at all, because that is the step that never happened before the fix. The return value cannot show this, since a still-queued invocation is left alone either way. Letting the test go one step further and actually expire the build would POST to Jenkins for real, so that step stays untested until a follow-up ticket makes it mockable.

## PR Check

**pr-check: PASS** — tested on `0f7226cb1bcfcfe16d605d07ee68ba201551a302`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0f7226cb1bcfcfe16d605d07ee68ba201551a302"} -->
