### PR TITLE
LRCI-8029 Reset shared static state in the base test class teardown

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -22,14 +21,6 @@ import org.mockito.verification.VerificationMode;
  */
 public class BasePortalControllerBuildRunnerTest
 	extends com.liferay.jenkins.results.parser.Test {
-
-	@After
-	@Override
-	public void tearDown() {
-		super.tearDown();
-
-		JenkinsMasterTestUtil.resetCaches();
-	}
 
 	@Test
 	public void testExpirePreviousBuild() throws Exception {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -13,7 +13,6 @@ import java.util.Date;
 
 import org.json.JSONObject;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,14 +28,6 @@ public class ClientCredentialsHTTPAuthorizationTest
 	@Before
 	public void setUpBuildProperties() {
 		JenkinsMasterTestUtil.getJenkinsCohortProperties("test-9", 1);
-	}
-
-	@After
-	@Override
-	public void tearDown() {
-		super.tearDown();
-
-		JenkinsMasterTestUtil.resetCaches();
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -62,8 +62,6 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		super.tearDown();
 
 		JenkinsMaster.maxRecentBatchAge = 120 * 1000;
-
-		JenkinsMasterTestUtil.resetCaches();
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -20,14 +19,6 @@ import org.junit.Test;
  */
 public class LoadBalancerUtilTest
 	extends com.liferay.jenkins.results.parser.Test {
-
-	@After
-	@Override
-	public void tearDown() {
-		super.tearDown();
-
-		JenkinsMasterTestUtil.resetCaches();
-	}
 
 	@Test
 	public void testGetAvailableJenkinsMasters() {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -45,7 +45,11 @@ public class Test {
 
 		Environment.setInstance(new Environment());
 
+		JenkinsMasterTestUtil.resetCaches();
+
 		JenkinsResultsParserUtil.setBuildProperties(new Properties());
+
+		JenkinsResultsParserUtil.setTopLevelJobNames(null);
 
 		Map<String, Job> jobs = ReflectionTestUtil.getFieldValue(
 			JobFactory.class, "_jobs");

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
@@ -16,7 +16,6 @@ import java.util.Properties;
 
 import org.json.JSONObject;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,14 +33,6 @@ public class JobHealthMonitorTest
 
 		JenkinsMasterTestUtil.getJenkinsMaster(
 			_MASTER_NAME, "http://" + _MASTER_NAME);
-	}
-
-	@After
-	@Override
-	public void tearDown() {
-		super.tearDown();
-
-		JenkinsMasterTestUtil.resetCaches();
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
@@ -11,7 +11,6 @@ import com.liferay.jenkins.results.parser.RandomTestUtil;
 import java.util.List;
 import java.util.Properties;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -20,14 +19,6 @@ import org.junit.Test;
  */
 public class MonitorFactoryTest
 	extends com.liferay.jenkins.results.parser.Test {
-
-	@After
-	@Override
-	public void tearDown() {
-		super.tearDown();
-
-		JenkinsMasterTestUtil.resetCaches();
-	}
 
 	@Test
 	public void testNewMonitorJobHealth() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8029

**What is being fixed:** Gradle forks a fresh JVM per test class, but the tooling we use to measure unit test strength runs the whole suite in a single JVM. In that shared JVM, test classes could observe static state left behind by earlier classes: WorkspaceGitRepositoryTest set the top level job names through JenkinsResultsParserUtil and nothing restored them, and the JenkinsMaster cache was only cleared by the test classes that remembered to add a teardown override for it. Any new test class touching that state started life polluted, which is what originally forced excluding ClientCredentialsHTTPAuthorizationTest from every strength measurement run.

**How it is being fixed:** The base Test class already resets shared state in its teardown, so the two missing pieces now live there with the rest: it clears the top level job names and the JenkinsMaster cache for every test class. That makes the six copied teardown overrides redundant, so they are removed, leaving the change a net simplification of 4 lines added and 47 removed. BuildQueueRebalancerTest keeps its own teardown because JenkinsCohort cannot be touched from a shared reset, since its static initializer requires the load balancer blacklist property. Verified by running the full suite in a single JVM in both forward and reverse alphabetical order, by a reflection probe showing the leaked state is gone after teardown, and by a strength measurement run that completes with only the standard PropertyValidatorTest exclusion.