### PR TITLE
LRCI-8041 Validate commit messages in the pr-check source format

### DIFF
--- a/.claude/skills/pr-check/validations/source-format.md
+++ b/.claude/skills/pr-check/validations/source-format.md
@@ -14,7 +14,7 @@ Run the SDK setup, then run the source formatter in `current-branch` mode:
 
 ```bash
 (cd "${REPO_ROOT}" && ant setup-sdk)
-(cd "${REPO_ROOT}/portal-impl" && ANT_OPTS="-Xmx2560m" ant format-source-current-branch)
+(cd "${REPO_ROOT}/portal-impl" && ANT_OPTS="-Xmx2560m" ant format-source-current-branch -Dvalidate.commit.messages=true)
 ```
 
 ## Autocommit


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8041

## What Is Being Fixed

The CI source format batch runs Source Formatter with `validate.commit.messages` set, so it rejects any commit message on the branch that uses one of the words in `git.commit.vulnerability.keywords` or a ticket prefix outside `jira.project.keys`. The pr-check source format validation runs the same Ant target without that property, and the property is only set by the `format-source` target, so pr-check never ran either check. A branch could pass pr-check and then fail the batch on a rule pr-check had no way to catch, which is how this surfaced.

## How It Is Being Fixed

The property is passed on the existing invocation. Nothing else about the validation changes, and a failing commit message leaves the working tree clean, so the `SF` autocommit step does not fire.

Verified by running the command on a branch whose commit message contained a blocked word, which now fails, and on one that did not, which passes. Note this also turns on the JIRA project key check, since Source Formatter runs both under the same property. CI enforces that rule too, so it is parity rather than a new gate. The companion `check.vulnerabilities` property is left alone for now because it reaches GitHub with a CI access token that a developer machine does not have.

## Why Are There No Tests?

The change is a single line in a Markdown skill definition with no code to exercise.

## PR Check

**pr-check: PASS** — tested on `f447a95bbc8bf6e617b146902913ccc191d16dfb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "f447a95bbc8bf6e617b146902913ccc191d16dfb"} -->
